### PR TITLE
IMTA-8188: Frontend notification memory leak fix

### DIFF
--- a/imports-frontend-entities/package-lock.json
+++ b/imports-frontend-entities/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipaffs/imports-frontend-entities",
-  "version": "1.0.164",
+  "version": "1.0.165",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/imports-frontend-entities/package.json
+++ b/imports-frontend-entities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipaffs/imports-frontend-entities",
-  "version": "1.0.164",
+  "version": "1.0.165",
   "repository": {
     "type": "git"
   },

--- a/imports-frontend-entities/src/entities/notification.js
+++ b/imports-frontend-entities/src/entities/notification.js
@@ -1,10 +1,8 @@
 const _ = require('lodash')
-const Ajv = require('ajv')
 
 const { getList } = require('../utils/list')
 const handler = require('./base/handler')
-const notificationJsonSchema = require('../../etc/notification-schema.json')
-const schemaDef = require('../../etc/schema-definition.json')
+const { notificationValidator } = require('../utils/notification_validator')
 const PartOne = require('./part_one')
 const PartTwo = require('./part_two')
 const PartThree = require('./part_three')
@@ -45,7 +43,6 @@ module.exports = class Notification {
     this.lastUpdatedBy = obj.lastUpdatedBy
     this.agencyOrganisationId = obj.agencyOrganisationId
 
-
     validate(this)
 
     return Object.seal(new Proxy(this, handler))
@@ -54,9 +51,9 @@ module.exports = class Notification {
 
 const validate = obj => {
 
-  let validate = new Ajv().addMetaSchema(schemaDef).compile(notificationJsonSchema)
-  if (!validate(obj)) {
-    throw Error('Notification constructor: ' + JSON.stringify(validate.errors))
+  const errors = notificationValidator.validate(obj)
+  if (errors.length > 0) {
+    throw new Error('Notification constructor: ' + JSON.stringify(errors))
   }
 }
 

--- a/imports-frontend-entities/src/utils/notification_validator.js
+++ b/imports-frontend-entities/src/utils/notification_validator.js
@@ -1,0 +1,21 @@
+const Ajv = require('ajv')
+const notificationJsonSchema = require('../../etc/notification-schema.json')
+const schemaDef = require('../../etc/schema-definition.json')
+
+class NotificationValidator {
+  constructor() {
+    this.validator = new Ajv().addMetaSchema(schemaDef).compile(notificationJsonSchema)
+  }
+
+  validate(notification) {
+    this.validator(notification)
+    return this.validator.errors === null ? [] : this.validator.errors
+  }
+}
+
+const notificationValidator = new NotificationValidator();
+Object.freeze(notificationValidator);
+
+module.exports = {
+  notificationValidator
+}

--- a/imports-frontend-entities/test/entities_test.js
+++ b/imports-frontend-entities/test/entities_test.js
@@ -101,4 +101,12 @@ describe('Entities: ', () => {
       }
     }
   })
+
+  it('throws an exception if an invalid notification is used', () => {
+    const invalidNotificationJson = {
+      key: 'text'
+    }
+
+    chai.expect(() => new Notification(invalidNotificationJson)).to.throw()
+  })
 })

--- a/imports-frontend-entities/test/utils/notification_validator_test.js
+++ b/imports-frontend-entities/test/utils/notification_validator_test.js
@@ -1,0 +1,31 @@
+const chai = require('chai')
+
+const {notificationValidator} = require.main.require('src/utils/notification_validator')
+
+describe('notification validator', () => {
+  it('should validate an empty object correctly', () => {
+
+    const errors = notificationValidator.validate({})
+    chai.expect(errors.length).to.equal(0)
+  })
+
+  it('should find errors in an invalid object', () => {
+
+    const invalidNotification = {
+      key: 'text'
+    }
+
+    const errors = notificationValidator.validate(invalidNotification)
+    chai.expect(errors.length).to.equal(1)
+  })
+
+  it('should not find errors in a valid object', () => {
+
+    const validNotification = {
+      referenceNumber: 'CHEDP.GB.2020.1985327'
+    }
+
+    const errors = notificationValidator.validate(validNotification)
+    chai.expect(errors.length).to.equal(0)
+  })
+})


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | iwan roberts (KAINOS) |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [IMTA-8188: Frontend notification memory ...](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/198) |
> | **GitLab MR Number** | [198](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/198) |
> | **Date Originally Opened** | Wed, 7 Apr 2021 |
> | **Approved on GitLab by** | Carl Evans (KAINOS), Kamesh Ganesan (KAINOS), Reece Bennett (KAINOS), daniel brennan (KAINOS), kamil mojek (KAINOS), marcus bond (KAINOS) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

The purpose of this change is to remediate the validation carried out in the notification entity so that only one compiled version of the validation function is used. It uses a singleton class to contain the compiled version of the validation function.

At the moment every time we create a notification using ``new Notification()`` we create two new copies of the validation function, thus causing a memory leak.