### PR TITLE
IMTA-10706: Removing phytosanitary validation for article 72 consignments

### DIFF
--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/ComplementParameterSet.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/ComplementParameterSet.java
@@ -33,6 +33,7 @@ public class ComplementParameterSet {
   public static final String TYPE_PRODUCT = "type_product";
   public static final String TYPE_QUANTITY = "type_quantity";
   public static final String COMMODITY_GROUP = "commodity_group";
+  public static final String LOW_RISK_ARTICLE_72_COMMODITY = "low_risk_article72_commodity";
 
   private UUID uniqueComplementID;
   private Integer complementID;

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/PhytosanitaryCertificateRequiredValidator.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/PhytosanitaryCertificateRequiredValidator.java
@@ -1,5 +1,6 @@
 package uk.gov.defra.tracesx.notificationschema.validation.annotations;
 
+import static uk.gov.defra.tracesx.notificationschema.representation.ComplementParameterSet.LOW_RISK_ARTICLE_72_COMMODITY;
 import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.DocumentType.PHYTOSANITARY_CERTIFICATE;
 
 import uk.gov.defra.tracesx.notificationschema.representation.AccompanyingDocument;
@@ -10,6 +11,7 @@ import uk.gov.defra.tracesx.notificationschema.representation.PartOne;
 import uk.gov.defra.tracesx.notificationschema.representation.VeterinaryInformation;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import javax.validation.ConstraintValidator;
@@ -46,6 +48,25 @@ public class PhytosanitaryCertificateRequiredValidator implements
         .anyMatch(PhytosanitaryCertificateRequiredValidator::isPhsiOrJoint);
   }
 
+  private boolean isArticle72Consignment(PartOne partOne) {
+    return isArticle72Country(partOne.getCommodities())
+        && partOne.getCommodities().getComplementParameterSet().stream()
+            .map(ComplementParameterSet::getKeyDataPair)
+            .allMatch(this::isArticle72Commodity);
+  }
+
+  private boolean isArticle72Commodity(List<ComplementParameterSetKeyDataPair> keyDataPairs) {
+    return keyDataPairs.stream()
+        .anyMatch(
+            keyDataPair ->
+                Objects.equals(keyDataPair.getKey(), LOW_RISK_ARTICLE_72_COMMODITY)
+                    && Objects.equals(keyDataPair.getData(), Boolean.TRUE.toString()));
+  }
+
+  private boolean isArticle72Country(Commodities commodities) {
+    return Optional.ofNullable(commodities.getIsLowRiskArticle72Country()).orElse(false);
+  }
+
   private static boolean hasPhytosanitaryCertificate(PartOne partOne) {
     return Optional.of(partOne)
         .map(PartOne::getVeterinaryInformation)
@@ -63,7 +84,7 @@ public class PhytosanitaryCertificateRequiredValidator implements
 
   @Override
   public boolean isValid(PartOne partOne, ConstraintValidatorContext constraintValidatorContext) {
-    if (hasPhsiOrJoint(partOne)) {
+    if (!isArticle72Consignment(partOne) && hasPhsiOrJoint(partOne)) {
       return hasPhytosanitaryCertificate(partOne);
     } else {
       return true;

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/PhytosanitaryCertificateAttachmentRequiredValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/PhytosanitaryCertificateAttachmentRequiredValidatorTest.java
@@ -20,7 +20,7 @@ public class PhytosanitaryCertificateAttachmentRequiredValidatorTest {
   }
 
   @Test
-  public void isValid_returnsTrue_whenDocumentTypeNull() {
+  public void isValid_ReturnsTrue_WhenDocumentTypeNull() {
     // Given
     AccompanyingDocument accompanyingDocument = AccompanyingDocument.builder().build();
 
@@ -32,7 +32,7 @@ public class PhytosanitaryCertificateAttachmentRequiredValidatorTest {
   }
 
   @Test
-  public void isValid_returnsTrue_whenNotPhytosanitaryCertificate() {
+  public void isValid_ReturnsTrue_WhenNotPhytosanitaryCertificate() {
     // Given
     AccompanyingDocument accompanyingDocument = AccompanyingDocument.builder()
         .documentType(VETERINARY_HEALTH_CERTIFICATE)
@@ -46,7 +46,7 @@ public class PhytosanitaryCertificateAttachmentRequiredValidatorTest {
   }
 
   @Test
-  public void isValid_returnsFalse_whenAttachmentNotPresent() {
+  public void isValid_ReturnsFalse_WhenAttachmentNotPresent() {
     // Given
     AccompanyingDocument accompanyingDocument = AccompanyingDocument.builder()
         .documentType(PHYTOSANITARY_CERTIFICATE)
@@ -60,7 +60,7 @@ public class PhytosanitaryCertificateAttachmentRequiredValidatorTest {
   }
 
   @Test
-  public void isValid_returnsTrue_whenAttachmentPresent() {
+  public void isValid_ReturnsTrue_WhenAttachmentPresent() {
     // Given
     AccompanyingDocument accompanyingDocument = AccompanyingDocument.builder()
         .documentType(PHYTOSANITARY_CERTIFICATE)

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/PhytosanitaryCertificateRequiredValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/PhytosanitaryCertificateRequiredValidatorTest.java
@@ -18,6 +18,7 @@ import java.util.List;
 public class PhytosanitaryCertificateRequiredValidatorTest {
 
   private static final String REGULATORY_AUTHORITY = "regulatory_authority";
+  private static final String LOW_RISK_ARTICLE_72_COMMODITY = "low_risk_article72_commodity";
   private static final String JOINT = "JOINT";
   private static final String PHSI = "PHSI";
   private static final String HMI = "HMI";
@@ -30,7 +31,7 @@ public class PhytosanitaryCertificateRequiredValidatorTest {
   }
 
   @Test
-  public void isValid_returnsTrue_whenComplementParameterSetNull() {
+  public void isValid_ReturnsTrue_WhenComplementParameterSetNull() {
     // Given
     PartOne partOne = PartOne.builder()
         .commodities(Commodities.builder().build())
@@ -44,7 +45,7 @@ public class PhytosanitaryCertificateRequiredValidatorTest {
   }
 
   @Test
-  public void isValid_returnsTrue_whenKeyDataPairNull() {
+  public void isValid_ReturnsTrue_WhenKeyDataPairNull() {
     // Given
     List<ComplementParameterSetKeyDataPair> keyDataPairs = new ArrayList<>();
     keyDataPairs.add(ComplementParameterSetKeyDataPair.builder().build());
@@ -66,7 +67,7 @@ public class PhytosanitaryCertificateRequiredValidatorTest {
   }
 
   @Test
-  public void isValid_returnsTrue_whenKeyNull() {
+  public void isValid_ReturnsTrue_WhenKeyNull() {
     // Given
     PartOne partOne = PartOne.builder()
         .commodities(Commodities.builder()
@@ -86,7 +87,7 @@ public class PhytosanitaryCertificateRequiredValidatorTest {
   }
 
   @Test
-  public void isValid_returnsTrue_whenDataNull() {
+  public void isValid_ReturnsTrue_WhenDataNull() {
     // Given
     PartOne partOne = PartOne.builder()
         .commodities(Commodities.builder()
@@ -108,7 +109,7 @@ public class PhytosanitaryCertificateRequiredValidatorTest {
   }
 
   @Test
-  public void isValid_returnsTrue_whenNoPhsiOrJointCommodities() {
+  public void isValid_ReturnsTrue_WhenNoPhsiOrJointCommodities() {
     // Given
     PartOne partOne = PartOne.builder()
         .commodities(Commodities.builder()
@@ -134,7 +135,7 @@ public class PhytosanitaryCertificateRequiredValidatorTest {
   }
 
   @Test
-  public void isValid_returnsFalse_whenVeterinaryInformationNull() {
+  public void isValid_ReturnsFalse_WhenVeterinaryInformationNull() {
     // Given
     PartOne partOne = PartOne.builder()
         .commodities(Commodities.builder()
@@ -157,7 +158,7 @@ public class PhytosanitaryCertificateRequiredValidatorTest {
   }
 
   @Test
-  public void isValid_returnsFalse_whenAccompanyingDocumentsNull() {
+  public void isValid_ReturnsFalse_WhenAccompanyingDocumentsNull() {
     // Given
     PartOne partOne = PartOne.builder()
         .commodities(Commodities.builder()
@@ -181,7 +182,7 @@ public class PhytosanitaryCertificateRequiredValidatorTest {
   }
 
   @Test
-  public void isValid_returnsFalse_whenPhsiAndNoPhytosanitaryCertificate() {
+  public void isValid_ReturnsFalse_WhenPhsiAndNoPhytosanitaryCertificate() {
     // Given
     PartOne partOne = PartOne.builder()
         .commodities(Commodities.builder()
@@ -207,7 +208,7 @@ public class PhytosanitaryCertificateRequiredValidatorTest {
   }
 
   @Test
-  public void isValid_returnsFalse_whenJointAndNoPhytosanitaryCertificate() {
+  public void isValid_ReturnsFalse_WhenJointAndNoPhytosanitaryCertificate() {
     // Given
     PartOne partOne = PartOne.builder()
         .commodities(Commodities.builder()
@@ -233,7 +234,7 @@ public class PhytosanitaryCertificateRequiredValidatorTest {
   }
 
   @Test
-  public void isValid_returnsTrue_whenPhsiAndPhytosanitaryCertificate() {
+  public void isValid_ReturnsTrue_WhenPhsiAndPhytosanitaryCertificate() {
     // Given
     PartOne partOne = PartOne.builder()
         .commodities(Commodities.builder()
@@ -260,7 +261,7 @@ public class PhytosanitaryCertificateRequiredValidatorTest {
   }
 
   @Test
-  public void isValid_returnsTrue_whenJointAndPhytosanitaryCertifiate() {
+  public void isValid_ReturnsTrue_WhenJointAndPhytosanitaryCertifiate() {
     // Given
     PartOne partOne = PartOne.builder()
         .commodities(Commodities.builder()
@@ -284,5 +285,122 @@ public class PhytosanitaryCertificateRequiredValidatorTest {
 
     // Then
     assertThat(result).isTrue();
+  }
+
+  @Test
+  public void isValid_ReturnsTrue_WhenConsignmentIsArticle72() {
+    // Given
+    PartOne partOne = PartOne.builder()
+        .commodities(Commodities.builder()
+            .isLowRiskArticle72Country(Boolean.TRUE)
+            .complementParameterSet(List.of(
+                ComplementParameterSet.builder()
+                    .keyDataPair(List.of(
+                        ComplementParameterSetKeyDataPair.builder()
+                            .key(REGULATORY_AUTHORITY)
+                            .data(JOINT)
+                            .build(),
+                        ComplementParameterSetKeyDataPair.builder()
+                            .key(LOW_RISK_ARTICLE_72_COMMODITY)
+                            .data(Boolean.TRUE.toString())
+                            .build()))
+                    .build(),
+                ComplementParameterSet.builder()
+                    .keyDataPair(List.of(
+                        ComplementParameterSetKeyDataPair.builder()
+                            .key(REGULATORY_AUTHORITY)
+                            .data(JOINT)
+                            .build(),
+                        ComplementParameterSetKeyDataPair.builder()
+                            .key(LOW_RISK_ARTICLE_72_COMMODITY)
+                            .data(Boolean.TRUE.toString())
+                            .build()))
+                    .build()))
+            .build())
+        .build();
+
+    // When
+    boolean result = validator.isValid(partOne, null);
+
+    // Then
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  public void isValid_ReturnsFalse_WhenConsignmentCountryIsNotAnArticle72Country() {
+    // Given
+    PartOne partOne = PartOne.builder()
+        .commodities(Commodities.builder()
+            .isLowRiskArticle72Country(Boolean.FALSE)
+            .complementParameterSet(List.of(
+                ComplementParameterSet.builder()
+                    .keyDataPair(List.of(
+                        ComplementParameterSetKeyDataPair.builder()
+                            .key(REGULATORY_AUTHORITY)
+                            .data(JOINT)
+                            .build(),
+                        ComplementParameterSetKeyDataPair.builder()
+                            .key(LOW_RISK_ARTICLE_72_COMMODITY)
+                            .data(Boolean.TRUE.toString())
+                            .build()))
+                    .build(),
+                ComplementParameterSet.builder()
+                    .keyDataPair(List.of(
+                        ComplementParameterSetKeyDataPair.builder()
+                            .key(REGULATORY_AUTHORITY)
+                            .data(JOINT)
+                            .build(),
+                        ComplementParameterSetKeyDataPair.builder()
+                            .key(LOW_RISK_ARTICLE_72_COMMODITY)
+                            .data(Boolean.TRUE.toString())
+                            .build()))
+                    .build()))
+            .build())
+        .build();
+
+    // When
+    boolean result = validator.isValid(partOne, null);
+
+    // Then
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  public void isValid_ReturnsFalse_WhenConsignmentCommoditiesAreNotArticle72() {
+    // Given
+    PartOne partOne = PartOne.builder()
+        .commodities(Commodities.builder()
+            .isLowRiskArticle72Country(Boolean.TRUE)
+            .complementParameterSet(List.of(
+                ComplementParameterSet.builder()
+                    .keyDataPair(List.of(
+                        ComplementParameterSetKeyDataPair.builder()
+                            .key(REGULATORY_AUTHORITY)
+                            .data(JOINT)
+                            .build(),
+                        ComplementParameterSetKeyDataPair.builder()
+                            .key(LOW_RISK_ARTICLE_72_COMMODITY)
+                            .data(Boolean.TRUE.toString())
+                            .build()))
+                    .build(),
+                ComplementParameterSet.builder()
+                    .keyDataPair(List.of(
+                        ComplementParameterSetKeyDataPair.builder()
+                            .key(REGULATORY_AUTHORITY)
+                            .data(JOINT)
+                            .build(),
+                        ComplementParameterSetKeyDataPair.builder()
+                            .key(LOW_RISK_ARTICLE_72_COMMODITY)
+                            .data(Boolean.FALSE.toString())
+                            .build()))
+                    .build()))
+            .build())
+        .build();
+
+    // When
+    boolean result = validator.isValid(partOne, null);
+
+    // Then
+    assertThat(result).isFalse();
   }
 }


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Sean Treanor (KAINOS) |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [IMTA-10706: Removing phytosanitary valid...](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/240) |
> | **GitLab MR Number** | [240](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/240) |
> | **Date Originally Opened** | Mon, 15 Nov 2021 |
> | **Approved on GitLab by** | Piotr Dudkiewicz, iwan roberts (KAINOS), kamil mojek (KAINOS) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: Ticket: https://eaflood.atlassian.net/browse/IMTA-10703
### :book: Changes:
* Added logic to suppress phytosanitary validation when the consignment is Article 72