### PR TITLE
Feature/imta 7918 country of destination

### DIFF
--- a/imports-frontend-entities/package-lock.json
+++ b/imports-frontend-entities/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipaffs/imports-frontend-entities",
-  "version": "1.0.86",
+  "version": "1.0.87",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/imports-frontend-entities/package.json
+++ b/imports-frontend-entities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipaffs/imports-frontend-entities",
-  "version": "1.0.86",
+  "version": "1.0.87",
   "repository": {
     "type": "git"
   },

--- a/imports-frontend-entities/src/entities/notification.js
+++ b/imports-frontend-entities/src/entities/notification.js
@@ -27,6 +27,7 @@ module.exports = class Notification {
     this.lastUpdated = obj.lastUpdated
     this.type = obj.type
     this.status = obj.status
+    this.countryOfDestination = obj.countryOfDestination
     this.partOne = _.get(obj, 'partOne') ? new PartOne(obj.partOne) : undefined
     this.partTwo = _.get(obj, 'partTwo') ? new PartTwo(obj.partTwo) : undefined
     this.partThree = _.get(obj, 'partThree') ? new PartThree(obj.partThree)

--- a/notification-schema-core/resources/notification-schema.json
+++ b/notification-schema-core/resources/notification-schema.json
@@ -51,6 +51,14 @@
         "IMP"
       ]
     },
+    "countryOfDestination" : {
+      "type": "string",
+      "description": "The receiving UK border country for the notification",
+      "enum": [
+        "GB",
+        "XI"
+      ]
+    },
     "replaces": {
       "$ref": "#/definitions/ReferenceNumber",
       "description": "Reference number of notification that was replaced by this one"

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/Notification.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/Notification.java
@@ -11,6 +11,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import uk.gov.defra.tracesx.notificationschema.representation.enumeration.CountryOfDestinationEnum;
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.NotificationTypeEnum;
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.StatusEnum;
 import uk.gov.defra.tracesx.notificationschema.representation.serialisation.IsoOffsetDateTimeDeserializer;
@@ -66,6 +67,9 @@ public class Notification {
 
   @ApiModelProperty(value = "Type of the notification that has been submitted")
   private NotificationTypeEnum type;
+
+  @ApiModelProperty(value = "The receiving UK border country for the notification")
+  private CountryOfDestinationEnum countryOfDestination;
 
   @NotNull(groups = BasicValidation.class, message = "may not be null or invalid")
   @ApiModelProperty(

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/CountryOfDestinationEnum.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/CountryOfDestinationEnum.java
@@ -1,0 +1,35 @@
+package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum CountryOfDestinationEnum {
+  GB("GB"),
+  NI("XI");
+
+  private String value;
+
+  CountryOfDestinationEnum(String value) {
+    this.value = value;
+  }
+
+  @JsonCreator
+  public static CountryOfDestinationEnum fromValue(String text) {
+    for (CountryOfDestinationEnum b : CountryOfDestinationEnum.values()) {
+      if (b.value.equals(text)) {
+        return b;
+      }
+    }
+    return null;
+  }
+
+  @JsonValue
+  public String getValue() {
+    return value;
+  }
+
+  @Override
+  public String toString() {
+    return value;
+  }
+}


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | marcus bond (KAINOS) |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [Feature/imta 7918 country of destination](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/111) |
> | **GitLab MR Number** | [111](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/111) |
> | **Date Originally Opened** | Wed, 5 Aug 2020 |
> | **Approved on GitLab by** | Reece Bennett (KAINOS), Stephen Donaghey (KAINOS), daniel brennan (KAINOS) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Add country of destination to schema to support DAERA GB / NI distinction