### PR TITLE
IMTA-8179: Ensure that CHED-PP certificates with no species info validate correctly

### DIFF
--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedppMinValueKeyDataPairValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedppMinValueKeyDataPairValidatorTest.java
@@ -31,8 +31,8 @@ public class ChedppMinValueKeyDataPairValidatorTest {
 
   @Mock
   private Commodities commodities;
-  private List<CommodityComplement> commodityComplements = new ArrayList<>();
-  private List<ComplementParameterSet> complementParameterSets = new ArrayList<>();
+  private final List<CommodityComplement> commodityComplements = new ArrayList<>();
+  private final List<ComplementParameterSet> complementParameterSets = new ArrayList<>();
 
   @Before
   public void setup() {
@@ -78,7 +78,6 @@ public class ChedppMinValueKeyDataPairValidatorTest {
 
   @Test
   public void testValidWhenNoComplementParameterSet() {
-    when(commodities.getComplementParameterSet()).thenReturn(null);
     assertThat(validator.isValid(commodities, null)).isTrue();
   }
 

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedppNotNullKeyDataPairValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedppNotNullKeyDataPairValidatorTest.java
@@ -69,7 +69,6 @@ public class ChedppNotNullKeyDataPairValidatorTest {
 
   @Test
   public void testValidWhenNoComplementParameterSet() {
-    when(commodities.getComplementParameterSet()).thenReturn(null);
     assertTrue(validator.isValid(commodities, null));
   }
 


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | iwan roberts (KAINOS) |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [IMTA-8179: Ensure that CHED-PP certifica...](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/120) |
> | **GitLab MR Number** | [120](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/120) |
> | **Date Originally Opened** | Tue, 8 Sep 2020 |
> | **Approved on GitLab by** | David McKinney (KAINOS), Sean Treanor (KAINOS), kamil mojek (KAINOS), marcus bond (KAINOS) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

The purpose of this change is to ensure that the issue seen on the CHED-PP certificate review page where valid data entries are rejected is remediated. The issue only occurs when the commodity does not contain species information. The change removes the species id check when mapping from commodityComplement to complementParameterSet.