### PR TITLE
IMTA-7989: Add control point field to schema

### DIFF
--- a/imports-frontend-entities/package-lock.json
+++ b/imports-frontend-entities/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipaffs/imports-frontend-entities",
-  "version": "1.0.98",
+  "version": "1.0.99",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/imports-frontend-entities/package.json
+++ b/imports-frontend-entities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipaffs/imports-frontend-entities",
-  "version": "1.0.98",
+  "version": "1.0.99",
   "repository": {
     "type": "git"
   },

--- a/imports-frontend-entities/src/entities/part_one.js
+++ b/imports-frontend-entities/src/entities/part_one.js
@@ -48,6 +48,7 @@ module.exports = class PartOne {
         obj.commodities) : undefined
     this.purpose = _.get(obj, 'purpose') ? new Purpose(obj.purpose) : undefined
     this.pointOfEntry = obj.pointOfEntry
+    this.pointOfEntryControlPoint = obj.pointOfEntryControlPoint
     this.arrivalDate = obj.arrivalDate
     this.arrivalTime = obj.arrivalTime
     this.meansOfTransport = _.get(obj, 'meansOfTransport')

--- a/notification-schema-core/resources/notification-schema.json
+++ b/notification-schema-core/resources/notification-schema.json
@@ -515,6 +515,12 @@
           "maxLength": 30,
           "description": "Either a Border-Inspection-Post or Designated-Point-Of-Entry, e.g. GBFXT1"
         },
+        "pointOfEntryControlPoint": {
+          "type": "string",
+          "minLength": 0,
+          "maxLength": 30,
+          "description": "A control point at the point of entry"
+        },
         "arrivalDate": {
           "type": "string",
           "javaType": "java.time.LocalDate",

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/PartOne.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/PartOne.java
@@ -163,6 +163,8 @@ public class PartOne {
           + ".not.null}")
   private String pointOfEntry;
 
+  private String pointOfEntryControlPoint;
+
   @NotNull(
       groups = NotificationHighRiskFieldValidation.class,
       message = "{uk.gov.defra.tracesx.notificationschema.representation.partone.arrivaldate"


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Reece Bennett (KAINOS) |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [IMTA-7989: Add control point field to sc...](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/123) |
> | **GitLab MR Number** | [123](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/123) |
> | **Date Originally Opened** | Mon, 14 Sep 2020 |
> | **Approved on GitLab by** | Stephen Donaghey (KAINOS), Stephen McVeigh, iwan roberts (KAINOS), marcus bond (KAINOS) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

https://eaflood.atlassian.net/browse/IMTA-7989