### PR TITLE
IMTA-6751: Add complementName field to the schema

### DIFF
--- a/imports-frontend-entities/package-lock.json
+++ b/imports-frontend-entities/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipaffs/imports-frontend-entities",
-  "version": "1.0.59",
+  "version": "1.0.60",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/imports-frontend-entities/package.json
+++ b/imports-frontend-entities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipaffs/imports-frontend-entities",
-  "version": "1.0.59",
+  "version": "1.0.60",
   "repository": {
     "type": "git"
   },

--- a/imports-frontend-entities/src/entities/complement.js
+++ b/imports-frontend-entities/src/entities/complement.js
@@ -10,6 +10,7 @@ module.exports = class CommodityComplement {
     this.commodityDescription = obj.commodityDescription
     this.commodityID = obj.commodityID
     this.complementID = obj.complementID
+    this.complementName = obj.complementName
     this.speciesID = obj.speciesID
     this.speciesName = obj.speciesName
     this.speciesTypeName = obj.speciesTypeName

--- a/notification-schema-core/resources/notification-schema.json
+++ b/notification-schema-core/resources/notification-schema.json
@@ -179,9 +179,15 @@
                     "minimum": 0,
                     "description": "Identifier of complement chosen from speciesFamily,speciesClass and speciesType'. This is also used to link to the complementParameterSet"
                   },
+                  "complementName": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 255,
+                    "description": "Represents the lowest granularity - either type, class, family or species name - for the commodity selected.  This is also used to drive behaviour for EU Import journeys"
+                  },
                   "speciesID": {
                     "type": "string",
-                    "description": "The species ID of the commodity that is imported. Not every commodity has a species ID. This is also used to link to the complementParameterSet"
+                    "description": "The species ID of the commodity that is imported. Not every commodity has a species ID. This is also used to link to the complementParameterSet. The species ID can change over time"
                   },
                   "speciesName": {
                     "type": "string",

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/CommodityComplement.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/CommodityComplement.java
@@ -18,6 +18,7 @@ public class CommodityComplement {
   private String commodityID;
   private String commodityDescription;
   private Integer complementID;
+  private String complementName;
   private String speciesID;
   private String speciesName;
   private String speciesTypeName;


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Reece Bennett (KAINOS) |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [IMTA-6751: Add complementName field to t...](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/75) |
> | **GitLab MR Number** | [75](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/75) |
> | **Date Originally Opened** | Tue, 18 Feb 2020 |
> | **Approved on GitLab by** | daniel brennan (KAINOS), dominik henjes (KAINOS), lee mason (KAINOS) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

https://eaflood.atlassian.net/browse/IMTA-6751