### PR TITLE
IMTA-9432: Validation if POD country not selected

### DIFF
--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/PartOne.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/PartOne.java
@@ -25,9 +25,11 @@ import uk.gov.defra.tracesx.notificationschema.representation.serialisation.IsoO
 import uk.gov.defra.tracesx.notificationschema.representation.serialisation.IsoTimeDeserializer;
 import uk.gov.defra.tracesx.notificationschema.representation.serialisation.IsoTimeSerializer;
 import uk.gov.defra.tracesx.notificationschema.validation.ValidationMessageCode;
+import uk.gov.defra.tracesx.notificationschema.validation.annotations.ChedppInvalidPodCheck;
 import uk.gov.defra.tracesx.notificationschema.validation.annotations.ChedppIsPositiveDoubleKeyDataPair;
 import uk.gov.defra.tracesx.notificationschema.validation.annotations.ChedppMinValueKeyDataPair;
 import uk.gov.defra.tracesx.notificationschema.validation.annotations.ChedppNotNullKeyDataPair;
+import uk.gov.defra.tracesx.notificationschema.validation.annotations.ChedppPodRequired;
 import uk.gov.defra.tracesx.notificationschema.validation.annotations.DogPlaceOfOriginImp;
 import uk.gov.defra.tracesx.notificationschema.validation.annotations.ImpPortOfEntry;
 import uk.gov.defra.tracesx.notificationschema.validation.annotations.ImpPortOfExit;
@@ -95,6 +97,13 @@ import javax.validation.constraints.NotNull;
     message = "{uk.gov.defra.tracesx.notificationschema.representation.partone.portofexitdate"
         + ".must.be.in.future}")
 @PhytosanitaryCertificateRequired(groups = NotificationChedppFieldValidation.class)
+@ChedppInvalidPodCheck(
+    groups = NotificationChedppFieldValidation.class,
+    message = "{uk.gov.defra.tracesx.notificationschema.representation.partone.pod"
+            + ".invalid.due.to.country}")
+@ChedppPodRequired(
+    groups = NotificationChedppFieldValidation.class,
+    message = "{uk.gov.defra.tracesx.notificationschema.representation.partone.pod.required}")
 public class PartOne {
 
   private TypeOfImp typeOfImp;

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedppInvalidPodCheck.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedppInvalidPodCheck.java
@@ -1,0 +1,24 @@
+package uk.gov.defra.tracesx.notificationschema.validation.annotations;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+@Target({TYPE, ANNOTATION_TYPE})
+@Retention(RUNTIME)
+@Constraint(validatedBy = ChedppInvalidPodCheckValidator.class)
+@Documented
+public @interface ChedppInvalidPodCheck {
+
+  String message() default "You must select an EU country if you are using a POD";
+
+  Class<?>[] groups() default {};
+
+  Class<? extends Payload>[] payload() default {};
+}

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedppInvalidPodCheckValidator.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedppInvalidPodCheckValidator.java
@@ -1,0 +1,21 @@
+package uk.gov.defra.tracesx.notificationschema.validation.annotations;
+
+import uk.gov.defra.tracesx.notificationschema.representation.PartOne;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class ChedppInvalidPodCheckValidator
+    implements ConstraintValidator<ChedppInvalidPodCheck, PartOne> {
+
+  @Override
+  public boolean isValid(PartOne partOne, ConstraintValidatorContext constraintValidatorContext) {
+    if (partOne == null || partOne.getCommodities() == null) {
+      return true;
+    }
+
+    return !(partOne.getPod() != null
+        && partOne.getCommodities().getCountryOfOriginIsPodCountry() != null
+        && partOne.getCommodities().getCountryOfOriginIsPodCountry().equals(Boolean.FALSE));
+  }
+}

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedppPodRequired.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedppPodRequired.java
@@ -1,0 +1,24 @@
+package uk.gov.defra.tracesx.notificationschema.validation.annotations;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+@Target({TYPE, ANNOTATION_TYPE})
+@Retention(RUNTIME)
+@Constraint(validatedBy = ChedppPodRequiredValidator.class)
+@Documented
+public @interface ChedppPodRequired {
+
+  String message() default "What is the temporary place of destination";
+
+  Class<?>[] groups() default {};
+
+  Class<? extends Payload>[] payload() default {};
+}

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedppPodRequiredValidator.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedppPodRequiredValidator.java
@@ -1,0 +1,21 @@
+package uk.gov.defra.tracesx.notificationschema.validation.annotations;
+
+import uk.gov.defra.tracesx.notificationschema.representation.PartOne;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class ChedppPodRequiredValidator implements ConstraintValidator<ChedppPodRequired, PartOne> {
+
+  private static final String VIA_TEMPORARY_PLACE_OF_DESTINATION = "POD";
+
+  @Override
+  public boolean isValid(PartOne partOne, ConstraintValidatorContext constraintValidatorContext) {
+    if (partOne == null || partOne.getPointOfEntryControlPoint() == null) {
+      return true;
+    }
+
+    return !(partOne.getPointOfEntryControlPoint().equals(VIA_TEMPORARY_PLACE_OF_DESTINATION)
+        && partOne.getPod() == null);
+  }
+}

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedppInvalidPodCheckValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedppInvalidPodCheckValidatorTest.java
@@ -1,0 +1,105 @@
+package uk.gov.defra.tracesx.notificationschema.validation.annotations;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.defra.tracesx.notificationschema.representation.Commodities;
+import uk.gov.defra.tracesx.notificationschema.representation.EconomicOperator;
+import uk.gov.defra.tracesx.notificationschema.representation.PartOne;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ChedppInvalidPodCheckValidatorTest {
+
+  private ChedppInvalidPodCheckValidator validator;
+  private PartOne partOne;
+  private Commodities commodities;
+  private EconomicOperator pod;
+
+  @Before
+  public void setup() {
+    validator = new ChedppInvalidPodCheckValidator();
+    partOne = new PartOne();
+    commodities = new Commodities();
+    pod = new EconomicOperator();
+  }
+
+  @Test
+  public void validatorShouldReturnTrueIfPartOneIsNull() {
+    // When
+    boolean result = validator.isValid(null, null);
+
+    // Then
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  public void validatorShouldReturnTrueIfCommoditiesIsNull() {
+    // Given
+    partOne.setCommodities(null);
+
+    // When
+    boolean result = validator.isValid(partOne, null);
+
+    // Then
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  public void validatorShouldReturnFalseIfPodIsSetForNonPodGroupCountry() {
+    // Given
+    commodities.setCountryOfOriginIsPodCountry(Boolean.FALSE);
+    partOne.setCommodities(commodities);
+    partOne.setPod(pod);
+
+    // When
+    boolean result = validator.isValid(partOne, null);
+
+    // Then
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  public void validatorShouldReturnTrueIfPodIsSetForPodGroupCountry() {
+    // Given
+    commodities.setCountryOfOriginIsPodCountry(Boolean.TRUE);
+    partOne.setCommodities(commodities);
+    partOne.setPod(pod);
+
+    // When
+    boolean result = validator.isValid(partOne, null);
+
+    // Then
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  public void validatorShouldReturnTrueIfPodIsNull() {
+    // Given
+    partOne.setPod(null);
+    commodities.setCountryOfOriginIsPodCountry(Boolean.FALSE);
+    partOne.setCommodities(commodities);
+
+    // When
+    boolean result = validator.isValid(partOne, null);
+
+    // Then
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  public void validatorShouldReturnTrueIfPodCountryGroupIsNull() {
+    // Given
+    commodities.setCountryOfOriginIsPodCountry(null);
+    partOne.setCommodities(commodities);
+    partOne.setPod(pod);
+
+    // When
+    boolean result = validator.isValid(partOne, null);
+
+    // Then
+    assertThat(result).isTrue();
+  }
+}

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedppPodRequiredValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedppPodRequiredValidatorTest.java
@@ -1,0 +1,87 @@
+package uk.gov.defra.tracesx.notificationschema.validation.annotations;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.defra.tracesx.notificationschema.representation.EconomicOperator;
+import uk.gov.defra.tracesx.notificationschema.representation.PartOne;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ChedppPodRequiredValidatorTest {
+
+  private ChedppPodRequiredValidator validator;
+  private PartOne partOne;
+  private EconomicOperator pod;
+
+  private static final String VIA_TEMPORARY_PLACE_OF_DESTINATION = "POD";
+
+  @Before
+  public void setup() {
+    validator = new ChedppPodRequiredValidator();
+    partOne = new PartOne();
+    pod = new EconomicOperator();
+  }
+
+  @Test
+  public void validatorShouldReturnTrueIfPartOneIsNull() {
+    // When
+    boolean result = validator.isValid(null, null);
+
+    // Then
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  public void validatorShouldReturnTrueIfInspectionPremiseIsNull() {
+    // Given
+    partOne.setPointOfEntryControlPoint(null);
+
+    // When
+    boolean result = validator.isValid(partOne, null);
+
+    // Then
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  public void validatorShouldReturnFalseIfPodIsNullAndInspectionPremiseSetToPod() {
+    // Given
+    partOne.setPointOfEntryControlPoint(VIA_TEMPORARY_PLACE_OF_DESTINATION);
+    partOne.setPod(null);
+
+    // When
+    boolean result = validator.isValid(partOne, null);
+
+    // Then
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  public void validatorShouldReturnTrueIfPodIsSetAndInspectionPremiseSetToPod() {
+    // Given
+    partOne.setPointOfEntryControlPoint(VIA_TEMPORARY_PLACE_OF_DESTINATION);
+    partOne.setPod(pod);
+
+    // When
+    boolean result = validator.isValid(partOne, null);
+
+    // Then
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  public void validatorShouldReturnTrueIfPodIsSetAndInspectionPremiseIsNotSetToPod() {
+    // Given
+    partOne.setPointOfEntryControlPoint("Some Random Place");
+    partOne.setPod(pod);
+
+    // When
+    boolean result = validator.isValid(partOne, null);
+
+    // Then
+    assertThat(result).isTrue();
+  }
+}


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Juliano Saunders (Kainos) |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [IMTA-9432: Validation if POD country not...](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/207) |
> | **GitLab MR Number** | [207](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/207) |
> | **Date Originally Opened** | Wed, 12 May 2021 |
> | **Approved on GitLab by** | Callum Atwal (kainos), Kamesh Ganesan (KAINOS), Kelly Moore, Sean Treanor (KAINOS), Stephen McVeigh, iwan roberts (KAINOS) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link:  [Ticket](https://eaflood.atlassian.net/browse/IMTA-9432)

### :book: Changes
* Add two validation rules:
 * invalid pod due to non pod group country
 * pod required when selecting pod in Inspection premise field