### PR TITLE
IMTA-3130: Removed the return null if incorrect enum value function. Now will…

### DIFF
--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/AnalysisType.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/AnalysisType.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum AnalysisType {
@@ -12,16 +11,6 @@ public enum AnalysisType {
 
   AnalysisType(String value) {
     this.value = value;
-  }
-
-  @JsonCreator
-  public static AnalysisType fromValue(String text) {
-    for (AnalysisType u : AnalysisType.values()) {
-      if (u.value.equalsIgnoreCase(text)) {
-        return u;
-      }
-    }
-    return null;
   }
 
   @JsonValue

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/AnimalCertification.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/AnimalCertification.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum AnimalCertification {
@@ -31,16 +30,6 @@ public enum AnimalCertification {
 
   AnimalCertification(String value) {
     this.value = value;
-  }
-
-  @JsonCreator
-  public static AnimalCertification fromValue(String text) {
-    for (AnimalCertification b : AnimalCertification.values()) {
-      if (b.value.equals(text)) {
-        return b;
-      }
-    }
-    return null;
   }
 
   @JsonValue

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/AnimalsUnit.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/AnimalsUnit.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum AnimalsUnit {
@@ -11,16 +10,6 @@ public enum AnimalsUnit {
 
   AnimalsUnit(String value) {
     this.value = value;
-  }
-
-  @JsonCreator
-  public static AnimalsUnit fromValue(String text) {
-    for (AnimalsUnit u : AnimalsUnit.values()) {
-      if (u.value.equalsIgnoreCase(text)) {
-        return u;
-      }
-    }
-    return null;
   }
 
   @JsonValue

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/AuthorityType.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/AuthorityType.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum AuthorityType {
@@ -13,16 +12,6 @@ public enum AuthorityType {
 
   AuthorityType(String value) {
     this.value = value;
-  }
-
-  @JsonCreator
-  public static AuthorityType fromValue(String text) {
-    for (AuthorityType b : AuthorityType.values()) {
-      if (String.valueOf(b.value).equals(text)) {
-        return b;
-      }
-    }
-    return null;
   }
 
   public String getValue() {

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ChedppNotAcceptableCommodityOrPackageEnum.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ChedppNotAcceptableCommodityOrPackageEnum.java
@@ -1,9 +1,6 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
-
-import java.util.Arrays;
 
 public enum ChedppNotAcceptableCommodityOrPackageEnum {
   COMMODITIES("c"),
@@ -14,14 +11,6 @@ public enum ChedppNotAcceptableCommodityOrPackageEnum {
 
   ChedppNotAcceptableCommodityOrPackageEnum(String value) {
     this.value = value;
-  }
-
-  @JsonCreator
-  public static ChedppNotAcceptableCommodityOrPackageEnum fromValue(String text) {
-    return Arrays.stream(ChedppNotAcceptableCommodityOrPackageEnum.values())
-        .filter(label -> label.value.equals(text))
-        .findFirst()
-        .orElse(null);
   }
 
   @JsonValue

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ChedppNotAcceptableReasonEnum.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ChedppNotAcceptableReasonEnum.java
@@ -1,9 +1,6 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
-
-import java.util.Arrays;
 
 public enum ChedppNotAcceptableReasonEnum {
   DOCPHMDM("doc-phmdm"),
@@ -40,14 +37,6 @@ public enum ChedppNotAcceptableReasonEnum {
 
   ChedppNotAcceptableReasonEnum(String value) {
     this.value = value;
-  }
-
-  @JsonCreator
-  public static ChedppNotAcceptableReasonEnum fromValue(String text) {
-    return Arrays.stream(ChedppNotAcceptableReasonEnum.values())
-        .filter(label -> label.value.equals(text))
-        .findFirst()
-        .orElse(null);
   }
 
   @JsonValue

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/CommodityIntention.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/CommodityIntention.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum CommodityIntention {
@@ -13,16 +12,6 @@ public enum CommodityIntention {
 
   CommodityIntention(String value) {
     this.value = value;
-  }
-
-  @JsonCreator
-  public static CommodityIntention fromValue(String text) {
-    for (CommodityIntention b : CommodityIntention.values()) {
-      if (b.value.equals(text)) {
-        return b;
-      }
-    }
-    return null;
   }
 
   @JsonValue

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/CommodityTemperature.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/CommodityTemperature.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum CommodityTemperature {
@@ -12,16 +11,6 @@ public enum CommodityTemperature {
 
   CommodityTemperature(String value) {
     this.value = value;
-  }
-
-  @JsonCreator
-  public static CommodityTemperature fromValue(String text) {
-    for (CommodityTemperature u : CommodityTemperature.values()) {
-      if (u.value.equalsIgnoreCase(text)) {
-        return u;
-      }
-    }
-    return null;
   }
 
   @JsonValue

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/Conclusion.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/Conclusion.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum Conclusion {
@@ -13,16 +12,6 @@ public enum Conclusion {
 
   Conclusion(String value) {
     this.value = value;
-  }
-
-  @JsonCreator
-  public static Conclusion fromValue(String text) {
-    for (Conclusion u : Conclusion.values()) {
-      if (u.value.equalsIgnoreCase(text)) {
-        return u;
-      }
-    }
-    return null;
   }
 
   @JsonValue

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ConservationOfSample.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ConservationOfSample.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum ConservationOfSample {
@@ -12,16 +11,6 @@ public enum ConservationOfSample {
 
   ConservationOfSample(String value) {
     this.value = value;
-  }
-
-  @JsonCreator
-  public static ConservationOfSample fromValue(String text) {
-    for (ConservationOfSample u : ConservationOfSample.values()) {
-      if (u.value.equalsIgnoreCase(text)) {
-        return u;
-      }
-    }
-    return null;
   }
 
   @JsonValue

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ConsignmentLeave.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ConsignmentLeave.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum ConsignmentLeave {
@@ -17,15 +16,5 @@ public enum ConsignmentLeave {
   @JsonValue
   public String getValue() {
     return this.value;
-  }
-
-  @JsonCreator
-  public static ConsignmentLeave fromValue(String text) {
-    for (ConsignmentLeave consignmentLeave : ConsignmentLeave.values()) {
-      if (consignmentLeave.value.equals(text)) {
-        return consignmentLeave;
-      }
-    }
-    return null;
   }
 }

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ControlStatus.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ControlStatus.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum ControlStatus {
@@ -16,15 +15,5 @@ public enum ControlStatus {
   @JsonValue
   public String getValue() {
     return this.value;
-  }
-
-  @JsonCreator
-  public static ControlStatus fromValue(String text) {
-    for (ControlStatus controlStatus : ControlStatus.values()) {
-      if (controlStatus.value.equals(text)) {
-        return controlStatus;
-      }
-    }
-    return null;
   }
 }

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/DecisionEnum.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/DecisionEnum.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import uk.gov.defra.tracesx.notificationschema.validation.CED;
 import uk.gov.defra.tracesx.notificationschema.validation.CHEDPP;
@@ -46,16 +45,6 @@ public enum DecisionEnum implements EntityProperty {
 
   DecisionEnum(String value) {
     this.value = value;
-  }
-
-  @JsonCreator
-  public static DecisionEnum fromValue(String text) {
-    for (DecisionEnum b : DecisionEnum.values()) {
-      if (b.value.equals(text)) {
-        return b;
-      }
-    }
-    return null;
   }
 
   @JsonValue

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/DefinitiveImportPurposeEnum.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/DefinitiveImportPurposeEnum.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import uk.gov.defra.tracesx.notificationschema.validation.CVEDA;
 import uk.gov.defra.tracesx.notificationschema.validation.EntityProperty;
@@ -17,16 +16,6 @@ public enum DefinitiveImportPurposeEnum implements EntityProperty {
 
   DefinitiveImportPurposeEnum(String value) {
     this.value = value;
-  }
-
-  @JsonCreator
-  public static DefinitiveImportPurposeEnum fromValue(String text) {
-    for (DefinitiveImportPurposeEnum b : DefinitiveImportPurposeEnum.values()) {
-      if (b.value.equals(text)) {
-        return b;
-      }
-    }
-    return null;
   }
 
   @JsonValue

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/DocumentType.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/DocumentType.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum DocumentType {
@@ -31,16 +30,6 @@ public enum DocumentType {
 
   DocumentType(String value) {
     this.value = value;
-  }
-
-  @JsonCreator
-  public static DocumentType fromValue(String text) {
-    for (DocumentType t : DocumentType.values()) {
-      if (t.value.equalsIgnoreCase(text)) {
-        return t;
-      }
-    }
-    return null;
   }
 
   @JsonValue

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/EconomicOperatorStatus.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/EconomicOperatorStatus.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum EconomicOperatorStatus {
@@ -12,16 +11,6 @@ public enum EconomicOperatorStatus {
 
   EconomicOperatorStatus(String value) {
     this.value = value;
-  }
-
-  @JsonCreator
-  public static EconomicOperatorStatus fromValue(String text) {
-    for (EconomicOperatorStatus u : EconomicOperatorStatus.values()) {
-      if (u.value.equalsIgnoreCase(text)) {
-        return u;
-      }
-    }
-    return null;
   }
 
   @JsonValue

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/EconomicOperatorType.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/EconomicOperatorType.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum EconomicOperatorType {
@@ -21,16 +20,6 @@ public enum EconomicOperatorType {
 
   EconomicOperatorType(String value) {
     this.value = value;
-  }
-
-  @JsonCreator
-  public static EconomicOperatorType fromValue(String text) {
-    for (EconomicOperatorType u : EconomicOperatorType.values()) {
-      if (u.value.equalsIgnoreCase(text)) {
-        return u;
-      }
-    }
-    return null;
   }
 
   @JsonValue

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ExternalSystem.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ExternalSystem.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum ExternalSystem {
@@ -10,16 +9,6 @@ public enum ExternalSystem {
 
   ExternalSystem(String value) {
     this.value = value;
-  }
-
-  @JsonCreator
-  public static ExternalSystem fromValue(String text) {
-    for (ExternalSystem b : ExternalSystem.values()) {
-      if (String.valueOf(b.value).equals(text)) {
-        return b;
-      }
-    }
-    return null;
   }
 
   public String getValue() {

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ForImportOrAdmissionEnum.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ForImportOrAdmissionEnum.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum ForImportOrAdmissionEnum {
@@ -12,16 +11,6 @@ public enum ForImportOrAdmissionEnum {
 
   ForImportOrAdmissionEnum(String value) {
     this.value = value;
-  }
-
-  @JsonCreator
-  public static ForImportOrAdmissionEnum fromValue(String text) {
-    for (ForImportOrAdmissionEnum u : ForImportOrAdmissionEnum.values()) {
-      if (u.value.equalsIgnoreCase(text)) {
-        return u;
-      }
-    }
-    return null;
   }
 
   @JsonValue

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ForNonConformingEnum.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ForNonConformingEnum.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum ForNonConformingEnum {
@@ -13,16 +12,6 @@ public enum ForNonConformingEnum {
 
   ForNonConformingEnum(String value) {
     this.value = value;
-  }
-
-  @JsonCreator
-  public static ForNonConformingEnum fromValue(String text) {
-    for (ForNonConformingEnum u : ForNonConformingEnum.values()) {
-      if (u.value.equalsIgnoreCase(text)) {
-        return u;
-      }
-    }
-    return null;
   }
 
   @JsonValue

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/FreeCirculationPurposeEnum.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/FreeCirculationPurposeEnum.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import uk.gov.defra.tracesx.notificationschema.validation.CED;
 import uk.gov.defra.tracesx.notificationschema.validation.CHEDPP;
@@ -33,16 +32,6 @@ public enum FreeCirculationPurposeEnum implements EntityProperty {
 
   FreeCirculationPurposeEnum(String value) {
     this.value = value;
-  }
-
-  @JsonCreator
-  public static FreeCirculationPurposeEnum fromValue(String text) {
-    for (FreeCirculationPurposeEnum b : FreeCirculationPurposeEnum.values()) {
-      if (b.value.equals(text)) {
-        return b;
-      }
-    }
-    return null;
   }
 
   @JsonValue

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/IUUOption.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/IUUOption.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum IUUOption {
@@ -11,16 +10,6 @@ public enum IUUOption {
 
   IUUOption(String value) {
     this.value = value;
-  }
-
-  @JsonCreator
-  public static IUUOption fromValue(String text) {
-    for (IUUOption u : IUUOption.values()) {
-      if (u.value.equalsIgnoreCase(text)) {
-        return u;
-      }
-    }
-    return null;
   }
 
   @JsonValue

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/IdentificationCheckType.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/IdentificationCheckType.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum IdentificationCheckType {
@@ -11,16 +10,6 @@ public enum IdentificationCheckType {
 
   IdentificationCheckType(String value) {
     this.value = value;
-  }
-
-  @JsonCreator
-  public static IdentificationCheckType fromValue(String text) {
-    for (IdentificationCheckType u : IdentificationCheckType.values()) {
-      if (u.value.equalsIgnoreCase(text)) {
-        return u;
-      }
-    }
-    return null;
   }
 
   @JsonValue

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/IfChanneledOptionEnum.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/IfChanneledOptionEnum.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import uk.gov.defra.tracesx.notificationschema.validation.CHEDPP;
 import uk.gov.defra.tracesx.notificationschema.validation.CVEDP;
@@ -18,16 +17,6 @@ public enum IfChanneledOptionEnum implements EntityProperty {
 
   IfChanneledOptionEnum(String value) {
     this.value = value;
-  }
-
-  @JsonCreator
-  public static IfChanneledOptionEnum fromValue(String text) {
-    for (IfChanneledOptionEnum u : IfChanneledOptionEnum.values()) {
-      if (u.value.equalsIgnoreCase(text)) {
-        return u;
-      }
-    }
-    return null;
   }
 
   @JsonValue

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ImpQuantityDataKeys.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ImpQuantityDataKeys.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum ImpQuantityDataKeys {
@@ -13,16 +12,6 @@ public enum ImpQuantityDataKeys {
 
   ImpQuantityDataKeys(String value) {
     this.value = value;
-  }
-
-  @JsonCreator
-  public static ImpQuantityDataKeys fromValue(String text) {
-    for (ImpQuantityDataKeys u : ImpQuantityDataKeys.values()) {
-      if (u.value.equalsIgnoreCase(text)) {
-        return u;
-      }
-    }
-    return null;
   }
 
   @JsonValue

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/InternalMarketPurpose.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/InternalMarketPurpose.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum InternalMarketPurpose {
@@ -14,16 +13,6 @@ public enum InternalMarketPurpose {
 
   InternalMarketPurpose(String value) {
     this.value = value;
-  }
-
-  @JsonCreator
-  public static InternalMarketPurpose fromValue(String text) {
-    for (InternalMarketPurpose u : InternalMarketPurpose.values()) {
-      if (u.value.equalsIgnoreCase(text)) {
-        return u;
-      }
-    }
-    return null;
   }
 
   @JsonValue

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/NotAcceptableActionEnum.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/NotAcceptableActionEnum.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import uk.gov.defra.tracesx.notificationschema.validation.CED;
 import uk.gov.defra.tracesx.notificationschema.validation.CHEDPP;
@@ -48,16 +47,6 @@ public enum NotAcceptableActionEnum implements EntityProperty {
 
   NotAcceptableActionEnum(String value) {
     this.value = value;
-  }
-
-  @JsonCreator
-  public static NotAcceptableActionEnum fromValue(String text) {
-    for (NotAcceptableActionEnum b : NotAcceptableActionEnum.values()) {
-      if (b.value.equals(text)) {
-        return b;
-      }
-    }
-    return null;
   }
 
   @JsonValue

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/NotAcceptableActionReasonEnum.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/NotAcceptableActionReasonEnum.java
@@ -1,9 +1,6 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
-
-import java.util.Arrays;
 
 public enum NotAcceptableActionReasonEnum {
   CONTAMINATED_PRODUCTS("ContaminatedProducts"),
@@ -16,14 +13,6 @@ public enum NotAcceptableActionReasonEnum {
 
   NotAcceptableActionReasonEnum(String value) {
     this.value = value;
-  }
-
-  @JsonCreator
-  public static NotAcceptableActionReasonEnum fromValue(String text) {
-    return Arrays.stream(NotAcceptableActionReasonEnum.values())
-        .filter(label -> label.value.equals(text))
-        .findFirst()
-        .orElse(null);
   }
 
   @JsonValue

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/NotAcceptableReasonsEnum.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/NotAcceptableReasonsEnum.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum NotAcceptableReasonsEnum {
@@ -30,16 +29,6 @@ public enum NotAcceptableReasonsEnum {
 
   NotAcceptableReasonsEnum(String value) {
     this.value = value;
-  }
-
-  @JsonCreator
-  public static NotAcceptableReasonsEnum fromValue(String text) {
-    for (NotAcceptableReasonsEnum b : NotAcceptableReasonsEnum.values()) {
-      if (b.value.equals(text)) {
-        return b;
-      }
-    }
-    return null;
   }
 
   @JsonValue

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/NotificationTypeEnum.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/NotificationTypeEnum.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum NotificationTypeEnum {
@@ -14,16 +13,6 @@ public enum NotificationTypeEnum {
 
   NotificationTypeEnum(String value) {
     this.value = value;
-  }
-
-  @JsonCreator
-  public static NotificationTypeEnum fromValue(String text) {
-    for (NotificationTypeEnum b : NotificationTypeEnum.values()) {
-      if (b.value.equals(text)) {
-        return b;
-      }
-    }
-    return null;
   }
 
   @JsonValue

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/PackageType.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/PackageType.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum PackageType {
@@ -32,16 +31,6 @@ public enum PackageType {
 
   PackageType(String value) {
     this.value = value;
-  }
-
-  @JsonCreator
-  public static PackageType fromValue(String text) {
-    for (PackageType u : PackageType.values()) {
-      if (u.value.equalsIgnoreCase(text)) {
-        return u;
-      }
-    }
-    return null;
   }
 
   @JsonValue

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/PartyType.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/PartyType.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum PartyType {
@@ -11,16 +10,6 @@ public enum PartyType {
 
   PartyType(String value) {
     this.value = value;
-  }
-
-  @JsonCreator
-  public static PartyType fromValue(String text) {
-    for (PartyType u : PartyType.values()) {
-      if (u.value.equalsIgnoreCase(text)) {
-        return u;
-      }
-    }
-    return null;
   }
 
   @JsonValue

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/PhysicalCheckNotDoneReason.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/PhysicalCheckNotDoneReason.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum PhysicalCheckNotDoneReason {
@@ -11,16 +10,6 @@ public enum PhysicalCheckNotDoneReason {
 
   PhysicalCheckNotDoneReason(String value) {
     this.value = value;
-  }
-
-  @JsonCreator
-  public static PhysicalCheckNotDoneReason fromValue(String text) {
-    for (PhysicalCheckNotDoneReason u : PhysicalCheckNotDoneReason.values()) {
-      if (u.value.equalsIgnoreCase(text)) {
-        return u;
-      }
-    }
-    return null;
   }
 
   @JsonValue

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/PurposeGroupEnum.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/PurposeGroupEnum.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum PurposeGroupEnum {
@@ -17,16 +16,6 @@ public enum PurposeGroupEnum {
 
   PurposeGroupEnum(String value) {
     this.value = value;
-  }
-
-  @JsonCreator
-  public static PurposeGroupEnum fromValue(String text) {
-    for (PurposeGroupEnum u : PurposeGroupEnum.values()) {
-      if (u.value.equalsIgnoreCase(text)) {
-        return u;
-      }
-    }
-    return null;
   }
 
   @JsonValue

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/Result.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/Result.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum Result {
@@ -14,16 +13,6 @@ public enum Result {
 
   Result(String value) {
     this.value = value;
-  }
-
-  @JsonCreator
-  public static Result fromValue(String text) {
-    for (Result u : Result.values()) {
-      if (u.value.equalsIgnoreCase(text)) {
-        return u;
-      }
-    }
-    return null;
   }
 
   @JsonValue

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/SpecificWarehouseNonConformingConsignmentEnum.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/SpecificWarehouseNonConformingConsignmentEnum.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import uk.gov.defra.tracesx.notificationschema.validation.CHEDPP;
 import uk.gov.defra.tracesx.notificationschema.validation.CVEDP;
@@ -24,17 +23,6 @@ public enum SpecificWarehouseNonConformingConsignmentEnum implements EntityPrope
 
   SpecificWarehouseNonConformingConsignmentEnum(String value) {
     this.value = value;
-  }
-
-  @JsonCreator
-  public static SpecificWarehouseNonConformingConsignmentEnum fromValue(String text) {
-    for (SpecificWarehouseNonConformingConsignmentEnum b :
-        SpecificWarehouseNonConformingConsignmentEnum.values()) {
-      if (b.value.equals(text)) {
-        return b;
-      }
-    }
-    return null;
   }
 
   @JsonValue

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/StatusEnum.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/StatusEnum.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum StatusEnum {
@@ -19,16 +18,6 @@ public enum StatusEnum {
 
   StatusEnum(String value) {
     this.value = value;
-  }
-
-  @JsonCreator
-  public static StatusEnum fromValue(String text) {
-    for (StatusEnum b : StatusEnum.values()) {
-      if (b.value.equals(text)) {
-        return b;
-      }
-    }
-    return null;
   }
 
   @JsonValue

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/TestReason.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/TestReason.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum TestReason {
@@ -15,16 +14,6 @@ public enum TestReason {
 
   TestReason(String value) {
     this.value = value;
-  }
-
-  @JsonCreator
-  public static TestReason fromValue(String text) {
-    for (TestReason u : TestReason.values()) {
-      if (u.value.equalsIgnoreCase(text)) {
-        return u;
-      }
-    }
-    return null;
   }
 
   @JsonValue

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/TransportMethod.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/TransportMethod.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum TransportMethod {
@@ -17,16 +16,6 @@ public enum TransportMethod {
 
   TransportMethod(String value) {
     this.value = value;
-  }
-
-  @JsonCreator
-  public static TransportMethod fromValue(String text) {
-    for (TransportMethod u : TransportMethod.values()) {
-      if (u.value.equalsIgnoreCase(text)) {
-        return u;
-      }
-    }
-    return null;
   }
 
   @JsonValue

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/TransportType.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/TransportType.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum TransportType {
@@ -16,16 +15,6 @@ public enum TransportType {
 
   TransportType(String value) {
     this.value = value;
-  }
-
-  @JsonCreator
-  public static TransportType fromValue(String text) {
-    for (TransportType b : TransportType.values()) {
-      if (String.valueOf(b.value).equals(text)) {
-        return b;
-      }
-    }
-    return null;
   }
 
   public String getValue() {

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/AnalysisTypeTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/AnalysisTypeTest.java
@@ -1,13 +1,11 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
 import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
 
 import org.junit.Test;
 
 public class AnalysisTypeTest {
   private final static String INITIAL_ANALYSIS_STRING = "Initial analysis";
-  private final static String INVALID_STRING = "Invalid";
 
   @Test
   public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
@@ -21,19 +19,5 @@ public class AnalysisTypeTest {
     String enumResult = AnalysisType.INITIAL.getValue();
 
     assertEquals(enumResult, INITIAL_ANALYSIS_STRING);
-  }
-
-  @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
-    AnalysisType enumResult = AnalysisType.fromValue(INITIAL_ANALYSIS_STRING);
-
-    assertEquals(enumResult, AnalysisType.INITIAL);
-  }
-
-  @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
-    AnalysisType enumResult = AnalysisType.fromValue(INVALID_STRING);
-
-    assertNull(enumResult);
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/AnimalCertificationTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/AnimalCertificationTest.java
@@ -1,13 +1,11 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
 import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
 
 import org.junit.Test;
 
 public class AnimalCertificationTest {
   private final static String APPROVED_STRING = "Approved";
-  private final static String INVALID_STRING = "Invalid";
 
   @Test
   public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
@@ -21,19 +19,5 @@ public class AnimalCertificationTest {
     String enumResult = AnimalCertification.APPROVED.getValue();
 
     assertEquals(enumResult, APPROVED_STRING);
-  }
-
-  @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
-    AnimalCertification enumResult = AnimalCertification.fromValue(APPROVED_STRING);
-
-    assertEquals(enumResult, AnimalCertification.APPROVED);
-  }
-
-  @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
-    AnimalCertification enumResult = AnimalCertification.fromValue(INVALID_STRING);
-
-    assertNull(enumResult);
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/AnimalsUnitTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/AnimalsUnitTest.java
@@ -1,13 +1,11 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
 import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
 
 import org.junit.Test;
 
 public class AnimalsUnitTest {
   private final static String PERCENT_STRING = "percent";
-  private final static String INVALID_STRING = "Invalid";
 
   @Test
   public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
@@ -21,19 +19,5 @@ public class AnimalsUnitTest {
     String enumResult = AnimalsUnit.PERCENT.getValue();
 
     assertEquals(enumResult, PERCENT_STRING);
-  }
-
-  @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
-    AnimalsUnit enumResult = AnimalsUnit.fromValue(PERCENT_STRING);
-
-    assertEquals(enumResult, AnimalsUnit.PERCENT);
-  }
-
-  @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
-    AnimalsUnit enumResult = AnimalsUnit.fromValue(INVALID_STRING);
-
-    assertNull(enumResult);
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/AuthorityTypeTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/AuthorityTypeTest.java
@@ -1,13 +1,11 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
 import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
 
 import org.junit.Test;
 
 public class AuthorityTypeTest {
   private final static String EXIT_BIP_STRING = "exitbip";
-  private final static String INVALID_STRING = "Invalid";
 
   @Test
   public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
@@ -21,19 +19,5 @@ public class AuthorityTypeTest {
     String enumResult = AuthorityType.EXITBIP.getValue();
 
     assertEquals(enumResult, EXIT_BIP_STRING);
-  }
-
-  @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
-    AuthorityType enumResult = AuthorityType.fromValue(EXIT_BIP_STRING);
-
-    assertEquals(enumResult, AuthorityType.EXITBIP);
-  }
-
-  @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
-    AuthorityType enumResult = AuthorityType.fromValue(INVALID_STRING);
-
-    assertNull(enumResult);
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ChedppNotAcceptableCommodityOrPackageEnumTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ChedppNotAcceptableCommodityOrPackageEnumTest.java
@@ -1,30 +1,11 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
 import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNotNull;
-import static junit.framework.TestCase.assertNull;
 
 import org.junit.Test;
 
 public class ChedppNotAcceptableCommodityOrPackageEnumTest {
   private final static String COMMODITIES_STRING = "c";
-
-  @Test
-  public void chedppNotAcceptableCommodityOrPackageEnumShouldReturnValueWhenValueIsValid() {
-    ChedppNotAcceptableCommodityOrPackageEnum enumResult = ChedppNotAcceptableCommodityOrPackageEnum
-        .fromValue(COMMODITIES_STRING);
-
-    assertEquals(enumResult, ChedppNotAcceptableCommodityOrPackageEnum.COMMODITIES);
-    assertNotNull(enumResult);
-  }
-
-  @Test
-  public void chedppNotAcceptableCommodityOrPackageEnumShouldReturnNullWhenValueIsInvalid() {
-    ChedppNotAcceptableCommodityOrPackageEnum enumResult = ChedppNotAcceptableCommodityOrPackageEnum
-        .fromValue("invalid");
-
-    assertNull(enumResult);
-  }
 
   @Test
   public void chedppNotAcceptableCommodityOrPackageEnumShouldReturnStringValue() {

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ChedppNotAcceptableReasonEnumTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ChedppNotAcceptableReasonEnumTest.java
@@ -1,28 +1,11 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
 import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNotNull;
-import static junit.framework.TestCase.assertNull;
 
 import org.junit.Test;
 
 public class ChedppNotAcceptableReasonEnumTest {
   private final static String DOCPHMDM_STRING = "doc-phmdm";
-
-  @Test
-  public void chedppNotAcceptableReasonEnumShouldReturnValueWhenValueIsValid() {
-    ChedppNotAcceptableReasonEnum enumResult = ChedppNotAcceptableReasonEnum.fromValue(DOCPHMDM_STRING);
-
-    assertEquals(enumResult, ChedppNotAcceptableReasonEnum.DOCPHMDM);
-    assertNotNull(enumResult);
-  }
-
-  @Test
-  public void chedppNotAcceptableReasonEnumShouldReturnNullWhenValueIsInvalid() {
-    ChedppNotAcceptableReasonEnum enumResult = ChedppNotAcceptableReasonEnum.fromValue("invalid");
-
-    assertNull(enumResult);
-  }
 
   @Test
   public void chedppNotAcceptableReasonEnumShouldReturnStringValue() {

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/CommodityIntentionTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/CommodityIntentionTest.java
@@ -1,13 +1,11 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
 import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
 
 import org.junit.Test;
 
 public class CommodityIntentionTest {
   private final static String HUMAN_STRING = "human";
-  private final static String INVALID_STRING = "Invalid";
 
   @Test
   public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
@@ -21,19 +19,5 @@ public class CommodityIntentionTest {
     String enumResult = CommodityIntention.HUMAN.getValue();
 
     assertEquals(enumResult, HUMAN_STRING);
-  }
-
-  @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
-    CommodityIntention enumResult = CommodityIntention.fromValue(HUMAN_STRING);
-
-    assertEquals(enumResult, CommodityIntention.HUMAN);
-  }
-
-  @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
-    CommodityIntention enumResult = CommodityIntention.fromValue(INVALID_STRING);
-
-    assertNull(enumResult);
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/CommodityTemperatureTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/CommodityTemperatureTest.java
@@ -1,13 +1,11 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
 import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
 
 import org.junit.Test;
 
 public class CommodityTemperatureTest {
   private final static String AMBIENT_STRING = "Ambient";
-  private final static String INVALID_STRING = "Invalid";
 
   @Test
   public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
@@ -21,19 +19,5 @@ public class CommodityTemperatureTest {
     String enumResult = CommodityTemperature.AMBIENT.getValue();
 
     assertEquals(enumResult, AMBIENT_STRING);
-  }
-
-  @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
-    CommodityTemperature enumResult = CommodityTemperature.fromValue(AMBIENT_STRING);
-
-    assertEquals(enumResult, CommodityTemperature.AMBIENT);
-  }
-
-  @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
-    CommodityTemperature enumResult = CommodityTemperature.fromValue(INVALID_STRING);
-
-    assertNull(enumResult);
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ConclusionTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ConclusionTest.java
@@ -1,13 +1,11 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
 import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
 
 import org.junit.Test;
 
 public class ConclusionTest {
   private final static String SATISFACTORY_STRING = "Satisfactory";
-  private final static String INVALID_STRING = "Invalid";
 
   @Test
   public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
@@ -21,19 +19,5 @@ public class ConclusionTest {
     String enumResult = Conclusion.SATISFACTORY.getValue();
 
     assertEquals(enumResult, SATISFACTORY_STRING);
-  }
-
-  @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
-    Conclusion enumResult = Conclusion.fromValue(SATISFACTORY_STRING);
-
-    assertEquals(enumResult, Conclusion.SATISFACTORY);
-  }
-
-  @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
-    Conclusion enumResult = Conclusion.fromValue(INVALID_STRING);
-
-    assertNull(enumResult);
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ConservationOfSampleTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ConservationOfSampleTest.java
@@ -1,13 +1,11 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
 import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
 
 import org.junit.Test;
 
 public class ConservationOfSampleTest {
   private final static String CHILLED_STRING = "Chilled";
-  private final static String INVALID_STRING = "Invalid";
 
   @Test
   public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
@@ -21,19 +19,5 @@ public class ConservationOfSampleTest {
     String enumResult = ConservationOfSample.CHILLED.getValue();
 
     assertEquals(enumResult, CHILLED_STRING);
-  }
-
-  @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
-    ConservationOfSample enumResult = ConservationOfSample.fromValue(CHILLED_STRING);
-
-    assertEquals(enumResult, ConservationOfSample.CHILLED);
-  }
-
-  @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
-    ConservationOfSample enumResult = ConservationOfSample.fromValue(INVALID_STRING);
-
-    assertNull(enumResult);
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ConsignmentLeaveTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ConsignmentLeaveTest.java
@@ -1,13 +1,11 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
 import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
 
 import org.junit.Test;
 
 public class ConsignmentLeaveTest {
   private final static String YES_STRING = "YES";
-  private final static String INVALID_STRING = "Invalid";
 
   @Test
   public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
@@ -21,19 +19,5 @@ public class ConsignmentLeaveTest {
     String enumResult = ConsignmentLeave.YES.getValue();
 
     assertEquals(enumResult, YES_STRING);
-  }
-
-  @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
-    ConsignmentLeave enumResult = ConsignmentLeave.fromValue(YES_STRING);
-
-    assertEquals(enumResult, ConsignmentLeave.YES);
-  }
-
-  @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
-    ConsignmentLeave enumResult = ConsignmentLeave.fromValue(INVALID_STRING);
-
-    assertNull(enumResult);
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ControlStatusTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ControlStatusTest.java
@@ -1,13 +1,11 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
 import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
 
 import org.junit.Test;
 
 public class ControlStatusTest {
   private final static String COMPLETED_STRING = "COMPLETED";
-  private final static String INVALID_STRING = "Invalid";
 
   @Test
   public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
@@ -21,19 +19,5 @@ public class ControlStatusTest {
     String enumResult = ControlStatus.COMPLETED.getValue();
 
     assertEquals(enumResult, COMPLETED_STRING);
-  }
-
-  @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
-    ControlStatus enumResult = ControlStatus.fromValue(COMPLETED_STRING);
-
-    assertEquals(enumResult, ControlStatus.COMPLETED);
-  }
-
-  @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
-    ControlStatus enumResult = ControlStatus.fromValue(INVALID_STRING);
-
-    assertNull(enumResult);
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/DecisionEnumTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/DecisionEnumTest.java
@@ -1,14 +1,11 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
 import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
 
 import org.junit.Test;
-import uk.gov.defra.tracesx.notificationschema.representation.Decision;
 
 public class DecisionEnumTest {
   private final static String NON_ACCEPTABLE_STRING = "Non Acceptable";
-  private final static String INVALID_STRING = "Invalid";
 
   @Test
   public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
@@ -22,19 +19,5 @@ public class DecisionEnumTest {
     String enumResult = DecisionEnum.NON_ACCEPTABLE.getValue();
 
     assertEquals(enumResult, NON_ACCEPTABLE_STRING);
-  }
-
-  @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
-    DecisionEnum enumResult = DecisionEnum.fromValue(NON_ACCEPTABLE_STRING);
-
-    assertEquals(enumResult, DecisionEnum.NON_ACCEPTABLE);
-  }
-
-  @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
-    DecisionEnum enumResult = DecisionEnum.fromValue(INVALID_STRING);
-
-    assertNull(enumResult);
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/DefinitiveImportPurposeEnumTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/DefinitiveImportPurposeEnumTest.java
@@ -1,13 +1,11 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
 import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
 
 import org.junit.Test;
 
 public class DefinitiveImportPurposeEnumTest {
   private final static String SLAUGHTER_STRING = "slaughter";
-  private final static String INVALID_STRING = "Invalid";
 
   @Test
   public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
@@ -21,19 +19,5 @@ public class DefinitiveImportPurposeEnumTest {
     String enumResult = DefinitiveImportPurposeEnum.SLAUGHTER.getValue();
 
     assertEquals(enumResult, SLAUGHTER_STRING);
-  }
-
-  @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
-    DefinitiveImportPurposeEnum enumResult = DefinitiveImportPurposeEnum.fromValue(SLAUGHTER_STRING);
-
-    assertEquals(enumResult, DefinitiveImportPurposeEnum.SLAUGHTER);
-  }
-
-  @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
-    DefinitiveImportPurposeEnum enumResult = DefinitiveImportPurposeEnum.fromValue(INVALID_STRING);
-
-    assertNull(enumResult);
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/DocumentTypeTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/DocumentTypeTest.java
@@ -1,13 +1,11 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
 import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
 
 import org.junit.Test;
 
 public class DocumentTypeTest {
   private final static String AIR_WAYBILL_STRING = "airWaybill";
-  private final static String INVALID_STRING = "Invalid";
 
   @Test
   public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
@@ -21,19 +19,5 @@ public class DocumentTypeTest {
     String enumResult = DocumentType.AIR_WAYBILL.getValue();
 
     assertEquals(enumResult, AIR_WAYBILL_STRING);
-  }
-
-  @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
-    DocumentType enumResult = DocumentType.fromValue(AIR_WAYBILL_STRING);
-
-    assertEquals(enumResult, DocumentType.AIR_WAYBILL);
-  }
-
-  @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
-    DocumentType enumResult = DocumentType.fromValue(INVALID_STRING);
-
-    assertNull(enumResult);
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/EconomicOperatorStatusTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/EconomicOperatorStatusTest.java
@@ -1,13 +1,11 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
 import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
 
 import org.junit.Test;
 
 public class EconomicOperatorStatusTest {
   private final static String SUSPENDED_STRING = "suspended";
-  private final static String INVALID_STRING = "Invalid";
 
   @Test
   public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
@@ -21,19 +19,5 @@ public class EconomicOperatorStatusTest {
     String enumResult = EconomicOperatorStatus.SUSPENDED.getValue();
 
     assertEquals(enumResult, SUSPENDED_STRING);
-  }
-
-  @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
-    EconomicOperatorStatus enumResult = EconomicOperatorStatus.fromValue(SUSPENDED_STRING);
-
-    assertEquals(enumResult, EconomicOperatorStatus.SUSPENDED);
-  }
-
-  @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
-    EconomicOperatorStatus enumResult = EconomicOperatorStatus.fromValue(INVALID_STRING);
-
-    assertNull(enumResult);
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/EconomicOperatorTypeTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/EconomicOperatorTypeTest.java
@@ -1,13 +1,11 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
 import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
 
 import org.junit.Test;
 
 public class EconomicOperatorTypeTest {
   private final static String CHARITY_STRING = "charity";
-  private final static String INVALID_STRING = "Invalid";
 
   @Test
   public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
@@ -21,19 +19,5 @@ public class EconomicOperatorTypeTest {
     String enumResult = EconomicOperatorType.CHARITY.getValue();
 
     assertEquals(enumResult, CHARITY_STRING);
-  }
-
-  @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
-    EconomicOperatorType enumResult = EconomicOperatorType.fromValue(CHARITY_STRING);
-
-    assertEquals(enumResult, EconomicOperatorType.CHARITY);
-  }
-
-  @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
-    EconomicOperatorType enumResult = EconomicOperatorType.fromValue(INVALID_STRING);
-
-    assertNull(enumResult);
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ExternalSystemTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ExternalSystemTest.java
@@ -1,13 +1,11 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
 import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
 
 import org.junit.Test;
 
 public class ExternalSystemTest {
   private final static String TRACESNT_STRING = "TRACESNT";
-  private final static String INVALID_STRING = "Invalid";
 
   @Test
   public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
@@ -21,19 +19,5 @@ public class ExternalSystemTest {
     String enumResult = ExternalSystem.TRACESNT.getValue();
 
     assertEquals(enumResult, TRACESNT_STRING);
-  }
-
-  @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
-    ExternalSystem enumResult = ExternalSystem.fromValue(TRACESNT_STRING);
-
-    assertEquals(enumResult, ExternalSystem.TRACESNT);
-  }
-
-  @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
-    ExternalSystem enumResult = ExternalSystem.fromValue(INVALID_STRING);
-
-    assertNull(enumResult);
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ForImportOrAdmissionEnumTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ForImportOrAdmissionEnumTest.java
@@ -1,13 +1,11 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
 import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
 
 import org.junit.Test;
 
 public class ForImportOrAdmissionEnumTest {
   private final static String DEFINITIVE_IMPORT_STRING = "Definitive import";
-  private final static String INVALID_STRING = "Invalid";
 
   @Test
   public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
@@ -21,19 +19,5 @@ public class ForImportOrAdmissionEnumTest {
     String enumResult = ForImportOrAdmissionEnum.DEFINITIVE_IMPORT.getValue();
 
     assertEquals(enumResult, DEFINITIVE_IMPORT_STRING);
-  }
-
-  @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
-    ForImportOrAdmissionEnum enumResult = ForImportOrAdmissionEnum.fromValue(DEFINITIVE_IMPORT_STRING);
-
-    assertEquals(enumResult, ForImportOrAdmissionEnum.DEFINITIVE_IMPORT);
-  }
-
-  @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
-    ForImportOrAdmissionEnum enumResult = ForImportOrAdmissionEnum.fromValue(INVALID_STRING);
-
-    assertNull(enumResult);
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ForNonConformingEnumTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ForNonConformingEnumTest.java
@@ -1,13 +1,11 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
 import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
 
 import org.junit.Test;
 
 public class ForNonConformingEnumTest {
   private final static String CUSTOMS_WAREHOUSE_STRING = "Customs Warehouse";
-  private final static String INVALID_STRING = "Invalid";
 
   @Test
   public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
@@ -21,19 +19,5 @@ public class ForNonConformingEnumTest {
     String enumResult = ForNonConformingEnum.CUSTOMS_WAREHOUSE.getValue();
 
     assertEquals(enumResult, CUSTOMS_WAREHOUSE_STRING);
-  }
-
-  @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
-    ForNonConformingEnum enumResult = ForNonConformingEnum.fromValue(CUSTOMS_WAREHOUSE_STRING);
-
-    assertEquals(enumResult, ForNonConformingEnum.CUSTOMS_WAREHOUSE);
-  }
-
-  @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
-    ForNonConformingEnum enumResult = ForNonConformingEnum.fromValue(INVALID_STRING);
-
-    assertNull(enumResult);
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/FreeCirculationPurposeEnumTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/FreeCirculationPurposeEnumTest.java
@@ -1,13 +1,11 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
 import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
 
 import org.junit.Test;
 
 public class FreeCirculationPurposeEnumTest {
   private final static String FURTHER_PROCESS_STRING = "Further Process";
-  private final static String INVALID_STRING = "Invalid";
 
   @Test
   public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
@@ -21,19 +19,5 @@ public class FreeCirculationPurposeEnumTest {
     String enumResult = FreeCirculationPurposeEnum.FURTHER_PROCESS.getValue();
 
     assertEquals(enumResult, FURTHER_PROCESS_STRING);
-  }
-
-  @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
-    FreeCirculationPurposeEnum enumResult = FreeCirculationPurposeEnum.fromValue(FURTHER_PROCESS_STRING);
-
-    assertEquals(enumResult, FreeCirculationPurposeEnum.FURTHER_PROCESS);
-  }
-
-  @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
-    FreeCirculationPurposeEnum enumResult = FreeCirculationPurposeEnum.fromValue(INVALID_STRING);
-
-    assertNull(enumResult);
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/IUUOptionTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/IUUOptionTest.java
@@ -1,13 +1,11 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
 import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
 
 import org.junit.Test;
 
 public class IUUOptionTest {
   private final static String IUUNA_STRING = "IUUNA";
-  private final static String INVALID_STRING = "Invalid";
 
   @Test
   public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
@@ -21,19 +19,5 @@ public class IUUOptionTest {
     String enumResult = IUUOption.IUUNA.getValue();
 
     assertEquals(enumResult, IUUNA_STRING);
-  }
-
-  @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
-    IUUOption enumResult = IUUOption.fromValue(IUUNA_STRING);
-
-    assertEquals(enumResult, IUUOption.IUUNA);
-  }
-
-  @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
-    IUUOption enumResult = IUUOption.fromValue(INVALID_STRING);
-
-    assertNull(enumResult);
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/IdentificationCheckTypeTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/IdentificationCheckTypeTest.java
@@ -1,13 +1,11 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
 import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
 
 import org.junit.Test;
 
 public class IdentificationCheckTypeTest {
   private final static String SEAL_CHECK_STRING = "Seal Check";
-  private final static String INVALID_STRING = "Invalid";
 
   @Test
   public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
@@ -21,19 +19,5 @@ public class IdentificationCheckTypeTest {
     String enumResult = IdentificationCheckType.SEAL_CHECK.getValue();
 
     assertEquals(enumResult, SEAL_CHECK_STRING);
-  }
-
-  @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
-    IdentificationCheckType enumResult = IdentificationCheckType.fromValue(SEAL_CHECK_STRING);
-
-    assertEquals(enumResult, IdentificationCheckType.SEAL_CHECK);
-  }
-
-  @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
-    IdentificationCheckType enumResult = IdentificationCheckType.fromValue(INVALID_STRING);
-
-    assertNull(enumResult);
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/IfChanneledOptionEnumTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/IfChanneledOptionEnumTest.java
@@ -1,13 +1,11 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
 import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
 
 import org.junit.Test;
 
 public class IfChanneledOptionEnumTest {
   private final static String ARTICLE_8_STRING = "article8";
-  private final static String INVALID_STRING = "Invalid";
 
   @Test
   public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
@@ -21,19 +19,5 @@ public class IfChanneledOptionEnumTest {
     String enumResult = IfChanneledOptionEnum.ARTICLE8.getValue();
 
     assertEquals(enumResult, ARTICLE_8_STRING);
-  }
-
-  @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
-    IfChanneledOptionEnum enumResult = IfChanneledOptionEnum.fromValue(ARTICLE_8_STRING);
-
-    assertEquals(enumResult, IfChanneledOptionEnum.ARTICLE8);
-  }
-
-  @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
-    IfChanneledOptionEnum enumResult = IfChanneledOptionEnum.fromValue(INVALID_STRING);
-
-    assertNull(enumResult);
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ImpQuantityDataKeysTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ImpQuantityDataKeysTest.java
@@ -1,13 +1,11 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
 import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
 
 import org.junit.Test;
 
 public class ImpQuantityDataKeysTest {
   private final static String QUANTITY_STRING = "quantity";
-  private final static String INVALID_STRING = "Invalid";
 
   @Test
   public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
@@ -21,19 +19,5 @@ public class ImpQuantityDataKeysTest {
     String enumResult = ImpQuantityDataKeys.QUANTITY.getValue();
 
     assertEquals(enumResult, QUANTITY_STRING);
-  }
-
-  @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
-    ImpQuantityDataKeys enumResult = ImpQuantityDataKeys.fromValue(QUANTITY_STRING);
-
-    assertEquals(enumResult, ImpQuantityDataKeys.QUANTITY);
-  }
-
-  @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
-    ImpQuantityDataKeys enumResult = ImpQuantityDataKeys.fromValue(INVALID_STRING);
-
-    assertNull(enumResult);
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/InternalMarketPurposeTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/InternalMarketPurposeTest.java
@@ -1,13 +1,11 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
 import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
 
 import org.junit.Test;
 
 public class InternalMarketPurposeTest {
   private final static String OTHER_STRING = "Other";
-  private final static String INVALID_STRING = "Invalid";
 
   @Test
   public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
@@ -21,19 +19,5 @@ public class InternalMarketPurposeTest {
     String enumResult = InternalMarketPurpose.OTHER.getValue();
 
     assertEquals(enumResult, OTHER_STRING);
-  }
-
-  @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
-    InternalMarketPurpose enumResult = InternalMarketPurpose.fromValue(OTHER_STRING);
-
-    assertEquals(enumResult, InternalMarketPurpose.OTHER);
-  }
-
-  @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
-    InternalMarketPurpose enumResult = InternalMarketPurpose.fromValue(INVALID_STRING);
-
-    assertNull(enumResult);
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/NotAcceptableActionEnumTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/NotAcceptableActionEnumTest.java
@@ -1,13 +1,11 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
 import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
 
 import org.junit.Test;
 
 public class NotAcceptableActionEnumTest {
   private final static String DESTRUCTION_STRING = "destruction";
-  private final static String INVALID_STRING = "Invalid";
 
   @Test
   public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
@@ -21,19 +19,5 @@ public class NotAcceptableActionEnumTest {
     String enumResult = NotAcceptableActionEnum.DESTRUCTION.getValue();
 
     assertEquals(enumResult, DESTRUCTION_STRING);
-  }
-
-  @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
-    NotAcceptableActionEnum enumResult = NotAcceptableActionEnum.fromValue(DESTRUCTION_STRING);
-
-    assertEquals(enumResult, NotAcceptableActionEnum.DESTRUCTION);
-  }
-
-  @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
-    NotAcceptableActionEnum enumResult = NotAcceptableActionEnum.fromValue(INVALID_STRING);
-
-    assertNull(enumResult);
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/NotAcceptableActionReasonEnumTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/NotAcceptableActionReasonEnumTest.java
@@ -1,13 +1,11 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
 import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
 
 import org.junit.Test;
 
 public class NotAcceptableActionReasonEnumTest {
   private final static String OTHER_STRING = "Other";
-  private final static String INVALID_STRING = "Invalid";
 
   @Test
   public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
@@ -21,19 +19,5 @@ public class NotAcceptableActionReasonEnumTest {
     String enumResult = NotAcceptableActionReasonEnum.OTHER.getValue();
 
     assertEquals(enumResult, OTHER_STRING);
-  }
-
-  @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
-    NotAcceptableActionReasonEnum enumResult = NotAcceptableActionReasonEnum.fromValue(OTHER_STRING);
-
-    assertEquals(enumResult, NotAcceptableActionReasonEnum.OTHER);
-  }
-
-  @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
-    NotAcceptableActionReasonEnum enumResult = NotAcceptableActionReasonEnum.fromValue(INVALID_STRING);
-
-    assertNull(enumResult);
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/NotAcceptableReasonsEnumTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/NotAcceptableReasonsEnumTest.java
@@ -1,13 +1,11 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
 import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
 
 import org.junit.Test;
 
 public class NotAcceptableReasonsEnumTest {
   private final static String ID_HEALTH_MARK_ERROR = "IdHealthMarkError";
-  private final static String INVALID_STRING = "Invalid";
 
   @Test
   public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
@@ -21,19 +19,5 @@ public class NotAcceptableReasonsEnumTest {
     String enumResult = NotAcceptableReasonsEnum.IDHEALTHMARKERROR.getValue();
 
     assertEquals(enumResult, ID_HEALTH_MARK_ERROR);
-  }
-
-  @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
-    NotAcceptableReasonsEnum enumResult = NotAcceptableReasonsEnum.fromValue(ID_HEALTH_MARK_ERROR);
-
-    assertEquals(enumResult, NotAcceptableReasonsEnum.IDHEALTHMARKERROR);
-  }
-
-  @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
-    NotAcceptableReasonsEnum enumResult = NotAcceptableReasonsEnum.fromValue(INVALID_STRING);
-
-    assertNull(enumResult);
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/NotificationTypeEnumTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/NotificationTypeEnumTest.java
@@ -1,13 +1,11 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
 import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
 
 import org.junit.Test;
 
 public class NotificationTypeEnumTest {
   private final static String CED_STRING = "CED";
-  private final static String INVALID_STRING = "Invalid";
 
   @Test
   public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
@@ -21,19 +19,5 @@ public class NotificationTypeEnumTest {
     String enumResult = NotificationTypeEnum.CED.getValue();
 
     assertEquals(enumResult, CED_STRING);
-  }
-
-  @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
-    NotificationTypeEnum enumResult = NotificationTypeEnum.fromValue(CED_STRING);
-
-    assertEquals(enumResult, NotificationTypeEnum.CED);
-  }
-
-  @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
-    NotificationTypeEnum enumResult = NotificationTypeEnum.fromValue(INVALID_STRING);
-
-    assertNull(enumResult);
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/PackageTypeTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/PackageTypeTest.java
@@ -1,13 +1,11 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
 import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
 
 import org.junit.Test;
 
 public class PackageTypeTest {
   private final static String BAG_STRING = "Bag";
-  private final static String INVALID_STRING = "Invalid";
 
   @Test
   public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
@@ -21,19 +19,5 @@ public class PackageTypeTest {
     String enumResult = PackageType.BAG.getValue();
 
     assertEquals(enumResult, BAG_STRING);
-  }
-
-  @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
-    PackageType enumResult = PackageType.fromValue(BAG_STRING);
-
-    assertEquals(enumResult, PackageType.BAG);
-  }
-
-  @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
-    PackageType enumResult = PackageType.fromValue(INVALID_STRING);
-
-    assertNull(enumResult);
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/PartyTypeTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/PartyTypeTest.java
@@ -1,13 +1,11 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
 import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
 
 import org.junit.Test;
 
 public class PartyTypeTest {
   private final static String COMMERCIAL_TRANSPORTER_STRING = "Commercial transporter";
-  private final static String INVALID_STRING = "Invalid";
 
   @Test
   public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
@@ -21,19 +19,5 @@ public class PartyTypeTest {
     String enumResult = PartyType.COMMERCIAL_TRANSPORTER.getValue();
 
     assertEquals(enumResult, COMMERCIAL_TRANSPORTER_STRING);
-  }
-
-  @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
-    PartyType enumResult = PartyType.fromValue(COMMERCIAL_TRANSPORTER_STRING);
-
-    assertEquals(enumResult, PartyType.COMMERCIAL_TRANSPORTER);
-  }
-
-  @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
-    PartyType enumResult = PartyType.fromValue(INVALID_STRING);
-
-    assertNull(enumResult);
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/PhysicalCheckNotDoneReasonTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/PhysicalCheckNotDoneReasonTest.java
@@ -1,13 +1,11 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
 import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
 
 import org.junit.Test;
 
 public class PhysicalCheckNotDoneReasonTest {
   private final static String OTHER_STRING = "Other";
-  private final static String INVALID_STRING = "Invalid";
 
   @Test
   public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
@@ -21,19 +19,5 @@ public class PhysicalCheckNotDoneReasonTest {
     String enumResult = PhysicalCheckNotDoneReason.OTHER.getValue();
 
     assertEquals(enumResult, OTHER_STRING);
-  }
-
-  @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
-    PhysicalCheckNotDoneReason enumResult = PhysicalCheckNotDoneReason.fromValue(OTHER_STRING);
-
-    assertEquals(enumResult, PhysicalCheckNotDoneReason.OTHER);
-  }
-
-  @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
-    PhysicalCheckNotDoneReason enumResult = PhysicalCheckNotDoneReason.fromValue(INVALID_STRING);
-
-    assertNull(enumResult);
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/PurposeGroupEnumTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/PurposeGroupEnumTest.java
@@ -1,13 +1,11 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
 import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
 
 import org.junit.Test;
 
 public class PurposeGroupEnumTest {
   private final static String FOR_IMPORT_STRING = "For Import";
-  private final static String INVALID_STRING = "Invalid";
 
   @Test
   public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
@@ -21,19 +19,5 @@ public class PurposeGroupEnumTest {
     String enumResult = PurposeGroupEnum.IMPORT.getValue();
 
     assertEquals(enumResult, FOR_IMPORT_STRING);
-  }
-
-  @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
-    PurposeGroupEnum enumResult = PurposeGroupEnum.fromValue(FOR_IMPORT_STRING);
-
-    assertEquals(enumResult, PurposeGroupEnum.IMPORT);
-  }
-
-  @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
-    PurposeGroupEnum enumResult = PurposeGroupEnum.fromValue(INVALID_STRING);
-
-    assertNull(enumResult);
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ResultTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ResultTest.java
@@ -1,13 +1,11 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
 import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
 
 import org.junit.Test;
 
 public class ResultTest {
   private final static String DEROGATION_STRING = "Derogation";
-  private final static String INVALID_STRING = "Invalid";
 
   @Test
   public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
@@ -21,19 +19,5 @@ public class ResultTest {
     String enumResult = Result.DEROGATION.getValue();
 
     assertEquals(enumResult, DEROGATION_STRING);
-  }
-
-  @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
-    Result enumResult = Result.fromValue(DEROGATION_STRING);
-
-    assertEquals(enumResult, Result.DEROGATION);
-  }
-
-  @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
-    Result enumResult = Result.fromValue(INVALID_STRING);
-
-    assertNull(enumResult);
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/SpecificWarehouseNonConformingConsignmentEnumTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/SpecificWarehouseNonConformingConsignmentEnumTest.java
@@ -1,13 +1,11 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
 import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
 
 import org.junit.Test;
 
 public class SpecificWarehouseNonConformingConsignmentEnumTest {
   private final static String SHIP_STRING = "Ship";
-  private final static String INVALID_STRING = "Invalid";
 
   @Test
   public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
@@ -21,19 +19,5 @@ public class SpecificWarehouseNonConformingConsignmentEnumTest {
     String enumResult = SpecificWarehouseNonConformingConsignmentEnum.SHIP.getValue();
 
     assertEquals(enumResult, SHIP_STRING);
-  }
-
-  @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
-    SpecificWarehouseNonConformingConsignmentEnum enumResult = SpecificWarehouseNonConformingConsignmentEnum.fromValue(SHIP_STRING);
-
-    assertEquals(enumResult, SpecificWarehouseNonConformingConsignmentEnum.SHIP);
-  }
-
-  @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
-    SpecificWarehouseNonConformingConsignmentEnum enumResult = SpecificWarehouseNonConformingConsignmentEnum.fromValue(INVALID_STRING);
-
-    assertNull(enumResult);
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/StatusEnumTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/StatusEnumTest.java
@@ -1,13 +1,11 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
 import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
 
 import org.junit.Test;
 
 public class StatusEnumTest {
   private final static String AMEND_STRING = "AMEND";
-  private final static String INVALID_STRING = "Invalid";
 
   @Test
   public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
@@ -21,19 +19,5 @@ public class StatusEnumTest {
     String enumResult = StatusEnum.AMEND.getValue();
 
     assertEquals(enumResult, AMEND_STRING);
-  }
-
-  @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
-    StatusEnum enumResult = StatusEnum.fromValue(AMEND_STRING);
-
-    assertEquals(enumResult, StatusEnum.AMEND);
-  }
-
-  @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
-    StatusEnum enumResult = StatusEnum.fromValue(INVALID_STRING);
-
-    assertNull(enumResult);
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/TestReasonTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/TestReasonTest.java
@@ -1,13 +1,11 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
 import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
 
 import org.junit.Test;
 
 public class TestReasonTest {
   private final static String RANDOM_STRING = "Random";
-  private final static String INVALID_STRING = "Invalid";
 
   @Test
   public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
@@ -21,19 +19,5 @@ public class TestReasonTest {
     String enumResult = TestReason.RANDOM.getValue();
 
     assertEquals(enumResult, RANDOM_STRING);
-  }
-
-  @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
-    TestReason enumResult = TestReason.fromValue(RANDOM_STRING);
-
-    assertEquals(enumResult, TestReason.RANDOM);
-  }
-
-  @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
-    TestReason enumResult = TestReason.fromValue(INVALID_STRING);
-
-    assertNull(enumResult);
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/TransportMethodTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/TransportMethodTest.java
@@ -1,13 +1,11 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
 import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
 
 import org.junit.Test;
 
 public class TransportMethodTest {
   private final static String OTHER_STRING = "Other";
-  private final static String INVALID_STRING = "Invalid";
 
   @Test
   public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
@@ -21,19 +19,5 @@ public class TransportMethodTest {
     String enumResult = TransportMethod.OTHER.getValue();
 
     assertEquals(enumResult, OTHER_STRING);
-  }
-
-  @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
-    TransportMethod enumResult = TransportMethod.fromValue(OTHER_STRING);
-
-    assertEquals(enumResult, TransportMethod.OTHER);
-  }
-
-  @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
-    TransportMethod enumResult = TransportMethod.fromValue(INVALID_STRING);
-
-    assertNull(enumResult);
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/TransportTypeTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/TransportTypeTest.java
@@ -1,13 +1,11 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
 import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
 
 import org.junit.Test;
 
 public class TransportTypeTest {
   private final static String OTHER_STRING = "other";
-  private final static String INVALID_STRING = "Invalid";
 
   @Test
   public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
@@ -21,19 +19,5 @@ public class TransportTypeTest {
     String enumResult = TransportType.OTHER.getValue();
 
     assertEquals(enumResult, OTHER_STRING);
-  }
-
-  @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
-    TransportType enumResult = TransportType.fromValue(OTHER_STRING);
-
-    assertEquals(enumResult, TransportType.OTHER);
-  }
-
-  @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
-    TransportType enumResult = TransportType.fromValue(INVALID_STRING);
-
-    assertNull(enumResult);
   }
 }


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | lee mason (KAINOS) |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [IMTA-3130: Removed the return null if in...](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/131) |
> | **GitLab MR Number** | [131](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/131) |
> | **Date Originally Opened** | Fri, 2 Oct 2020 |
> | **Approved on GitLab by** | Blakeley, Paul (Kainos), Nicholas Martin, Popa, Paul (Kainos), bridget.hodgson (Kainos) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

IMTA-3130: Removed the return null if incorrect enum value function. Now will throw an illegal argument exception