### PR TITLE
IMTA 8599 - Bump schema version for JS schema so it's available for frontends to use

### DIFF
--- a/imports-frontend-entities/package-lock.json
+++ b/imports-frontend-entities/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipaffs/imports-frontend-entities",
-  "version": "1.0.180",
+  "version": "1.0.183",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/imports-frontend-entities/package.json
+++ b/imports-frontend-entities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipaffs/imports-frontend-entities",
-  "version": "1.0.180",
+  "version": "1.0.183",
   "repository": {
     "type": "git"
   },


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | dominik henjes (KAINOS) |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [IMTA 8599 - Bump schema version for JS s...](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/215) |
> | **GitLab MR Number** | [215](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/215) |
> | **Date Originally Opened** | Mon, 21 Jun 2021 |
> | **Approved on GitLab by** | Blakeley, Paul (Kainos), Juliano Saunders (Kainos), Kelly Moore, Reece Bennett (KAINOS), Sean Treanor (KAINOS), kamil mojek (KAINOS) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: ticket: https://eaflood.atlassian.net/browse/IMTA-9599
### :book: Changes:
* Bump schema version number to allow updated schema to be used by other microservices