### PR TITLE
IMTA-8948: Allow identity/physical checks to be null for CHEDP

### DIFF
--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/ConsignmentCheck.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/ConsignmentCheck.java
@@ -88,19 +88,11 @@ public class ConsignmentCheck {
               + ".identitycheck.not.null}")
   private Boolean identityCheckDone;
 
-  @NotNull(
-      groups = {
-          NotificationCvedpFieldValidation.class
-      },
-      message =
-          "{uk.gov.defra.tracesx.notificationschema.representation.parttwo.consignmentcheck"
-              + ".identitychecktype.not.null}")
   private IdentificationCheckType identityCheckType;
 
   @NotNull(
       groups = {
-          NotificationCvedaFieldValidation.class,
-          NotificationCvedpFieldValidation.class
+          NotificationCvedaFieldValidation.class
       },
       message =
           "{uk.gov.defra.tracesx.notificationschema.representation.parttwo.consignmentcheck"
@@ -116,8 +108,7 @@ public class ConsignmentCheck {
 
   @NotNull(
       groups = {
-          NotificationCvedaFieldValidation.class,
-          NotificationCvedpFieldValidation.class
+          NotificationCvedaFieldValidation.class
       },
       message =
           "{uk.gov.defra.tracesx.notificationschema.representation.parttwo.consignmentcheck"

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/PartTwo.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/PartTwo.java
@@ -13,11 +13,14 @@ import uk.gov.defra.tracesx.notificationschema.representation.serialisation.IsoO
 import uk.gov.defra.tracesx.notificationschema.representation.serialisation.IsoOffsetDateTimeSerializer;
 import uk.gov.defra.tracesx.notificationschema.validation.ValidationMessageCode;
 import uk.gov.defra.tracesx.notificationschema.validation.annotations.CedOrCvedpControlledDestination;
+import uk.gov.defra.tracesx.notificationschema.validation.annotations.ChedpIdentityCheck;
+import uk.gov.defra.tracesx.notificationschema.validation.annotations.ChedpPhysicalCheck;
 import uk.gov.defra.tracesx.notificationschema.validation.annotations.CvedaControlledDestination;
 import uk.gov.defra.tracesx.notificationschema.validation.annotations.LaboratoryTestsNotAdded;
 import uk.gov.defra.tracesx.notificationschema.validation.annotations.LaboratoryTestsPending;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCedOrCvedpFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCvedaFieldValidation;
+import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCvedpFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationHighRiskNonChedppFieldValidation;
 
 import java.time.LocalDateTime;
@@ -51,6 +54,8 @@ import javax.validation.constraints.NotNull;
     message =
         "{uk.gov.defra.tracesx.notificationschema.representation.parttwo.controlleddestination"
             + ".not.empty}")
+@ChedpIdentityCheck(groups = NotificationCvedpFieldValidation.class)
+@ChedpPhysicalCheck(groups = NotificationCvedpFieldValidation.class)
 public class PartTwo {
 
   @Valid

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedpIdentityCheck.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedpIdentityCheck.java
@@ -1,0 +1,25 @@
+package uk.gov.defra.tracesx.notificationschema.validation.annotations;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+@Target({TYPE, ANNOTATION_TYPE})
+@Retention(RUNTIME)
+@Constraint(validatedBy = ChedpIdentityCheckValidator.class)
+@Documented
+public @interface ChedpIdentityCheck {
+
+  String message() default "{uk.gov.defra.tracesx.notificationschema.representation.parttwo"
+      + ".consignmentcheck.identitycheck.not.null}";
+
+  Class<?>[] groups() default {};
+
+  Class<? extends Payload>[] payload() default {};
+}

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedpIdentityCheckValidator.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedpIdentityCheckValidator.java
@@ -1,0 +1,34 @@
+package uk.gov.defra.tracesx.notificationschema.validation.annotations;
+
+import static java.lang.Boolean.TRUE;
+
+import uk.gov.defra.tracesx.notificationschema.representation.PartTwo;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class ChedpIdentityCheckValidator
+    implements ConstraintValidator<ChedpIdentityCheck, PartTwo> {
+
+  @Override
+  public void initialize(ChedpIdentityCheck constraintAnnotation) {
+    // no action
+  }
+
+  @Override
+  public boolean isValid(PartTwo partTwo, ConstraintValidatorContext context) {
+    if (partTwo == null) {
+      return true;
+    }
+
+    if (partTwo.getDecision() == null
+        || partTwo.getDecision().getConsignmentAcceptable() == null
+        || TRUE.equals(partTwo.getDecision().getConsignmentAcceptable())) {
+      return partTwo.getConsignmentCheck() != null
+          && partTwo.getConsignmentCheck().getIdentityCheckType() != null
+          && partTwo.getConsignmentCheck().getIdentityCheckResult() != null;
+    } else {
+      return true;
+    }
+  }
+}

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedpPhysicalCheck.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedpPhysicalCheck.java
@@ -1,0 +1,25 @@
+package uk.gov.defra.tracesx.notificationschema.validation.annotations;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+@Target({TYPE, ANNOTATION_TYPE})
+@Retention(RUNTIME)
+@Constraint(validatedBy = ChedpPhysicalCheckValidator.class)
+@Documented
+public @interface ChedpPhysicalCheck {
+
+  String message() default "{uk.gov.defra.tracesx.notificationschema.representation.parttwo"
+      + ".consignmentcheck.physicalcheck.not.null}";
+
+  Class<?>[] groups() default {};
+
+  Class<? extends Payload>[] payload() default {};
+}

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedpPhysicalCheckValidator.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedpPhysicalCheckValidator.java
@@ -1,0 +1,33 @@
+package uk.gov.defra.tracesx.notificationschema.validation.annotations;
+
+import static java.lang.Boolean.TRUE;
+
+import uk.gov.defra.tracesx.notificationschema.representation.PartTwo;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class ChedpPhysicalCheckValidator
+    implements ConstraintValidator<ChedpPhysicalCheck, PartTwo> {
+
+  @Override
+  public void initialize(ChedpPhysicalCheck constraintAnnotation) {
+    // no action
+  }
+
+  @Override
+  public boolean isValid(PartTwo partTwo, ConstraintValidatorContext context) {
+    if (partTwo == null) {
+      return true;
+    }
+
+    if (partTwo.getDecision() == null
+        || partTwo.getDecision().getConsignmentAcceptable() == null
+        || TRUE.equals(partTwo.getDecision().getConsignmentAcceptable())) {
+      return partTwo.getConsignmentCheck() != null
+          && partTwo.getConsignmentCheck().getPhysicalCheckResult() != null;
+    } else {
+      return true;
+    }
+  }
+}

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedpIdentityCheckTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedpIdentityCheckTest.java
@@ -1,0 +1,143 @@
+package uk.gov.defra.tracesx.notificationschema.validation.annotations;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.IdentificationCheckType.FULL_IDENTITY_CHECK;
+import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.Result.NOT_SATISFACTORY;
+
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.defra.tracesx.notificationschema.representation.ConsignmentCheck;
+import uk.gov.defra.tracesx.notificationschema.representation.Decision;
+import uk.gov.defra.tracesx.notificationschema.representation.PartTwo;
+
+public class ChedpIdentityCheckTest {
+
+  private ChedpIdentityCheckValidator validator;
+  private PartTwo partTwo;
+
+  @Before
+  public void setUp() {
+    validator = new ChedpIdentityCheckValidator();
+    partTwo = new PartTwo();
+  }
+
+  @Test
+  public void isValid_returnsTrue_whenNullPassed() {
+    assertTrue(validator.isValid(null, null));
+  }
+
+
+  @Test
+  public void isValid_returnsFalse_whenDecisionNullAndConsignmentCheckNull() {
+    assertFalse(validator.isValid(partTwo, null));
+  }
+
+  @Test
+  public void isValid_returnsFalse_whenDecisionNullAndIdentityCheckTypeNull() {
+    partTwo.setConsignmentCheck(new ConsignmentCheck());
+
+    assertFalse(validator.isValid(partTwo, null));
+  }
+
+  @Test
+  public void isValid_returnsFalse_whenDecisionNullAndIdentityCheckResultNull() {
+    partTwo.setConsignmentCheck(ConsignmentCheck.builder()
+        .identityCheckType(FULL_IDENTITY_CHECK)
+        .build());
+
+    assertFalse(validator.isValid(partTwo, null));
+  }
+
+  @Test
+  public void isValid_returnsTrue_whenDecisionNullAndIdentityCheckResultNotNull() {
+    partTwo.setConsignmentCheck(ConsignmentCheck.builder()
+        .identityCheckType(FULL_IDENTITY_CHECK)
+        .identityCheckResult(NOT_SATISFACTORY)
+        .build());
+
+    assertTrue(validator.isValid(partTwo, null));
+  }
+
+
+  @Test
+  public void isValid_returnsFalse_whenConsignmentAcceptableNullAndConsignmentCheckNull() {
+    partTwo.setDecision(new Decision());
+
+    assertFalse(validator.isValid(partTwo, null));
+  }
+
+  @Test
+  public void isValid_returnsFalse_whenConsignmentAcceptableNullAndIdentityCheckTypeNull() {
+    partTwo.setDecision(new Decision());
+    partTwo.setConsignmentCheck(new ConsignmentCheck());
+
+    assertFalse(validator.isValid(partTwo, null));
+  }
+
+  @Test
+  public void isValid_returnsFalse_whenConsignmentAcceptableNullAndIdentityCheckResultNull() {
+    partTwo.setDecision(new Decision());
+    partTwo.setConsignmentCheck(ConsignmentCheck.builder()
+        .identityCheckType(FULL_IDENTITY_CHECK)
+        .build());
+
+    assertFalse(validator.isValid(partTwo, null));
+  }
+
+  @Test
+  public void isValid_returnsTrue_whenConsignmentAcceptableNullAndIdentityCheckResultNotNull() {
+    partTwo.setDecision(new Decision());
+    partTwo.setConsignmentCheck(ConsignmentCheck.builder()
+        .identityCheckType(FULL_IDENTITY_CHECK)
+        .identityCheckResult(NOT_SATISFACTORY)
+        .build());
+
+    assertTrue(validator.isValid(partTwo, null));
+  }
+
+
+  @Test
+  public void isValid_returnsFalse_whenConsignmentAcceptableTrueAndConsignmentCheckNull() {
+    partTwo.setDecision(Decision.builder().consignmentAcceptable(true).build());
+
+    assertFalse(validator.isValid(partTwo, null));
+  }
+
+  @Test
+  public void isValid_returnsFalse_whenConsignmentAcceptableTrueAndIdentityCheckTypeNull() {
+    partTwo.setDecision(Decision.builder().consignmentAcceptable(true).build());
+    partTwo.setConsignmentCheck(new ConsignmentCheck());
+
+    assertFalse(validator.isValid(partTwo, null));
+  }
+
+  @Test
+  public void isValid_returnsFalse_whenConsignmentAcceptableTrueAndIdentityCheckResultNull() {
+    partTwo.setDecision(Decision.builder().consignmentAcceptable(true).build());
+    partTwo.setConsignmentCheck(ConsignmentCheck.builder()
+        .identityCheckType(FULL_IDENTITY_CHECK)
+        .build());
+
+    assertFalse(validator.isValid(partTwo, null));
+  }
+
+  @Test
+  public void isValid_returnsTrue_whenConsignmentAcceptableTrueAndIdentityCheckResultNotNull() {
+    partTwo.setDecision(Decision.builder().consignmentAcceptable(true).build());
+    partTwo.setConsignmentCheck(ConsignmentCheck.builder()
+        .identityCheckType(FULL_IDENTITY_CHECK)
+        .identityCheckResult(NOT_SATISFACTORY)
+        .build());
+
+    assertTrue(validator.isValid(partTwo, null));
+  }
+
+
+  @Test
+  public void isValid_returnsTrue_whenConsignmentAcceptableFalse() {
+    partTwo.setDecision(Decision.builder().consignmentAcceptable(false).build());
+
+    assertTrue(validator.isValid(partTwo, null));
+  }
+}

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedpPhysicalCheckTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedpPhysicalCheckTest.java
@@ -1,0 +1,100 @@
+package uk.gov.defra.tracesx.notificationschema.validation.annotations;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.Result.NOT_SATISFACTORY;
+
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.defra.tracesx.notificationschema.representation.ConsignmentCheck;
+import uk.gov.defra.tracesx.notificationschema.representation.Decision;
+import uk.gov.defra.tracesx.notificationschema.representation.PartTwo;
+
+public class ChedpPhysicalCheckTest {
+
+  private ChedpPhysicalCheckValidator validator;
+  private PartTwo partTwo;
+
+  @Before
+  public void setUp() {
+    validator = new ChedpPhysicalCheckValidator();
+    partTwo = new PartTwo();
+  }
+
+  @Test
+  public void isValid_returnsTrue_whenNullPassed() {
+    assertTrue(validator.isValid(null, null));
+  }
+
+  @Test
+  public void isValid_returnsFalse_whenDecisionNullAndConsignmentCheckNull() {
+    assertFalse(validator.isValid(partTwo, null));
+  }
+
+  @Test
+  public void isValid_returnsFalse_whenDecisionNullAndPhysicalCheckResultNull() {
+    partTwo.setConsignmentCheck(new ConsignmentCheck());
+
+    assertFalse(validator.isValid(partTwo, null));
+  }
+
+  @Test
+  public void isValid_returnsTrue_whenDecisionNullAndPhysicalCheckResultNotNull() {
+    partTwo.setConsignmentCheck(ConsignmentCheck.builder().physicalCheckResult(NOT_SATISFACTORY).build());
+
+    assertTrue(validator.isValid(partTwo, null));
+  }
+
+  @Test
+  public void isValid_returnsFalse_whenConsignmentAcceptableNullAndConsignmentCheckNull() {
+    partTwo.setDecision(new Decision());
+
+    assertFalse(validator.isValid(partTwo, null));
+  }
+
+  @Test
+  public void isValid_returnsFalse_whenConsignmentAcceptableNullAndPhysicalCheckResultNull() {
+    partTwo.setDecision(new Decision());
+    partTwo.setConsignmentCheck(new ConsignmentCheck());
+
+    assertFalse(validator.isValid(partTwo, null));
+  }
+
+  @Test
+  public void isValid_returnsTrue_whenConsignmentAcceptableNullAndPhysicalCheckResultNotNull() {
+    partTwo.setDecision(new Decision());
+    partTwo.setConsignmentCheck(ConsignmentCheck.builder().physicalCheckResult(NOT_SATISFACTORY).build());
+
+    assertTrue(validator.isValid(partTwo, null));
+  }
+
+  @Test
+  public void isValid_returnsFalse_whenConsignmentAcceptableTrueAndConsignmentCheckNull() {
+    partTwo.setDecision(Decision.builder().consignmentAcceptable(true).build());
+
+    assertFalse(validator.isValid(partTwo, null));
+  }
+
+  @Test
+  public void isValid_returnsFalse_whenConsignmentAcceptableTrueAndPhysicalCheckResultNull() {
+    partTwo.setDecision(Decision.builder().consignmentAcceptable(true).build());
+    partTwo.setConsignmentCheck(new ConsignmentCheck());
+
+    assertFalse(validator.isValid(partTwo, null));
+  }
+
+  @Test
+  public void isValid_returnsTrue_whenConsignmentAcceptableTrueAndPhysicalCheckResultNotNull() {
+    partTwo.setDecision(Decision.builder().consignmentAcceptable(true).build());
+    partTwo.setConsignmentCheck(ConsignmentCheck.builder().physicalCheckResult(NOT_SATISFACTORY).build());
+
+    assertTrue(validator.isValid(partTwo, null));
+  }
+
+  @Test
+  public void isValid_returnsTrue_whenConsignmentAcceptableFalse() {
+    partTwo.setDecision(Decision.builder().consignmentAcceptable(false).build());
+
+    assertTrue(validator.isValid(partTwo, null));
+  }
+}


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Reece Bennett (KAINOS) |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [IMTA-8948: Allow identity/physical check...](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/175) |
> | **GitLab MR Number** | [175](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/175) |
> | **Date Originally Opened** | Tue, 9 Feb 2021 |
> | **Approved on GitLab by** | Sean Treanor (KAINOS), Stephen Donaghey (KAINOS), marcus bond (KAINOS) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Allow a CHEDP notification to be rejected based on document checks only by making identity and physical checks to be null if the decision is not acceptable.

https://eaflood.atlassian.net/browse/IMTA-8948