### PR TITLE
IMTA-6330 Remove Date Time Formatter

### DIFF
--- a/imports-frontend-entities/package-lock.json
+++ b/imports-frontend-entities/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipaffs/imports-frontend-entities",
-  "version": "1.0.100",
+  "version": "1.0.101",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/imports-frontend-entities/package.json
+++ b/imports-frontend-entities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipaffs/imports-frontend-entities",
-  "version": "1.0.100",
+  "version": "1.0.101",
   "repository": {
     "type": "git"
   },

--- a/notification-schema-core/resources/notification-schema.json
+++ b/notification-schema-core/resources/notification-schema.json
@@ -32,7 +32,6 @@
     "lastUpdated": {
       "type": "string",
       "javaType": "java.time.LocalDateTime",
-      "format": "date-time",
       "description": "Date when the notification was last updated."
     },
     "lastUpdatedBy": {
@@ -657,7 +656,6 @@
         "submissionDate": {
           "type": "string",
           "javaType": "java.time.LocalDateTime",
-          "format": "date-time",
           "description": "Date and time when the notification was submitted"
         },
         "submittedBy": {
@@ -702,7 +700,6 @@
     "decisionDate": {
       "type": "string",
       "javaType": "java.time.LocalDateTime",
-      "format": "date-time",
       "description": "Date when the notification was validated or rejected"
     },
     "partTwo": {
@@ -1136,7 +1133,6 @@
         "checkDate": {
           "type": "string",
           "javaType": "java.time.LocalDateTime",
-          "format": "date-time",
           "description": "User entered date when the checks were completed"
         },
         "accompanyingDocuments": {
@@ -1571,7 +1567,6 @@
         "testDate": {
           "type": "string",
           "javaType": "java.time.LocalDateTime",
-          "format": "date-time",
           "description": "Date of tests"
         },
         "testReason": {
@@ -1704,7 +1699,6 @@
         "signed": {
           "type": "string",
           "javaType": "java.time.LocalDateTime",
-          "format": "date-time",
           "description": "Date of sign"
         }
       }
@@ -1744,7 +1738,6 @@
         "signed": {
           "type": "string",
           "javaType": "java.time.LocalDateTime",
-          "format": "date-time",
           "description": "Date of sign"
         }
       }


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Stephen Donaghey (KAINOS) |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [IMTA-6330 Remove Date Time Formatter](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/125) |
> | **GitLab MR Number** | [125](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/125) |
> | **Date Originally Opened** | Thu, 24 Sep 2020 |
> | **Approved on GitLab by** | David McKinney (KAINOS), Ghost User, Reece Bennett (KAINOS) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Removing due to the fact we use LocalDateTime's and not ZonedDateTime's. The schema validation library doesn't support standard LocalDateTime, as the Zone is missing.