### PR TITLE
IMTA-5481 Missing validation on part 1 review page

### DIFF
--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/EconomicOperator.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/EconomicOperator.java
@@ -9,9 +9,8 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.EconomicOperatorStatus;
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.EconomicOperatorType;
-import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationAfterMeansOfTransport;
-import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCedFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCvedaFieldValidation;
+import uk.gov.defra.tracesx.notificationschema.validation.groups.TransporterDetailsRequiredValidation;
 
 import javax.validation.constraints.NotNull;
 
@@ -25,21 +24,21 @@ public class EconomicOperator {
   private String id;
 
   @NotNull(
-      groups = {NotificationAfterMeansOfTransport.class, NotificationCedFieldValidation.class},
+      groups = TransporterDetailsRequiredValidation.class,
       message =
           "{uk.gov.defra.tracesx.notificationschema.representation.partone.transporter.type.not"
               + ".null}")
   private EconomicOperatorType type;
 
   @NotNull(
-      groups = {NotificationCvedaFieldValidation.class},
+      groups = NotificationCvedaFieldValidation.class,
       message =
           "{uk.gov.defra.tracesx.notificationschema.representation.partone.transporter.status.not"
               + ".null}")
   private EconomicOperatorStatus status;
 
   @NotNull(
-      groups = {NotificationAfterMeansOfTransport.class, NotificationCedFieldValidation.class},
+      groups = TransporterDetailsRequiredValidation.class,
       message =
           "{uk.gov.defra.tracesx.notificationschema.representation.partone.transporter"
               + ".companyname.not.null}")
@@ -52,7 +51,7 @@ public class EconomicOperator {
   private String otherIdentifier;
 
   @NotNull(
-      groups = {NotificationAfterMeansOfTransport.class, NotificationCedFieldValidation.class},
+      groups = TransporterDetailsRequiredValidation.class,
       message =
           "{uk.gov.defra.tracesx.notificationschema.representation.partone.transporter.address"
               + ".not.null}")

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/MeansOfTransportAfterBip.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/MeansOfTransportAfterBip.java
@@ -8,7 +8,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.TransportMethod;
-import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationAfterMeansOfTransport;
+import uk.gov.defra.tracesx.notificationschema.validation.groups.TransporterDetailsRequiredCEDValidation;
+import uk.gov.defra.tracesx.notificationschema.validation.groups.TransporterDetailsRequiredValidation;
 
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
@@ -24,20 +25,23 @@ public class MeansOfTransportAfterBip implements MeansOfTransport {
       message =
           "{uk.gov.defra.tracesx.notificationschema.representation.partone.meansoftransport.id"
               + ".not.empty}",
-      groups = NotificationAfterMeansOfTransport.class)
+      groups = {TransporterDetailsRequiredValidation.class,
+          TransporterDetailsRequiredCEDValidation.class})
   private String id = null;
 
   @NotNull(
       message =
           "{uk.gov.defra.tracesx.notificationschema.representation.partone.meansoftransport.type"
               + ".not.null}",
-      groups = NotificationAfterMeansOfTransport.class)
+      groups = {TransporterDetailsRequiredValidation.class,
+          TransporterDetailsRequiredCEDValidation.class})
   private TransportMethod type = null;
 
   @NotEmpty(
       message =
           "{uk.gov.defra.tracesx.notificationschema.representation.partone.meansoftransport"
               + ".document.not.empty}",
-      groups = NotificationAfterMeansOfTransport.class)
+      groups = {TransporterDetailsRequiredValidation.class,
+          TransporterDetailsRequiredCEDValidation.class})
   private String document = null;
 }

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/PartOne.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/PartOne.java
@@ -17,12 +17,13 @@ import uk.gov.defra.tracesx.notificationschema.representation.serialisation.IsoO
 import uk.gov.defra.tracesx.notificationschema.representation.serialisation.IsoTimeDeserializer;
 import uk.gov.defra.tracesx.notificationschema.representation.serialisation.IsoTimeSerializer;
 import uk.gov.defra.tracesx.notificationschema.validation.ValidationMessageCode;
-import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationAfterMeansOfTransport;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCedFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCvedaFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationVeterinaryApprovedEstablishmentValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationVeterinaryValidation;
+import uk.gov.defra.tracesx.notificationschema.validation.groups.TransporterDetailsRequiredCEDValidation;
+import uk.gov.defra.tracesx.notificationschema.validation.groups.TransporterDetailsRequiredValidation;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -103,7 +104,7 @@ public class PartOne {
 
   @Valid
   @NotNull(
-      groups = NotificationAfterMeansOfTransport.class,
+      groups = TransporterDetailsRequiredValidation.class,
       message = "{uk.gov.defra.tracesx.notificationschema.representation.partone.transporter"
           + ".not.null}")
   private EconomicOperator transporter;
@@ -112,7 +113,8 @@ public class PartOne {
 
   @Valid
   @NotNull(
-      groups = {NotificationAfterMeansOfTransport.class, NotificationCedFieldValidation.class},
+      groups = {TransporterDetailsRequiredValidation.class,
+          TransporterDetailsRequiredCEDValidation.class},
       message =
           "{uk.gov.defra.tracesx.notificationschema.representation.partone.meansoftransport.not"
               + ".null}")
@@ -127,7 +129,8 @@ public class PartOne {
   private MeansOfTransportBeforeBip meansOfTransportFromEntryPoint;
 
   @NotNull(
-      groups = {NotificationAfterMeansOfTransport.class, NotificationCedFieldValidation.class},
+      groups = {TransporterDetailsRequiredValidation.class,
+          TransporterDetailsRequiredCEDValidation.class},
       message = "{uk.gov.defra.tracesx.notificationschema.representation.partone.departuredate"
           + ".not.null}")
   @JsonSerialize(using = IsoDateSerializer.class)
@@ -135,7 +138,8 @@ public class PartOne {
   private LocalDate departureDate;
 
   @NotNull(
-      groups = {NotificationAfterMeansOfTransport.class, NotificationCedFieldValidation.class},
+      groups = {TransporterDetailsRequiredValidation.class,
+          TransporterDetailsRequiredCEDValidation.class},
       message = "{uk.gov.defra.tracesx.notificationschema.representation.partone.departuretime"
           + ".not.null}")
   @JsonSerialize(using = IsoTimeSerializer.class)

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/groups/TransporterDetailsRequiredCEDValidation.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/groups/TransporterDetailsRequiredCEDValidation.java
@@ -1,0 +1,5 @@
+package uk.gov.defra.tracesx.notificationschema.validation.groups;
+
+public interface TransporterDetailsRequiredCEDValidation {
+
+}

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/groups/TransporterDetailsRequiredValidation.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/groups/TransporterDetailsRequiredValidation.java
@@ -1,5 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.validation.groups;
 
-public interface NotificationAfterMeansOfTransport {
+public interface TransporterDetailsRequiredValidation {
 
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/CedOrCvedpControlledDestinationValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/CedOrCvedpControlledDestinationValidatorTest.java
@@ -33,7 +33,7 @@ public class CedOrCvedpControlledDestinationValidatorTest {
   private CedOrCvedpControlledDestinationValidator validator;
 
   @DataPoints("requiring Controlled Destination")
-  public static NotAcceptableActionEnum[] notAcceptableActions = new NotAcceptableActionEnum[]{
+  public static final NotAcceptableActionEnum[] notAcceptableActions = new NotAcceptableActionEnum[]{
       DESTRUCTION,
       SLAUGHTER,
       OTHER

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ControlledDestinationRequirementHelperTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ControlledDestinationRequirementHelperTest.java
@@ -47,7 +47,6 @@ public class ControlledDestinationRequirementHelperTest {
     assertTrue(result);
   }
 
-
   @Test
   public void isControlledDestinationRequiredForCveda_nonAcceptableReExportAction_isFalse() {
     decision.setDecision(NON_ACCEPTABLE);
@@ -60,7 +59,7 @@ public class ControlledDestinationRequirementHelperTest {
   }
 
   @DataPoints("Decisions for CED CVEDP that require controlled destinations")
-  public static Decision[] decisionThatRequireControlledDestinations = new Decision[]{
+  public static final Decision[] decisionThatRequireControlledDestinations = new Decision[]{
       Decision.builder().decision(ACCEPTABLE_IF_CHANNELED).build(),
       Decision.builder().decision(ACCEPTABLE_FOR_SPECIFIC_WAREHOUSE).build(),
       Decision.builder().decision(NON_ACCEPTABLE).notAcceptableAction(DESTRUCTION).build(),
@@ -80,7 +79,7 @@ public class ControlledDestinationRequirementHelperTest {
   }
 
   @DataPoints("Decisions for CED CVEDP that not require controlled destinations")
-  public static Decision[] decisionsThatNotRequireControlledDestination = new Decision[]{
+  public static final Decision[] decisionsThatNotRequireControlledDestination = new Decision[]{
       Decision.builder().decision(NON_ACCEPTABLE).notAcceptableAction(REEXPORT).build(),
       Decision.builder().decision(NON_ACCEPTABLE).build(),
       Decision.builder().decision(ACCEPTABLE_FOR_TEMPORARY_IMPORT).build(),

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/CvedaControlledDestinationValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/CvedaControlledDestinationValidatorTest.java
@@ -49,19 +49,19 @@ public class CvedaControlledDestinationValidatorTest {
   }
 
   @DataPoints("Decisions for ControlledDestinations without subOption")
-  public static DecisionEnum[] decisionsWithoutSubOption = new DecisionEnum[]{
+  public static final DecisionEnum[] decisionsWithoutSubOption = new DecisionEnum[]{
       ACCEPTABLE_FOR_SPECIFIC_WAREHOUSE,
       ACCEPTABLE_IF_CHANNELED
   };
 
   @DataPoints("Decisions for ControlledDestinations with subOptions")
-  public static DecisionEnum[] decisionsWithSubOption = new DecisionEnum[]{
+  public static final DecisionEnum[] decisionsWithSubOption = new DecisionEnum[]{
       NON_ACCEPTABLE,
       ACCEPTABLE_FOR_INTERNAL_MARKET,
   };
 
   @DataPoints("requiring Controlled Destinations")
-  public static NotAcceptableActionEnum[] notAcceptableActionEnumsRequiringControlledDestinations =
+  public static final NotAcceptableActionEnum[] notAcceptableActionEnumsRequiringControlledDestinations =
       new NotAcceptableActionEnum[]{
           SLAUGHTER,
           EUTHANASIA,

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/IfChanneledOptionValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/IfChanneledOptionValidatorTest.java
@@ -26,7 +26,7 @@ public class IfChanneledOptionValidatorTest {
   private IfChanneledOptionValidator validator;
 
   @DataPoints("Other decisions")
-  public static DecisionEnum[] decisions =
+  public static final DecisionEnum[] decisions =
       new DecisionEnum[]{
           ACCEPTABLE_FOR_SPECIFIC_WAREHOUSE,
           ACCEPTABLE_FOR_INTERNAL_MARKET,

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/SpecificWarehouseValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/SpecificWarehouseValidatorTest.java
@@ -29,7 +29,7 @@ public class SpecificWarehouseValidatorTest {
   private Decision decision;
 
   @DataPoints("Other decisions")
-  public static DecisionEnum[] decisions =
+  public static final DecisionEnum[] decisions =
       new DecisionEnum[]{
           ACCEPTABLE_IF_CHANNELED,
           ACCEPTABLE_FOR_INTERNAL_MARKET,


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Mateusz Kalinowski |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [IMTA-5481 Missing validation on part 1 r...](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/31) |
> | **GitLab MR Number** | [31](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/31) |
> | **Date Originally Opened** | Tue, 23 Jul 2019 |
> | **Approved on GitLab by** | Lukasz Kedron (KAINOS), daniel brennan (KAINOS), praveen seepathi (DDTS) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

As part of this story:
- Renamed `NotificationAfterMeansOfTransport` to `TransporterDetailsRequiredValidation` to better reflect how this group works
- Added `TransporterDetailsRequiredCEDValidation` group for CED (CED does not have `transporter`)
- Fixed some Sonarqube errors by adding `final` to `@DataPoint` fields