### PR TITLE
IMTA 7695 - CHEDPP validation changes for Product Type key data and exclusion of wood packaging

### DIFF
--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/Commodities.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/Commodities.java
@@ -12,6 +12,7 @@ import uk.gov.defra.tracesx.notificationschema.representation.enumeration.Commod
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.CommodityTemperature;
 import uk.gov.defra.tracesx.notificationschema.validation.annotations.MinCommoditiesGrossWeight;
 import uk.gov.defra.tracesx.notificationschema.validation.annotations.QuantityImp;
+import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCedOrCvedpFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCedOrCvedpOrChedppFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCvedaFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationHighRiskFieldValidation;
@@ -53,7 +54,7 @@ public class Commodities {
   private Integer numberOfPackages;
 
   @NotNull(
-      groups = NotificationCedOrCvedpOrChedppFieldValidation.class,
+      groups = NotificationCedOrCvedpFieldValidation.class,
       message =
           "{uk.gov.defra.tracesx.notificationschema.representation.partone.commodities"
               + ".temperature.not.null}")
@@ -83,7 +84,7 @@ public class Commodities {
   @QuantityImp(
       groups = NotificationLowRiskFieldValidation.class,
       message = "{uk.gov.defra.tracesx.notificationschema.representation.partone.euimp"
-              + ".commodities.complementParameterSet.has.value}")
+          + ".commodities.complementParameterSet.has.value}")
   private List<ComplementParameterSet> complementParameterSet = null;
 
   private Boolean includeNonAblactedAnimals = null;

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/ComplementParameterSet.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/ComplementParameterSet.java
@@ -9,7 +9,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import uk.gov.defra.tracesx.notificationschema.validation.annotations.MinValueKeyDataPair;
 import uk.gov.defra.tracesx.notificationschema.validation.annotations.NotNullKeyDataPair;
-import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCedOrCvedpOrChedppFieldValidation;
+import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCedOrCvedpFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCvedaFieldValidation;
 
 import java.util.ArrayList;
@@ -27,6 +27,7 @@ public class ComplementParameterSet {
   public static final String NET_WEIGHT = "netweight";
   public static final String NUMBER_ANIMAL = "number_animal";
   public static final String TYPE_PACKAGE = "type_package";
+  public static final String TYPE_PRODUCT = "type_product";
   private Integer complementID;
   private String speciesID;
 
@@ -34,7 +35,7 @@ public class ComplementParameterSet {
   @MinValueKeyDataPair.List({
       @MinValueKeyDataPair(
           groups = {
-              NotificationCedOrCvedpOrChedppFieldValidation.class,
+              NotificationCedOrCvedpFieldValidation.class,
               NotificationCvedaFieldValidation.class
           },
           field = NUMBER_PACKAGE,
@@ -42,7 +43,7 @@ public class ComplementParameterSet {
               "{uk.gov.defra.tracesx.notificationschema.representation.partone.commodities"
                   + ".complementparameterset.keydatapair.number_package.message}"),
       @MinValueKeyDataPair(
-          groups = NotificationCedOrCvedpOrChedppFieldValidation.class,
+          groups = NotificationCedOrCvedpFieldValidation.class,
           field = NET_WEIGHT,
           message =
               "{uk.gov.defra.tracesx.notificationschema.representation.partone.commodities"
@@ -56,7 +57,7 @@ public class ComplementParameterSet {
       })
   @NotNullKeyDataPair.List({
       @NotNullKeyDataPair(
-          groups = NotificationCedOrCvedpOrChedppFieldValidation.class,
+          groups = NotificationCedOrCvedpFieldValidation.class,
           field = TYPE_PACKAGE,
           message =
               "{uk.gov.defra.tracesx.notificationschema.representation.partone.commodities"

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/PartOne.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/PartOne.java
@@ -1,5 +1,10 @@
 package uk.gov.defra.tracesx.notificationschema.representation;
 
+import static uk.gov.defra.tracesx.notificationschema.representation.ComplementParameterSet.NET_WEIGHT;
+import static uk.gov.defra.tracesx.notificationschema.representation.ComplementParameterSet.NUMBER_PACKAGE;
+import static uk.gov.defra.tracesx.notificationschema.representation.ComplementParameterSet.TYPE_PACKAGE;
+import static uk.gov.defra.tracesx.notificationschema.representation.ComplementParameterSet.TYPE_PRODUCT;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -17,9 +22,12 @@ import uk.gov.defra.tracesx.notificationschema.representation.serialisation.IsoO
 import uk.gov.defra.tracesx.notificationschema.representation.serialisation.IsoTimeDeserializer;
 import uk.gov.defra.tracesx.notificationschema.representation.serialisation.IsoTimeSerializer;
 import uk.gov.defra.tracesx.notificationschema.validation.ValidationMessageCode;
+import uk.gov.defra.tracesx.notificationschema.validation.annotations.ChedppMinValueKeyDataPair;
+import uk.gov.defra.tracesx.notificationschema.validation.annotations.ChedppNotNullKeyDataPair;
 import uk.gov.defra.tracesx.notificationschema.validation.annotations.DogPlaceOfOriginImp;
 import uk.gov.defra.tracesx.notificationschema.validation.annotations.NotNullVeterinaryDocument;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCedFieldValidation;
+import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationChedppFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCvedaFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationHighRiskFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationLowRiskFieldValidation;
@@ -102,6 +110,30 @@ public class PartOne {
       groups = NotificationHighRiskFieldValidation.class,
       message = "{uk.gov.defra.tracesx.notificationschema.representation.partone.commodities"
           + ".not.null}")
+  @ChedppMinValueKeyDataPair(
+      groups = NotificationChedppFieldValidation.class,
+      field = NUMBER_PACKAGE,
+      message =
+          "{uk.gov.defra.tracesx.notificationschema.representation.partone.commodities"
+              + ".complementparameterset.keydatapair.number_package.message}")
+  @ChedppMinValueKeyDataPair(
+      groups = NotificationChedppFieldValidation.class,
+      field = NET_WEIGHT,
+      message =
+          "{uk.gov.defra.tracesx.notificationschema.representation.partone.commodities"
+              + ".complementparameterset.keydatapair.net_weight.message}")
+  @ChedppNotNullKeyDataPair(
+      groups = NotificationChedppFieldValidation.class,
+      field = TYPE_PACKAGE,
+      message =
+          "{uk.gov.defra.tracesx.notificationschema.representation.partone.commodities"
+              + ".complementparameterset.keydatapair.type_package.message}")
+  @ChedppNotNullKeyDataPair(
+      groups = NotificationChedppFieldValidation.class,
+      field = TYPE_PRODUCT,
+      message =
+          "{uk.gov.defra.tracesx.notificationschema.representation.partone.commodities"
+              + ".complementparameterset.keydatapair.type_product.message}")
   private Commodities commodities;
 
   @Valid

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedppMinValueKeyDataPair.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedppMinValueKeyDataPair.java
@@ -1,0 +1,35 @@
+package uk.gov.defra.tracesx.notificationschema.validation.annotations;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+@Target({FIELD})
+@Retention(RUNTIME)
+@Constraint(validatedBy = ChedppMinValueKeyDataPairValidator.class)
+@Documented
+@Repeatable(ChedppMinValueKeyDataPair.List.class)
+public @interface ChedppMinValueKeyDataPair {
+
+  String message() default "Invalid key data pair";
+
+  Class<?>[] groups() default {};
+
+  Class<? extends Payload>[] payload() default {};
+
+  String field();
+
+  @Target({FIELD})
+  @Retention(RUNTIME)
+  @Documented
+  @interface List {
+
+    ChedppMinValueKeyDataPair[] value();
+  }
+}

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedppMinValueKeyDataPairValidator.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedppMinValueKeyDataPairValidator.java
@@ -1,0 +1,21 @@
+package uk.gov.defra.tracesx.notificationschema.validation.annotations;
+
+import uk.gov.defra.tracesx.notificationschema.representation.ComplementParameterSet;
+
+public class ChedppMinValueKeyDataPairValidator
+    extends CommoditiesComplementParameterSetKeyDataPairValidator<ChedppMinValueKeyDataPair> {
+
+  @Override
+  public ComplementParameterSetKeyDataPairValidator initializeValidator(
+      ChedppMinValueKeyDataPair constraintAnnotation) {
+    return new MinValueKeyDataPairValidation(constraintAnnotation.field());
+  }
+
+  @Override
+  protected boolean isKeyDataPairValid(ComplementParameterSet complementParameterSet) {
+    if (complementParameterSet.getKeyDataPair() == null) {
+      return true;
+    }
+    return super.isKeyDataPairValid(complementParameterSet);
+  }
+}

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedppNotNullKeyDataPair.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedppNotNullKeyDataPair.java
@@ -1,0 +1,35 @@
+package uk.gov.defra.tracesx.notificationschema.validation.annotations;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+@Target({FIELD})
+@Retention(RUNTIME)
+@Constraint(validatedBy = ChedppNotNullKeyDataPairValidator.class)
+@Documented
+@Repeatable(ChedppNotNullKeyDataPair.List.class)
+public @interface ChedppNotNullKeyDataPair {
+
+  String message() default "Invalid key data pair";
+
+  Class<?>[] groups() default {};
+
+  Class<? extends Payload>[] payload() default {};
+
+  String field();
+
+  @Target({FIELD})
+  @Retention(RUNTIME)
+  @Documented
+  @interface List {
+
+    ChedppNotNullKeyDataPair[] value();
+  }
+}

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedppNotNullKeyDataPairValidator.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedppNotNullKeyDataPairValidator.java
@@ -1,0 +1,11 @@
+package uk.gov.defra.tracesx.notificationschema.validation.annotations;
+
+public class ChedppNotNullKeyDataPairValidator
+    extends CommoditiesComplementParameterSetKeyDataPairValidator<ChedppNotNullKeyDataPair> {
+
+  @Override
+  public ComplementParameterSetKeyDataPairValidator initializeValidator(
+      ChedppNotNullKeyDataPair constraintAnnotation) {
+    return new NotNullKeyDataPairValidation(constraintAnnotation.field());
+  }
+}

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/CommoditiesComplementParameterSetKeyDataPairValidator.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/CommoditiesComplementParameterSetKeyDataPairValidator.java
@@ -1,0 +1,61 @@
+package uk.gov.defra.tracesx.notificationschema.validation.annotations;
+
+import uk.gov.defra.tracesx.notificationschema.representation.Commodities;
+import uk.gov.defra.tracesx.notificationschema.representation.CommodityComplement;
+import uk.gov.defra.tracesx.notificationschema.representation.ComplementParameterSet;
+
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public abstract class CommoditiesComplementParameterSetKeyDataPairValidator<A extends Annotation>
+    implements ConstraintValidator<A, Commodities> {
+
+  private ComplementParameterSetKeyDataPairValidator validation;
+
+  @Override
+  public void initialize(A constraintAnnotation) {
+    this.validation = initializeValidator(constraintAnnotation);
+  }
+
+  abstract ComplementParameterSetKeyDataPairValidator initializeValidator(A constraintAnnotation);
+
+  @Override
+  public boolean isValid(
+      Commodities commodities, ConstraintValidatorContext context) {
+    if (commodities.getCommodityComplement() == null
+        || commodities.getComplementParameterSet() == null) {
+      return true;
+    }
+
+    List<CommodityComplement> commodityComplements = commodities.getCommodityComplement().stream()
+        .filter(
+            commodityComplement -> !Boolean.TRUE.equals(commodityComplement.getIsWoodPackaging()))
+        .collect(Collectors.toList());
+    List<ComplementParameterSet> complementParameterSets = new ArrayList<>(
+        commodityComplements.size());
+    for (CommodityComplement complement : commodityComplements) {
+      Optional<ComplementParameterSet> complementParameterSetOptional = commodities
+          .getComplementParameterSet()
+          .stream().filter(complementParameterSet ->
+              complement.getComplementID().equals(complementParameterSet.getComplementID())
+                  && complement.getSpeciesID().equals(complementParameterSet.getSpeciesID()))
+          .findFirst();
+      if (complementParameterSetOptional.isPresent()) {
+        complementParameterSets.add(complementParameterSetOptional.get());
+      } else {
+        return false;
+      }
+    }
+
+    return complementParameterSets.stream().allMatch(this::isKeyDataPairValid);
+  }
+
+  protected boolean isKeyDataPairValid(ComplementParameterSet complementParameterSet) {
+    return validation.isValid(complementParameterSet.getKeyDataPair());
+  }
+}

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ComplementParameterSetKeyDataPairValidator.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ComplementParameterSetKeyDataPairValidator.java
@@ -1,0 +1,35 @@
+package uk.gov.defra.tracesx.notificationschema.validation.annotations;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import uk.gov.defra.tracesx.notificationschema.representation.ComplementParameterSetKeyDataPair;
+
+import java.util.List;
+
+@Getter
+@RequiredArgsConstructor
+public abstract class ComplementParameterSetKeyDataPairValidator {
+
+  private final String fieldName;
+
+  public boolean isValid(
+      List<ComplementParameterSetKeyDataPair> keyDataPairList) {
+    if (keyDataPairList == null) {
+      return false;
+    }
+    for (ComplementParameterSetKeyDataPair keyDataPair : keyDataPairList) {
+      String key = keyDataPair.getKey();
+      if (isBlank(key)) {
+        return false;
+      }
+      if (key.equals(getFieldName())) {
+        return isValid(keyDataPair.getData());
+      }
+    }
+    return false;
+  }
+
+  protected abstract boolean isValid(String data);
+}

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/MinValueKeyDataPairValidation.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/MinValueKeyDataPairValidation.java
@@ -1,0 +1,24 @@
+package uk.gov.defra.tracesx.notificationschema.validation.annotations;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+public class MinValueKeyDataPairValidation extends ComplementParameterSetKeyDataPairValidator {
+
+  public MinValueKeyDataPairValidation(String fieldName) {
+    super(fieldName);
+  }
+
+  @Override
+  protected boolean isValid(String data) {
+    try {
+      BigDecimal decimalValue =
+          Optional.ofNullable(data)
+              .map(BigDecimal::new)
+              .orElseThrow(NumberFormatException::new);
+      return decimalValue.compareTo(BigDecimal.ZERO) > 0;
+    } catch (NumberFormatException exception) {
+      return false;
+    }
+  }
+}

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/MinValueKeyDataPairValidator.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/MinValueKeyDataPairValidator.java
@@ -1,23 +1,19 @@
 package uk.gov.defra.tracesx.notificationschema.validation.annotations;
 
-import static org.apache.commons.lang3.StringUtils.isBlank;
-
 import uk.gov.defra.tracesx.notificationschema.representation.ComplementParameterSetKeyDataPair;
 
-import java.math.BigDecimal;
 import java.util.List;
-import java.util.Optional;
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
 
 public class MinValueKeyDataPairValidator
     implements ConstraintValidator<MinValueKeyDataPair, List<ComplementParameterSetKeyDataPair>> {
 
-  private String fieldName;
+  private MinValueKeyDataPairValidation validation;
 
   @Override
   public void initialize(MinValueKeyDataPair constraintAnnotation) {
-    this.fieldName = constraintAnnotation.field();
+    this.validation = new MinValueKeyDataPairValidation(constraintAnnotation.field());
   }
 
   @Override
@@ -26,26 +22,6 @@ public class MinValueKeyDataPairValidator
     if (keyDataPairList == null) {
       return true;
     }
-    for (ComplementParameterSetKeyDataPair keyDataPair : keyDataPairList) {
-      String key = keyDataPair.getKey();
-      if (isBlank(key)) {
-        return false;
-      }
-      if (key.equals(fieldName)) {
-        String data = keyDataPair.getData();
-        try {
-          BigDecimal value =
-              Optional.ofNullable(data)
-                  .map(BigDecimal::new)
-                  .orElseThrow(NumberFormatException::new);
-          if (value.compareTo(BigDecimal.ZERO) > 0) {
-            return true;
-          }
-        } catch (NumberFormatException exception) {
-          return false;
-        }
-      }
-    }
-    return false;
+    return validation.isValid(keyDataPairList);
   }
 }

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/NotNullKeyDataPairValidation.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/NotNullKeyDataPairValidation.java
@@ -1,0 +1,15 @@
+package uk.gov.defra.tracesx.notificationschema.validation.annotations;
+
+import static org.apache.commons.lang3.StringUtils.isEmpty;
+
+public class NotNullKeyDataPairValidation extends ComplementParameterSetKeyDataPairValidator {
+
+  public NotNullKeyDataPairValidation(String fieldName) {
+    super(fieldName);
+  }
+
+  @Override
+  protected boolean isValid(String data) {
+    return !isEmpty(data);
+  }
+}

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/NotNullKeyDataPairValidator.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/NotNullKeyDataPairValidator.java
@@ -1,8 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.validation.annotations;
 
-import static org.apache.commons.lang3.StringUtils.isBlank;
-import static org.apache.commons.lang3.StringUtils.isEmpty;
-
 import uk.gov.defra.tracesx.notificationschema.representation.ComplementParameterSetKeyDataPair;
 
 import java.util.List;
@@ -12,28 +9,16 @@ import javax.validation.ConstraintValidatorContext;
 public class NotNullKeyDataPairValidator
     implements ConstraintValidator<NotNullKeyDataPair, List<ComplementParameterSetKeyDataPair>> {
 
-  private String fieldName;
+  private NotNullKeyDataPairValidation validation;
 
   @Override
   public void initialize(NotNullKeyDataPair constraintAnnotation) {
-    this.fieldName = constraintAnnotation.field();
+    this.validation = new NotNullKeyDataPairValidation(constraintAnnotation.field());
   }
 
   @Override
   public boolean isValid(
       List<ComplementParameterSetKeyDataPair> keyDataPairList, ConstraintValidatorContext context) {
-    if (keyDataPairList == null) {
-      return false;
-    }
-    for (ComplementParameterSetKeyDataPair keyDataPair : keyDataPairList) {
-      String key = keyDataPair.getKey();
-      if (isBlank(key)) {
-        return false;
-      }
-      if (key.equals(fieldName)) {
-        return !isEmpty(keyDataPair.getData());
-      }
-    }
-    return false;
+    return validation.isValid(keyDataPairList);
   }
 }

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/groups/NotificationCedOrCvedpFieldValidation.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/groups/NotificationCedOrCvedpFieldValidation.java
@@ -1,0 +1,6 @@
+package uk.gov.defra.tracesx.notificationschema.validation.groups;
+
+public interface NotificationCedOrCvedpFieldValidation extends
+    NotificationHighRiskFieldValidation {
+
+}

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedppMinValueKeyDataPairValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedppMinValueKeyDataPairValidatorTest.java
@@ -1,0 +1,200 @@
+package uk.gov.defra.tracesx.notificationschema.validation.annotations;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.defra.tracesx.notificationschema.representation.Commodities;
+import uk.gov.defra.tracesx.notificationschema.representation.CommodityComplement;
+import uk.gov.defra.tracesx.notificationschema.representation.ComplementParameterSet;
+import uk.gov.defra.tracesx.notificationschema.representation.ComplementParameterSet.ComplementParameterSetBuilder;
+import uk.gov.defra.tracesx.notificationschema.representation.ComplementParameterSetKeyDataPair;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ChedppMinValueKeyDataPairValidatorTest {
+
+  private static final String FIELD_NAME = "data-field";
+
+  @Mock
+  private ChedppMinValueKeyDataPair mockKeyDataPair;
+
+  private ChedppMinValueKeyDataPairValidator validator;
+
+  @Mock
+  private Commodities commodities;
+  private List<CommodityComplement> commodityComplements = new ArrayList<>();
+  private List<ComplementParameterSet> complementParameterSets = new ArrayList<>();
+
+  @Before
+  public void setup() {
+    validator = new ChedppMinValueKeyDataPairValidator();
+    when(mockKeyDataPair.field()).thenReturn(FIELD_NAME);
+    when(commodities.getCommodityComplement()).thenReturn(commodityComplements);
+    when(commodities.getComplementParameterSet()).thenReturn(complementParameterSets);
+    validator.initialize(mockKeyDataPair);
+  }
+
+  private CommodityComplement createCommodityComplement(Integer complementID, String speciesID,
+      Boolean isWoodPackaging) {
+    return CommodityComplement.builder().complementID(complementID).speciesID(speciesID)
+        .isWoodPackaging(isWoodPackaging).build();
+  }
+
+  private ComplementParameterSet createComplementParameterSet(
+      CommodityComplement commodityComplement) {
+    ComplementParameterSetBuilder builder = ComplementParameterSet.builder()
+        .complementID(commodityComplement.getComplementID())
+        .speciesID(commodityComplement.getSpeciesID());
+
+    return builder.build();
+  }
+
+  private ComplementParameterSet createComplementParameterSet(
+      CommodityComplement commodityComplement, ComplementParameterSetKeyDataPair... keyDataPairs) {
+    ComplementParameterSetBuilder builder = ComplementParameterSet.builder()
+        .complementID(commodityComplement.getComplementID())
+        .speciesID(commodityComplement.getSpeciesID());
+    if (keyDataPairs != null) {
+      builder.keyDataPair(Arrays.asList(keyDataPairs));
+    }
+
+    return builder.build();
+  }
+
+  @Test
+  public void testValidWhenNoCommodityComplement() {
+    when(commodities.getCommodityComplement()).thenReturn(null);
+    assertTrue(validator.isValid(commodities, null));
+  }
+
+  @Test
+  public void testValidWhenNoComplementParameterSet() {
+    when(commodities.getComplementParameterSet()).thenReturn(null);
+    assertTrue(validator.isValid(commodities, null));
+  }
+
+  @Test
+  public void testValidWhenEmptyCommoditiesData() {
+    assertTrue(validator.isValid(commodities, null));
+  }
+
+  @Test
+  public void testNotValidWhenNoMatchingComplementParameterSet() {
+    CommodityComplement commodityComplement = createCommodityComplement(1, "1", null);
+    ComplementParameterSet complementParameterSet = createComplementParameterSet(
+        commodityComplement);
+    complementParameterSet.setComplementID(complementParameterSet.getComplementID() + 1);
+    commodityComplements.add(commodityComplement);
+    complementParameterSets.add(complementParameterSet);
+
+    assertFalse(validator.isValid(commodities, null));
+  }
+
+  @Test
+  public void testValidWhenOnlyInvalidWoodPackagingCommodity() {
+    CommodityComplement commodityComplement = createCommodityComplement(1, "1", true);
+    ComplementParameterSet complementParameterSet = createComplementParameterSet(
+        commodityComplement);
+    commodityComplements.add(commodityComplement);
+    complementParameterSets.add(complementParameterSet);
+
+    assertTrue(validator.isValid(commodities, null));
+  }
+
+  @Test
+  public void testNotValidWhenNullKeyDataPairInComplementParameterSet() {
+    CommodityComplement commodityComplement = createCommodityComplement(1, "1", null);
+    ComplementParameterSet complementParameterSet = createComplementParameterSet(
+        commodityComplement);
+    commodityComplements.add(commodityComplement);
+    complementParameterSets.add(complementParameterSet);
+
+    assertTrue(validator.isValid(commodities, null));
+  }
+
+  @Test
+  public void testValidWhenCommodityIsValidAndWoodPackagingIsInvalid() {
+    CommodityComplement commodityComplement = createCommodityComplement(1, "1", null);
+    ComplementParameterSet complementParameterSet = createComplementParameterSet(
+        commodityComplement,
+        ComplementParameterSetKeyDataPair.builder().key(FIELD_NAME).data("10").build(),
+        ComplementParameterSetKeyDataPair.builder().key("foo").data("bar").build());
+    commodityComplements.add(commodityComplement);
+    complementParameterSets.add(complementParameterSet);
+
+    commodityComplement = createCommodityComplement(2, "2", true);
+    complementParameterSet = createComplementParameterSet(
+        commodityComplement);
+    commodityComplements.add(commodityComplement);
+    complementParameterSets.add(complementParameterSet);
+
+    assertTrue(validator.isValid(commodities, null));
+  }
+
+  @Test
+  public void testValidWhenAllCommoditiesValid() {
+    CommodityComplement commodityComplement = createCommodityComplement(1, "1", null);
+    ComplementParameterSet complementParameterSet = createComplementParameterSet(
+        commodityComplement,
+        ComplementParameterSetKeyDataPair.builder().key(FIELD_NAME).data("1").build(),
+        ComplementParameterSetKeyDataPair.builder().key("foo").data("bar").build());
+    commodityComplements.add(commodityComplement);
+    complementParameterSets.add(complementParameterSet);
+
+    commodityComplement = createCommodityComplement(2, "1", null);
+    complementParameterSet = createComplementParameterSet(
+        commodityComplement,
+        ComplementParameterSetKeyDataPair.builder().key(FIELD_NAME).data("1.0").build(),
+        ComplementParameterSetKeyDataPair.builder().key("foo").data("bar").build());
+    commodityComplements.add(commodityComplement);
+    complementParameterSets.add(complementParameterSet);
+
+    commodityComplement = createCommodityComplement(3, "1", null);
+    complementParameterSet = createComplementParameterSet(
+        commodityComplement,
+        ComplementParameterSetKeyDataPair.builder().key(FIELD_NAME).data("1.11").build(),
+        ComplementParameterSetKeyDataPair.builder().key("foo").data("bar").build());
+    commodityComplements.add(commodityComplement);
+    complementParameterSets.add(complementParameterSet);
+
+    assertTrue(validator.isValid(commodities, null));
+  }
+
+  @Test
+  public void testNotValidWhenNotAllCommoditiesValid() {
+    CommodityComplement commodityComplement = createCommodityComplement(1, "1", null);
+    ComplementParameterSet complementParameterSet = createComplementParameterSet(
+        commodityComplement,
+        ComplementParameterSetKeyDataPair.builder().key(FIELD_NAME).data("1").build(),
+        ComplementParameterSetKeyDataPair.builder().key("foo").data("bar").build());
+    commodityComplements.add(commodityComplement);
+    complementParameterSets.add(complementParameterSet);
+
+    commodityComplement = createCommodityComplement(2, "1", null);
+    complementParameterSet = createComplementParameterSet(
+        commodityComplement,
+        ComplementParameterSetKeyDataPair.builder().key(FIELD_NAME).data("x").build(),
+        ComplementParameterSetKeyDataPair.builder().key("foo").data("bar").build());
+    commodityComplements.add(commodityComplement);
+    complementParameterSets.add(complementParameterSet);
+
+    commodityComplement = createCommodityComplement(3, "1", null);
+    complementParameterSet = createComplementParameterSet(
+        commodityComplement,
+        ComplementParameterSetKeyDataPair.builder().key(FIELD_NAME).data("1").build(),
+        ComplementParameterSetKeyDataPair.builder().key("foo").data("bar").build());
+    commodityComplements.add(commodityComplement);
+    complementParameterSets.add(complementParameterSet);
+
+    assertFalse(validator.isValid(commodities, null));
+  }
+}

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedppNotNullKeyDataPairValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedppNotNullKeyDataPairValidatorTest.java
@@ -1,0 +1,191 @@
+package uk.gov.defra.tracesx.notificationschema.validation.annotations;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.defra.tracesx.notificationschema.representation.Commodities;
+import uk.gov.defra.tracesx.notificationschema.representation.CommodityComplement;
+import uk.gov.defra.tracesx.notificationschema.representation.ComplementParameterSet;
+import uk.gov.defra.tracesx.notificationschema.representation.ComplementParameterSet.ComplementParameterSetBuilder;
+import uk.gov.defra.tracesx.notificationschema.representation.ComplementParameterSetKeyDataPair;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ChedppNotNullKeyDataPairValidatorTest {
+
+  private static final String FIELD_NAME = "data-field";
+
+  @Mock
+  private ChedppNotNullKeyDataPair mockKeyDataPair;
+
+  private ChedppNotNullKeyDataPairValidator validator;
+
+  @Mock
+  private Commodities commodities;
+  private List<CommodityComplement> commodityComplements = new ArrayList<>();
+  private List<ComplementParameterSet> complementParameterSets = new ArrayList<>();
+
+  @Before
+  public void setup() {
+    validator = new ChedppNotNullKeyDataPairValidator();
+    when(mockKeyDataPair.field()).thenReturn(FIELD_NAME);
+    when(commodities.getCommodityComplement()).thenReturn(commodityComplements);
+    when(commodities.getComplementParameterSet()).thenReturn(complementParameterSets);
+    validator.initialize(mockKeyDataPair);
+  }
+
+  private CommodityComplement createCommodityComplement(Integer complementID, String speciesID,
+      Boolean isWoodPackaging) {
+    return CommodityComplement.builder().complementID(complementID).speciesID(speciesID)
+        .isWoodPackaging(isWoodPackaging).build();
+  }
+
+  private ComplementParameterSet createComplementParameterSet(
+      CommodityComplement commodityComplement, ComplementParameterSetKeyDataPair... keyDataPairs) {
+    ComplementParameterSetBuilder builder = ComplementParameterSet.builder()
+        .complementID(commodityComplement.getComplementID())
+        .speciesID(commodityComplement.getSpeciesID());
+    if (keyDataPairs != null) {
+      builder.keyDataPair(Arrays.asList(keyDataPairs));
+    }
+
+    return builder.build();
+  }
+
+  @Test
+  public void testValidWhenNoCommodityComplement() {
+    when(commodities.getCommodityComplement()).thenReturn(null);
+    assertTrue(validator.isValid(commodities, null));
+  }
+
+  @Test
+  public void testValidWhenNoComplementParameterSet() {
+    when(commodities.getComplementParameterSet()).thenReturn(null);
+    assertTrue(validator.isValid(commodities, null));
+  }
+
+  @Test
+  public void testValidWhenEmptyCommoditiesData() {
+    assertTrue(validator.isValid(commodities, null));
+  }
+
+  @Test
+  public void testNotValidWhenNoMatchingComplementParameterSet() {
+    CommodityComplement commodityComplement = createCommodityComplement(1, "1", null);
+    ComplementParameterSet complementParameterSet = createComplementParameterSet(
+        commodityComplement);
+    complementParameterSet.setComplementID(complementParameterSet.getComplementID() + 1);
+    commodityComplements.add(commodityComplement);
+    complementParameterSets.add(complementParameterSet);
+
+    assertFalse(validator.isValid(commodities, null));
+  }
+
+  @Test
+  public void testValidWhenOnlyInvalidWoodPackagingCommodity() {
+    CommodityComplement commodityComplement = createCommodityComplement(1, "1", true);
+    ComplementParameterSet complementParameterSet = createComplementParameterSet(
+        commodityComplement);
+    commodityComplements.add(commodityComplement);
+    complementParameterSets.add(complementParameterSet);
+
+    assertTrue(validator.isValid(commodities, null));
+  }
+
+  @Test
+  public void testNotValidWhenNullKeyDataPairInComplementParameterSet() {
+    CommodityComplement commodityComplement = createCommodityComplement(1, "1", null);
+    ComplementParameterSet complementParameterSet = createComplementParameterSet(
+        commodityComplement);
+    commodityComplements.add(commodityComplement);
+    complementParameterSets.add(complementParameterSet);
+
+    assertFalse(validator.isValid(commodities, null));
+  }
+
+  @Test
+  public void testValidWhenCommodityIsValidAndWoodPackagingIsInvalid() {
+    CommodityComplement commodityComplement = createCommodityComplement(1, "1", null);
+    ComplementParameterSet complementParameterSet = createComplementParameterSet(
+        commodityComplement,
+        ComplementParameterSetKeyDataPair.builder().key(FIELD_NAME).data("hello").build(),
+        ComplementParameterSetKeyDataPair.builder().key("foo").data("bar").build());
+    commodityComplements.add(commodityComplement);
+    complementParameterSets.add(complementParameterSet);
+
+    commodityComplement = createCommodityComplement(2, "2", true);
+    complementParameterSet = createComplementParameterSet(
+        commodityComplement);
+    commodityComplements.add(commodityComplement);
+    complementParameterSets.add(complementParameterSet);
+
+    assertTrue(validator.isValid(commodities, null));
+  }
+
+  @Test
+  public void testValidWhenAllCommoditiesValid() {
+    CommodityComplement commodityComplement = createCommodityComplement(1, "1", null);
+    ComplementParameterSet complementParameterSet = createComplementParameterSet(
+        commodityComplement,
+        ComplementParameterSetKeyDataPair.builder().key(FIELD_NAME).data("hello").build(),
+        ComplementParameterSetKeyDataPair.builder().key("foo").data("bar").build());
+    commodityComplements.add(commodityComplement);
+    complementParameterSets.add(complementParameterSet);
+
+    commodityComplement = createCommodityComplement(2, "1", null);
+    complementParameterSet = createComplementParameterSet(
+        commodityComplement,
+        ComplementParameterSetKeyDataPair.builder().key(FIELD_NAME).data("hello").build(),
+        ComplementParameterSetKeyDataPair.builder().key("foo").data("bar").build());
+    commodityComplements.add(commodityComplement);
+    complementParameterSets.add(complementParameterSet);
+
+    commodityComplement = createCommodityComplement(3, "1", null);
+    complementParameterSet = createComplementParameterSet(
+        commodityComplement,
+        ComplementParameterSetKeyDataPair.builder().key(FIELD_NAME).data("hello").build(),
+        ComplementParameterSetKeyDataPair.builder().key("foo").data("bar").build());
+    commodityComplements.add(commodityComplement);
+    complementParameterSets.add(complementParameterSet);
+
+    assertTrue(validator.isValid(commodities, null));
+  }
+
+  @Test
+  public void testNotValidWhenNotAllCommoditiesValid() {
+    CommodityComplement commodityComplement = createCommodityComplement(1, "1", null);
+    ComplementParameterSet complementParameterSet = createComplementParameterSet(
+        commodityComplement,
+        ComplementParameterSetKeyDataPair.builder().key(FIELD_NAME).data("hello").build(),
+        ComplementParameterSetKeyDataPair.builder().key("foo").data("bar").build());
+    commodityComplements.add(commodityComplement);
+    complementParameterSets.add(complementParameterSet);
+
+    commodityComplement = createCommodityComplement(2, "1", null);
+    complementParameterSet = createComplementParameterSet(
+        commodityComplement,
+        ComplementParameterSetKeyDataPair.builder().key(FIELD_NAME).data("hello").build(),
+        ComplementParameterSetKeyDataPair.builder().key("foo").data("bar").build());
+    commodityComplements.add(commodityComplement);
+    complementParameterSets.add(complementParameterSet);
+
+    commodityComplement = createCommodityComplement(3, "1", null);
+    complementParameterSet = createComplementParameterSet(
+        commodityComplement,
+        ComplementParameterSetKeyDataPair.builder().key(FIELD_NAME).build(),
+        ComplementParameterSetKeyDataPair.builder().key("foo").data("bar").build());
+    commodityComplements.add(commodityComplement);
+    complementParameterSets.add(complementParameterSet);
+
+    assertFalse(validator.isValid(commodities, null));
+  }
+}

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/MinValueKeyDataPairValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/MinValueKeyDataPairValidatorTest.java
@@ -28,6 +28,7 @@ public class MinValueKeyDataPairValidatorTest {
     validator = new MinValueKeyDataPairValidator();
     when(mockKeyDataPair.field()).thenReturn("number_package");
     keyDataPairList = new ArrayList<>();
+    validator.initialize(mockKeyDataPair);
   }
 
   @Test
@@ -37,8 +38,6 @@ public class MinValueKeyDataPairValidatorTest {
 
   @Test
   public void testNumPackagesIsInvalidIfNoMatchingFieldPresent() {
-    validator.initialize(mockKeyDataPair);
-
     ComplementParameterSetKeyDataPair pair = new ComplementParameterSetKeyDataPair();
     pair.setKey("netweight");
     keyDataPairList.add(pair);
@@ -52,8 +51,6 @@ public class MinValueKeyDataPairValidatorTest {
 
   @Test
   public void testNumPackagesIsInvalidIfDataValueCannotBeParsedToInteger() {
-    validator.initialize(mockKeyDataPair);
-
     ComplementParameterSetKeyDataPair pair = new ComplementParameterSetKeyDataPair();
     pair.setKey("number_package");
     pair.setData("X");
@@ -64,8 +61,6 @@ public class MinValueKeyDataPairValidatorTest {
 
   @Test
   public void testNumPackagesIsInvalidIfDataValueIsZero() {
-    validator.initialize(mockKeyDataPair);
-
     ComplementParameterSetKeyDataPair pair = new ComplementParameterSetKeyDataPair();
     pair.setKey("number_package");
     pair.setData("0");
@@ -76,8 +71,6 @@ public class MinValueKeyDataPairValidatorTest {
 
   @Test
   public void testNumPackagesIsValidIfDataValueIsOne() {
-    validator.initialize(mockKeyDataPair);
-
     ComplementParameterSetKeyDataPair pair = new ComplementParameterSetKeyDataPair();
     pair.setKey("number_package");
     pair.setData("1");

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/NotNullKeyDataPairValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/NotNullKeyDataPairValidatorTest.java
@@ -28,6 +28,7 @@ public class NotNullKeyDataPairValidatorTest {
     validator = new NotNullKeyDataPairValidator();
     when(mockKeyDataPair.field()).thenReturn("type_package");
     keyDataPairList = new ArrayList<>();
+    validator.initialize(mockKeyDataPair);
   }
 
   @Test
@@ -36,19 +37,7 @@ public class NotNullKeyDataPairValidatorTest {
   }
 
   @Test
-  public void testKeyDataPairIsValidIfObjectPassedContainsOnlyPackageType() {
-    ComplementParameterSetKeyDataPair pair = new ComplementParameterSetKeyDataPair();
-    pair.setKey("type_package");
-    pair.setData("bag");
-    keyDataPairList.add(pair);
-
-    assertFalse(validator.isValid(keyDataPairList, null));
-  }
-
-  @Test
   public void testTypePackageIsInvalidIfNoMatchingFieldPresent() {
-    validator.initialize(mockKeyDataPair);
-
     ComplementParameterSetKeyDataPair pair = new ComplementParameterSetKeyDataPair();
     pair.setKey("netweight");
     keyDataPairList.add(pair);
@@ -62,8 +51,6 @@ public class NotNullKeyDataPairValidatorTest {
 
   @Test
   public void testTypePackageIsInValidIfDataValueIsEmpty() {
-    validator.initialize(mockKeyDataPair);
-
     ComplementParameterSetKeyDataPair pair = new ComplementParameterSetKeyDataPair();
     pair.setKey("type_package");
     pair.setData("");
@@ -74,8 +61,6 @@ public class NotNullKeyDataPairValidatorTest {
 
   @Test
   public void testTypePackageIsValidIfDataValueIsNotEmpty() {
-    validator.initialize(mockKeyDataPair);
-
     ComplementParameterSetKeyDataPair pair = new ComplementParameterSetKeyDataPair();
     pair.setKey("type_package");
     pair.setData("bag");


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | dominik henjes (KAINOS) |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [IMTA 7695 - CHEDPP validation changes fo...](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/99) |
> | **GitLab MR Number** | [99](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/99) |
> | **Date Originally Opened** | Fri, 17 Jul 2020 |
> | **Approved on GitLab by** | David McKinney (KAINOS), Reece Bennett (KAINOS), Stephen Donaghey (KAINOS) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

- Adds product type key for CHEDPP
- Moves CHEDPP key data pair validation to Commodities level in order to exclude wood packaging commodities from import commodity validation
- Refactors common validation code for reuse at different object graph levels