### PR TITLE
IMTA-10708: Removed inspection premise validation for article 72 consignments

### DIFF
--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/Commodities.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/Commodities.java
@@ -1,5 +1,6 @@
 package uk.gov.defra.tracesx.notificationschema.representation;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import lombok.AccessLevel;
@@ -24,7 +25,10 @@ import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationLow
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
 import javax.validation.Valid;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
@@ -42,18 +46,21 @@ import javax.validation.constraints.NotNull;
 @NotNullWoodPackagingKeyDataPair(
     groups = NotificationChedppFieldValidation.class,
     field = "units-quantity",
-    message = "{uk.gov.defra.tracesx.notificationschema.representation.partone.commodities"
-        + ".woodpackagingnumberunits.not.null}")
+    message =
+        "{uk.gov.defra.tracesx.notificationschema.representation.partone.commodities"
+            + ".woodpackagingnumberunits.not.null}")
 @NotNullWoodPackagingKeyDataPair(
     groups = NotificationChedppFieldValidation.class,
     field = "units-type",
-    message = "{uk.gov.defra.tracesx.notificationschema.representation.partone.commodities"
-        + ".woodpackagingunittype.not.null}")
+    message =
+        "{uk.gov.defra.tracesx.notificationschema.representation.partone.commodities"
+            + ".woodpackagingunittype.not.null}")
 @NotNullWoodPackagingKeyDataPair(
     groups = NotificationChedppFieldValidation.class,
     field = "country-of-origin",
-    message = "{uk.gov.defra.tracesx.notificationschema.representation.partone.commodities"
-        + ".woodpackagingcountryoforigin.not.null}")
+    message =
+        "{uk.gov.defra.tracesx.notificationschema.representation.partone.commodities"
+            + ".woodpackagingcountryoforigin.not.null}")
 @ChedppGmsDeclaration(
     groups = NotificationChedppFieldValidation.class,
     message =
@@ -112,8 +119,9 @@ public class Commodities {
   @Valid
   @QuantityImp(
       groups = NotificationLowRiskFieldValidation.class,
-      message = "{uk.gov.defra.tracesx.notificationschema.representation.partone.euimp"
-          + ".commodities.complementParameterSet.quantity.not.null}")
+      message =
+          "{uk.gov.defra.tracesx.notificationschema.representation.partone.euimp"
+              + ".commodities.complementParameterSet.quantity.not.null}")
   private List<ComplementParameterSet> complementParameterSet = null;
 
   private Boolean includeNonAblactedAnimals = null;
@@ -168,5 +176,12 @@ public class Commodities {
     }
     this.complementParameterSet.add(complementParameterSetItem);
     return this;
+  }
+
+  @JsonIgnore
+  public boolean isArticle72Consignment() {
+    return Optional.ofNullable(this.isLowRiskArticle72Country).orElse(false)
+        && this.complementParameterSet != null
+        && this.complementParameterSet.stream().allMatch(ComplementParameterSet::isArticle72);
   }
 }

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/ComplementParameterSet.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/ComplementParameterSet.java
@@ -1,5 +1,6 @@
 package uk.gov.defra.tracesx.notificationschema.representation;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import lombok.AccessLevel;
@@ -15,6 +16,7 @@ import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCve
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 import javax.validation.Valid;
 
@@ -84,5 +86,13 @@ public class ComplementParameterSet {
     }
     this.keyDataPair.add(keyDataPairItem);
     return this;
+  }
+
+  @JsonIgnore
+  public boolean isArticle72() {
+    return this.keyDataPair.stream().filter(Objects::nonNull)
+        .anyMatch(keyDataPair ->
+            LOW_RISK_ARTICLE_72_COMMODITY.equals(keyDataPair.getKey())
+            && Boolean.parseBoolean(keyDataPair.getData()));
   }
 }

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedppPodRequiredValidator.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedppPodRequiredValidator.java
@@ -1,7 +1,9 @@
 package uk.gov.defra.tracesx.notificationschema.validation.annotations;
 
+import uk.gov.defra.tracesx.notificationschema.representation.Commodities;
 import uk.gov.defra.tracesx.notificationschema.representation.PartOne;
 
+import java.util.Optional;
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
 
@@ -11,6 +13,11 @@ public class ChedppPodRequiredValidator implements ConstraintValidator<ChedppPod
 
   @Override
   public boolean isValid(PartOne partOne, ConstraintValidatorContext constraintValidatorContext) {
+    if (partOne != null && Optional.ofNullable(partOne.getCommodities())
+        .map(Commodities::isArticle72Consignment).orElse(false)) {
+      return true;
+    }
+
     if (partOne == null || partOne.getPointOfEntryControlPoint() == null) {
       return true;
     }

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/PhytosanitaryCertificateRequiredValidator.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/PhytosanitaryCertificateRequiredValidator.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.validation.annotations;
 
-import static uk.gov.defra.tracesx.notificationschema.representation.ComplementParameterSet.LOW_RISK_ARTICLE_72_COMMODITY;
 import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.DocumentType.PHYTOSANITARY_CERTIFICATE;
 
 import uk.gov.defra.tracesx.notificationschema.representation.AccompanyingDocument;
@@ -11,28 +10,24 @@ import uk.gov.defra.tracesx.notificationschema.representation.PartOne;
 import uk.gov.defra.tracesx.notificationschema.representation.VeterinaryInformation;
 
 import java.util.Collection;
-import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
 
-public class PhytosanitaryCertificateRequiredValidator implements
-    ConstraintValidator<PhytosanitaryCertificateRequired, PartOne> {
+public class PhytosanitaryCertificateRequiredValidator
+    implements ConstraintValidator<PhytosanitaryCertificateRequired, PartOne> {
 
   private static final String REGULATORY_AUTHORITY = "regulatory_authority";
   private static final String JOINT = "JOINT";
   private static final String PHSI = "PHSI";
 
-  private static boolean isRegulatoryAuthority(
-      ComplementParameterSetKeyDataPair keyDataPair) {
-    return keyDataPair.getKey() != null
-        && keyDataPair.getKey().equals(REGULATORY_AUTHORITY);
+  private static boolean isRegulatoryAuthority(ComplementParameterSetKeyDataPair keyDataPair) {
+    return REGULATORY_AUTHORITY.equals(keyDataPair.getKey());
   }
 
   private static boolean isPhsiOrJoint(ComplementParameterSetKeyDataPair keyDataPair) {
-    return keyDataPair.getData() != null
-        && (keyDataPair.getData().equals(PHSI) || keyDataPair.getData().equals(JOINT));
+    return PHSI.equals(keyDataPair.getData()) || JOINT.equals(keyDataPair.getData());
   }
 
   private static boolean hasPhsiOrJoint(PartOne partOne) {
@@ -46,25 +41,6 @@ public class PhytosanitaryCertificateRequiredValidator implements
         .filter(Objects::nonNull)
         .filter(PhytosanitaryCertificateRequiredValidator::isRegulatoryAuthority)
         .anyMatch(PhytosanitaryCertificateRequiredValidator::isPhsiOrJoint);
-  }
-
-  private boolean isArticle72Consignment(PartOne partOne) {
-    return isArticle72Country(partOne.getCommodities())
-        && partOne.getCommodities().getComplementParameterSet().stream()
-            .map(ComplementParameterSet::getKeyDataPair)
-            .allMatch(this::isArticle72Commodity);
-  }
-
-  private boolean isArticle72Commodity(List<ComplementParameterSetKeyDataPair> keyDataPairs) {
-    return keyDataPairs.stream()
-        .anyMatch(
-            keyDataPair ->
-                Objects.equals(keyDataPair.getKey(), LOW_RISK_ARTICLE_72_COMMODITY)
-                    && Objects.equals(keyDataPair.getData(), Boolean.TRUE.toString()));
-  }
-
-  private boolean isArticle72Country(Commodities commodities) {
-    return Optional.ofNullable(commodities.getIsLowRiskArticle72Country()).orElse(false);
   }
 
   private static boolean hasPhytosanitaryCertificate(PartOne partOne) {
@@ -84,7 +60,8 @@ public class PhytosanitaryCertificateRequiredValidator implements
 
   @Override
   public boolean isValid(PartOne partOne, ConstraintValidatorContext constraintValidatorContext) {
-    if (!isArticle72Consignment(partOne) && hasPhsiOrJoint(partOne)) {
+    if (!Optional.ofNullable(partOne.getCommodities())
+        .map(Commodities::isArticle72Consignment).orElse(false) && hasPhsiOrJoint(partOne)) {
       return hasPhytosanitaryCertificate(partOne);
     } else {
       return true;

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/CommoditiesTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/CommoditiesTest.java
@@ -1,14 +1,21 @@
 package uk.gov.defra.tracesx.notificationschema.representation;
 
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static uk.gov.defra.tracesx.notificationschema.representation.ComplementParameterSet.LOW_RISK_ARTICLE_72_COMMODITY;
 
 import org.junit.Test;
+
+import java.util.List;
+import java.util.UUID;
 
 public class CommoditiesTest {
 
   @Test
   public void checkAddCommodityComplementItemWithNullList() {
-
     Commodities commodities = new Commodities();
 
     commodities.setCommodityComplement(null);
@@ -21,7 +28,6 @@ public class CommoditiesTest {
 
   @Test
   public void checkAddComplementParameterSetItemWithNullList() {
-
     Commodities commodities = new Commodities();
 
     commodities.setComplementParameterSet(null);
@@ -30,5 +36,72 @@ public class CommoditiesTest {
         .addComplementParameterSetItem(new ComplementParameterSet());
 
     assertEquals(2, commodities.getComplementParameterSet().size());
+  }
+
+  @Test
+  public void isArticle72Consignment_ReturnsFalse_WhenComplementParameterSetIsNull() {
+    Commodities commodities = Commodities.builder()
+        .isLowRiskArticle72Country(true)
+        .build();
+
+    assertFalse(commodities.isArticle72Consignment());
+  }
+
+  @Test
+  public void isArticle72Consignment_ReturnsFalse_WhenIsLowRiskArticle72CountryIsNull() {
+    Commodities commodities = Commodities.builder()
+        .complementParameterSet(List.of(
+            buildComplementParameterSet(TRUE),
+            buildComplementParameterSet(TRUE)
+        )).build();
+
+    assertFalse(commodities.isArticle72Consignment());
+  }
+
+  @Test
+  public void isArticle72Consignment_ReturnsFalse_WhenIsLowRiskArticle72CountryIsFalse() {
+    Commodities commodities = Commodities.builder()
+        .isLowRiskArticle72Country(false)
+        .complementParameterSet(List.of(
+            buildComplementParameterSet(TRUE),
+            buildComplementParameterSet(TRUE)
+        )).build();
+
+    assertFalse(commodities.isArticle72Consignment());
+  }
+
+  @Test
+  public void isArticle72Consignment_ReturnsFalse_WhenNotAllCommoditiesAreArticle72() {
+    Commodities commodities = Commodities.builder()
+        .isLowRiskArticle72Country(true)
+        .complementParameterSet(List.of(
+            buildComplementParameterSet(FALSE),
+            buildComplementParameterSet(TRUE)
+        )).build();
+
+    assertFalse(commodities.isArticle72Consignment());
+  }
+
+  @Test
+  public void isArticle72Consignment_ReturnsTrue_WhenAllCommoditiesAreArticle72() {
+    Commodities commodities = Commodities.builder()
+        .isLowRiskArticle72Country(true)
+        .complementParameterSet(List.of(
+            buildComplementParameterSet(TRUE),
+            buildComplementParameterSet(TRUE)
+        )).build();
+
+    assertTrue(commodities.isArticle72Consignment());
+  }
+
+  private ComplementParameterSet buildComplementParameterSet(Boolean isLowRiskArticle72Commodity) {
+    return ComplementParameterSet.builder()
+        .uniqueComplementID(UUID.randomUUID())
+        .keyDataPair(List.of(
+            ComplementParameterSetKeyDataPair.builder()
+                .key(LOW_RISK_ARTICLE_72_COMMODITY)
+                .data(isLowRiskArticle72Commodity.toString())
+                .build()
+        )).build();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/ComplementParameterSetTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/ComplementParameterSetTest.java
@@ -1,0 +1,52 @@
+package uk.gov.defra.tracesx.notificationschema.representation;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static uk.gov.defra.tracesx.notificationschema.representation.ComplementParameterSet.COMMODITY_GROUP;
+import static uk.gov.defra.tracesx.notificationschema.representation.ComplementParameterSet.LOW_RISK_ARTICLE_72_COMMODITY;
+import static uk.gov.defra.tracesx.notificationschema.representation.ComplementParameterSet.QUANTITY;
+
+import org.junit.Test;
+
+import java.util.List;
+
+public class ComplementParameterSetTest {
+
+  @Test
+  public void isArticle72_ReturnsFalse_WhenDoesNotContainLowRiskArticle72CommodityKey() {
+    ComplementParameterSet complementParameterSet = ComplementParameterSet.builder()
+        .keyDataPair(List.of(
+            ComplementParameterSetKeyDataPair.builder().key(QUANTITY).data("1").build(),
+            ComplementParameterSetKeyDataPair.builder().key(COMMODITY_GROUP).data("true").build()
+        ))
+        .build();
+
+    assertFalse(complementParameterSet.isArticle72());
+  }
+
+  @Test
+  public void isArticle72_ReturnsFalse_WhenLowRiskArticle72CommodityIsFalse() {
+    ComplementParameterSet complementParameterSet = ComplementParameterSet.builder()
+        .keyDataPair(List.of(
+            ComplementParameterSetKeyDataPair.builder().key(QUANTITY).data("1").build(),
+            ComplementParameterSetKeyDataPair.builder().key(LOW_RISK_ARTICLE_72_COMMODITY)
+                .data("false").build()
+        ))
+        .build();
+
+    assertFalse(complementParameterSet.isArticle72());
+  }
+
+  @Test
+  public void isArticle72_ReturnsTrue_WhenLowRiskArticle72CommodityIsTrue() {
+    ComplementParameterSet complementParameterSet = ComplementParameterSet.builder()
+        .keyDataPair(List.of(
+            ComplementParameterSetKeyDataPair.builder().key(QUANTITY).data("1").build(),
+            ComplementParameterSetKeyDataPair.builder().key(LOW_RISK_ARTICLE_72_COMMODITY)
+                .data("true").build()
+        ))
+        .build();
+
+    assertTrue(complementParameterSet.isArticle72());
+  }
+}

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedppPodRequiredValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedppPodRequiredValidatorTest.java
@@ -1,13 +1,20 @@
 package uk.gov.defra.tracesx.notificationschema.validation.annotations;
 
+import static java.lang.Boolean.TRUE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.defra.tracesx.notificationschema.representation.ComplementParameterSet.LOW_RISK_ARTICLE_72_COMMODITY;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.defra.tracesx.notificationschema.representation.Commodities;
+import uk.gov.defra.tracesx.notificationschema.representation.ComplementParameterSet;
+import uk.gov.defra.tracesx.notificationschema.representation.ComplementParameterSetKeyDataPair;
 import uk.gov.defra.tracesx.notificationschema.representation.EconomicOperator;
 import uk.gov.defra.tracesx.notificationschema.representation.PartOne;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import java.util.List;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ChedppPodRequiredValidatorTest {
@@ -83,5 +90,36 @@ public class ChedppPodRequiredValidatorTest {
 
     // Then
     assertThat(result).isTrue();
+  }
+
+  @Test
+  public void isValid_ReturnsTrue_WhenConsignmentIsArticle72() {
+    partOne.setCommodities(Commodities.builder()
+        .isLowRiskArticle72Country(true)
+        .complementParameterSet(List.of(
+            ComplementParameterSet.builder()
+                .keyDataPair(List.of(
+                    ComplementParameterSetKeyDataPair.builder()
+                        .key(LOW_RISK_ARTICLE_72_COMMODITY)
+                        .data(TRUE.toString())
+                        .build()
+                )).build()
+        )).build());
+
+    boolean result = validator.isValid(partOne, null);
+
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  public void isValid_ReturnsFalse_WhenConsignmentIsNotArticle72() {
+    partOne.setPointOfEntryControlPoint(VIA_TEMPORARY_PLACE_OF_DESTINATION);
+    partOne.setCommodities(Commodities.builder()
+        .isLowRiskArticle72Country(false)
+        .build());
+
+    boolean result = validator.isValid(partOne, null);
+
+    assertThat(result).isFalse();
   }
 }


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Piotr Dudkiewicz |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [IMTA-10708: Removed inspection premise v...](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/241) |
> | **GitLab MR Number** | [241](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/241) |
> | **Date Originally Opened** | Tue, 16 Nov 2021 |
> | **Approved on GitLab by** | Callum Atwal (kainos), James Taylor (kainos), Lewis Birks (Kainos), Reece Bennett (KAINOS), Sean Treanor (KAINOS), lee mason (KAINOS) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: Ticket: https://eaflood.atlassian.net/browse/IMTA-10708
### :book: Changes:
* Removed inspection premise validation for Low Risk Article 72 consignments