### PR TITLE
IMTA-10706: Adding phytosanitary document suppression for article 72 consignments

### DIFF
--- a/imports-frontend-entities/package-lock.json
+++ b/imports-frontend-entities/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipaffs/imports-frontend-entities",
-  "version": "1.0.203",
+  "version": "1.0.204",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/imports-frontend-entities/package.json
+++ b/imports-frontend-entities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipaffs/imports-frontend-entities",
-  "version": "1.0.203",
+  "version": "1.0.204",
   "repository": {
     "type": "git"
   },

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/AccompanyingDocument.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/AccompanyingDocument.java
@@ -23,7 +23,6 @@ import java.util.UUID;
 @JsonInclude(Include.NON_EMPTY)
 @NoArgsConstructor(access = AccessLevel.PUBLIC)
 @AllArgsConstructor(access = AccessLevel.PUBLIC)
-@PhytosanitaryCertificateAttachmentRequired(groups = NotificationChedppFieldValidation.class)
 public class AccompanyingDocument {
 
   private DocumentType documentType = null;

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/Commodities.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/Commodities.java
@@ -14,6 +14,7 @@ import uk.gov.defra.tracesx.notificationschema.validation.annotations.ChedppGmsD
 import uk.gov.defra.tracesx.notificationschema.validation.annotations.MinCommoditiesGrossWeight;
 import uk.gov.defra.tracesx.notificationschema.validation.annotations.NotNullFinishedOrPropagatedKeyDataPair;
 import uk.gov.defra.tracesx.notificationschema.validation.annotations.NotNullWoodPackagingKeyDataPair;
+import uk.gov.defra.tracesx.notificationschema.validation.annotations.PhytosanitaryCertificateAttachmentRequired;
 import uk.gov.defra.tracesx.notificationschema.validation.annotations.QuantityImp;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCedOrCvedpFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCedOrCvedpOrChedppFieldValidation;

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/PartOne.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/PartOne.java
@@ -37,6 +37,7 @@ import uk.gov.defra.tracesx.notificationschema.validation.annotations.ImpPortOfE
 import uk.gov.defra.tracesx.notificationschema.validation.annotations.NotNullPurposeExitBip;
 import uk.gov.defra.tracesx.notificationschema.validation.annotations.NotNullPurposeExitDate;
 import uk.gov.defra.tracesx.notificationschema.validation.annotations.NotNullWoodPackagingCommodity;
+import uk.gov.defra.tracesx.notificationschema.validation.annotations.PhytosanitaryCertificateAttachmentRequired;
 import uk.gov.defra.tracesx.notificationschema.validation.annotations.PhytosanitaryCertificateRequired;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCedFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationChedppFieldValidation;
@@ -104,6 +105,7 @@ import javax.validation.constraints.NotNull;
 @ChedppPodRequired(
     groups = NotificationChedppFieldValidation.class,
     message = "{uk.gov.defra.tracesx.notificationschema.representation.partone.pod.required}")
+@PhytosanitaryCertificateAttachmentRequired(groups = NotificationChedppFieldValidation.class)
 public class PartOne {
 
   private TypeOfImp typeOfImp;

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/PhytosanitaryCertificateAttachmentRequiredValidator.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/PhytosanitaryCertificateAttachmentRequiredValidator.java
@@ -3,21 +3,21 @@ package uk.gov.defra.tracesx.notificationschema.validation.annotations;
 import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.DocumentType.PHYTOSANITARY_CERTIFICATE;
 
 import uk.gov.defra.tracesx.notificationschema.representation.AccompanyingDocument;
+import uk.gov.defra.tracesx.notificationschema.representation.Commodities;
+import uk.gov.defra.tracesx.notificationschema.representation.ComplementParameterSetKeyDataPair;
+import uk.gov.defra.tracesx.notificationschema.representation.PartOne;
 
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
 
-public class PhytosanitaryCertificateAttachmentRequiredValidator implements
-    ConstraintValidator<PhytosanitaryCertificateAttachmentRequired, AccompanyingDocument> {
+public class PhytosanitaryCertificateAttachmentRequiredValidator
+    implements ConstraintValidator<PhytosanitaryCertificateAttachmentRequired, PartOne> {
 
-  private static boolean isPhytosanitaryCertificate(AccompanyingDocument accompanyingDocument) {
-    return accompanyingDocument.getDocumentType() != null
-        && accompanyingDocument.getDocumentType().equals(PHYTOSANITARY_CERTIFICATE);
-  }
-
-  private static boolean hasAttachment(AccompanyingDocument accompanyingDocument) {
-    return accompanyingDocument.getAttachmentId() != null;
-  }
+  private static final String ARTICLE_72_COMMODITY_KEY = "low_risk_article72_commodity";
 
   @Override
   public void initialize(PhytosanitaryCertificateAttachmentRequired constraintAnnotation) {
@@ -25,12 +25,37 @@ public class PhytosanitaryCertificateAttachmentRequiredValidator implements
   }
 
   @Override
-  public boolean isValid(AccompanyingDocument accompanyingDocument,
-      ConstraintValidatorContext constraintValidatorContext) {
-    if (isPhytosanitaryCertificate(accompanyingDocument)) {
-      return hasAttachment(accompanyingDocument);
-    } else {
-      return true;
-    }
+  public boolean isValid(PartOne partOne, ConstraintValidatorContext constraintValidatorContext) {
+
+    return isArticle72Consignment(partOne)
+        || partOne.getVeterinaryInformation().getAccompanyingDocuments().stream()
+            .filter(this::isPhytosanitaryCertificate)
+            .findFirst()
+            .map(this::hasAttachment)
+            .orElse(true);
+  }
+
+  private boolean isPhytosanitaryCertificate(AccompanyingDocument accompanyingDocument) {
+    return accompanyingDocument.getDocumentType() != null
+        && accompanyingDocument.getDocumentType().equals(PHYTOSANITARY_CERTIFICATE);
+  }
+
+  private boolean hasAttachment(AccompanyingDocument accompanyingDocument) {
+    return accompanyingDocument.getAttachmentId() != null;
+  }
+
+  private boolean isArticle72Commodity(List<ComplementParameterSetKeyDataPair> keyDataPairs) {
+    return keyDataPairs.stream()
+        .anyMatch(
+            keyDataPair ->
+                Objects.equals(keyDataPair.getKey(), ARTICLE_72_COMMODITY_KEY)
+                    && Objects.equals(keyDataPair.getData(), "true"));
+  }
+
+  private boolean isArticle72Consignment(PartOne partOne) {
+    return partOne.getCommodities().getComplementParameterSet().stream()
+            .allMatch(parameterSet -> isArticle72Commodity(parameterSet.getKeyDataPair()))
+        && Optional.ofNullable(partOne.getCommodities().getCountryOfOriginIsPodCountry())
+            .orElse(false);
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/PhytosanitaryCertificateAttachmentRequiredValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/PhytosanitaryCertificateAttachmentRequiredValidatorTest.java
@@ -7,25 +7,43 @@ import static uk.gov.defra.tracesx.notificationschema.representation.enumeration
 import org.junit.Before;
 import org.junit.Test;
 import uk.gov.defra.tracesx.notificationschema.representation.AccompanyingDocument;
+import uk.gov.defra.tracesx.notificationschema.representation.Commodities;
+import uk.gov.defra.tracesx.notificationschema.representation.ComplementParameterSet;
+import uk.gov.defra.tracesx.notificationschema.representation.ComplementParameterSetKeyDataPair;
+import uk.gov.defra.tracesx.notificationschema.representation.PartOne;
+import uk.gov.defra.tracesx.notificationschema.representation.VeterinaryInformation;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
 
 public class PhytosanitaryCertificateAttachmentRequiredValidatorTest {
 
   private PhytosanitaryCertificateAttachmentRequiredValidator validator;
 
+  private PartOne partOne;
+
   @Before
   public void setUp() {
     validator = new PhytosanitaryCertificateAttachmentRequiredValidator();
+
+    partOne =
+        PartOne.builder()
+            .commodities(
+                Commodities.builder()
+                    .isLowRiskArticle72Country(null)
+                    .complementParameterSet(new ArrayList<>())
+                    .build())
+            .veterinaryInformation(
+                VeterinaryInformation.builder().accompanyingDocuments(new ArrayList<>()).build())
+            .build();
   }
 
   @Test
   public void isValid_returnsTrue_whenDocumentTypeNull() {
-    // Given
-    AccompanyingDocument accompanyingDocument = AccompanyingDocument.builder().build();
-
-    // When
-    boolean result = validator.isValid(accompanyingDocument, null);
+    // Given / When
+    boolean result = validator.isValid(partOne, null);
 
     // Then
     assertThat(result).isTrue();
@@ -34,12 +52,13 @@ public class PhytosanitaryCertificateAttachmentRequiredValidatorTest {
   @Test
   public void isValid_returnsTrue_whenNotPhytosanitaryCertificate() {
     // Given
-    AccompanyingDocument accompanyingDocument = AccompanyingDocument.builder()
-        .documentType(VETERINARY_HEALTH_CERTIFICATE)
-        .build();
+    partOne
+        .getVeterinaryInformation()
+        .getAccompanyingDocuments()
+        .add(AccompanyingDocument.builder().documentType(VETERINARY_HEALTH_CERTIFICATE).build());
 
     // When
-    boolean result = validator.isValid(accompanyingDocument, null);
+    boolean result = validator.isValid(partOne, null);
 
     // Then
     assertThat(result).isTrue();
@@ -48,12 +67,13 @@ public class PhytosanitaryCertificateAttachmentRequiredValidatorTest {
   @Test
   public void isValid_returnsFalse_whenAttachmentNotPresent() {
     // Given
-    AccompanyingDocument accompanyingDocument = AccompanyingDocument.builder()
-        .documentType(PHYTOSANITARY_CERTIFICATE)
-        .build();
+    partOne
+        .getVeterinaryInformation()
+        .getAccompanyingDocuments()
+        .add(AccompanyingDocument.builder().documentType(PHYTOSANITARY_CERTIFICATE).build());
 
     // When
-    boolean result = validator.isValid(accompanyingDocument, null);
+    boolean result = validator.isValid(partOne, null);
 
     // Then
     assertThat(result).isFalse();
@@ -62,13 +82,34 @@ public class PhytosanitaryCertificateAttachmentRequiredValidatorTest {
   @Test
   public void isValid_returnsTrue_whenAttachmentPresent() {
     // Given
-    AccompanyingDocument accompanyingDocument = AccompanyingDocument.builder()
-        .documentType(PHYTOSANITARY_CERTIFICATE)
-        .attachmentId(UUID.randomUUID())
-        .build();
+    partOne
+        .getVeterinaryInformation()
+        .getAccompanyingDocuments()
+        .add(
+            AccompanyingDocument.builder()
+                .documentType(PHYTOSANITARY_CERTIFICATE)
+                .attachmentId(UUID.randomUUID())
+                .build());
 
     // When
-    boolean result = validator.isValid(accompanyingDocument, null);
+    boolean result = validator.isValid(partOne, null);
+
+    // Then
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  public void isValid_ReturnsTrue_WhenTheConsignmentIsArticle72() {
+    // Given
+    partOne.getCommodities().getComplementParameterSet().add(ComplementParameterSet.builder()
+        .keyDataPair(Collections.singletonList(ComplementParameterSetKeyDataPair.builder()
+            .key("low_risk_article72_commodity")
+            .data("true")
+            .build()))
+        .build());
+
+    // When
+    boolean result = validator.isValid(partOne, null);
 
     // Then
     assertThat(result).isTrue();


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Sean Treanor (KAINOS) |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [IMTA-10706: Adding phytosanitary documen...](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/239) |
> | **GitLab MR Number** | [239](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/239) |
> | **Date Originally Opened** | Mon, 15 Nov 2021 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **closed** on GitLab

## Original Description

### :link: Ticket: https://eaflood.atlassian.net/browse/IMTA-10706
### :book: Changes:
* Adding suppression to the phytosanitary validation for article 72 commodities