### PR TITLE
IMTA-11183: EU ChedA - Means of Transport after BCP only required for Airplane

### DIFF
--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/EconomicOperator.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/EconomicOperator.java
@@ -24,7 +24,7 @@ public class EconomicOperator {
   private String id;
 
   @NotNull(
-      groups = TransporterDetailsRequiredValidation.class,
+      groups = {NotificationCvedaFieldValidation.class, TransporterDetailsRequiredValidation.class},
       message =
           "{uk.gov.defra.tracesx.notificationschema.representation.partone.transporter.type.not"
               + ".null}")
@@ -38,7 +38,7 @@ public class EconomicOperator {
   private EconomicOperatorStatus status;
 
   @NotNull(
-      groups = TransporterDetailsRequiredValidation.class,
+      groups = {NotificationCvedaFieldValidation.class, TransporterDetailsRequiredValidation.class},
       message =
           "{uk.gov.defra.tracesx.notificationschema.representation.partone.transporter"
               + ".companyname.not.null}")
@@ -51,7 +51,7 @@ public class EconomicOperator {
   private String otherIdentifier;
 
   @NotNull(
-      groups = TransporterDetailsRequiredValidation.class,
+      groups = {NotificationCvedaFieldValidation.class, TransporterDetailsRequiredValidation.class},
       message =
           "{uk.gov.defra.tracesx.notificationschema.representation.partone.transporter.address"
               + ".not.null}")

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/MeansOfTransportAfterBip.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/MeansOfTransportAfterBip.java
@@ -9,6 +9,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.TransportMethod;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.TransporterDetailsRequiredCEDorChedppValidation;
+import uk.gov.defra.tracesx.notificationschema.validation.groups.TransporterDetailsRequiredCvedaValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.TransporterDetailsRequiredValidation;
 
 import javax.validation.constraints.NotEmpty;
@@ -25,7 +26,8 @@ public class MeansOfTransportAfterBip implements MeansOfTransport {
       message =
           "{uk.gov.defra.tracesx.notificationschema.representation.partone.meansoftransport.id"
               + ".not.empty}",
-      groups = {TransporterDetailsRequiredValidation.class,
+      groups = {TransporterDetailsRequiredCvedaValidation.class,
+          TransporterDetailsRequiredValidation.class,
           TransporterDetailsRequiredCEDorChedppValidation.class})
   private String id = null;
 
@@ -33,7 +35,8 @@ public class MeansOfTransportAfterBip implements MeansOfTransport {
       message =
           "{uk.gov.defra.tracesx.notificationschema.representation.partone.meansoftransport.type"
               + ".not.null}",
-      groups = {TransporterDetailsRequiredValidation.class,
+      groups = {TransporterDetailsRequiredCvedaValidation.class,
+          TransporterDetailsRequiredValidation.class,
           TransporterDetailsRequiredCEDorChedppValidation.class})
   private TransportMethod type = null;
 
@@ -41,7 +44,8 @@ public class MeansOfTransportAfterBip implements MeansOfTransport {
       message =
           "{uk.gov.defra.tracesx.notificationschema.representation.partone.meansoftransport"
               + ".document.not.empty}",
-      groups = {TransporterDetailsRequiredValidation.class,
+      groups = {TransporterDetailsRequiredCvedaValidation.class,
+          TransporterDetailsRequiredValidation.class,
           TransporterDetailsRequiredCEDorChedppValidation.class})
   private String document = null;
 }

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/PartOne.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/PartOne.java
@@ -47,6 +47,7 @@ import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationLow
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationVeterinaryApprovedEstablishmentValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.PointOfEntryControlPointValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.TransporterDetailsRequiredCEDorChedppValidation;
+import uk.gov.defra.tracesx.notificationschema.validation.groups.TransporterDetailsRequiredCvedaValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.TransporterDetailsRequiredValidation;
 
 import java.time.LocalDate;
@@ -259,7 +260,8 @@ public class PartOne {
 
   @Valid
   @NotNull(
-      groups = TransporterDetailsRequiredValidation.class,
+      groups = {TransporterDetailsRequiredCvedaValidation.class,
+          TransporterDetailsRequiredValidation.class},
       message = "{uk.gov.defra.tracesx.notificationschema.representation.partone.transporter"
           + ".not.null}")
   private EconomicOperator transporter;
@@ -268,7 +270,8 @@ public class PartOne {
 
   @Valid
   @NotNull(
-      groups = {TransporterDetailsRequiredValidation.class,
+      groups = {TransporterDetailsRequiredCvedaValidation.class,
+          TransporterDetailsRequiredValidation.class,
           TransporterDetailsRequiredCEDorChedppValidation.class},
       message =
           "{uk.gov.defra.tracesx.notificationschema.representation.partone.meansoftransport.not"
@@ -284,8 +287,9 @@ public class PartOne {
   private MeansOfTransportBeforeBip meansOfTransportFromEntryPoint;
 
   @NotNull(
-      groups = {TransporterDetailsRequiredValidation.class,
-          TransporterDetailsRequiredCEDorChedppValidation.class},
+      groups = {TransporterDetailsRequiredCvedaValidation.class,
+          TransporterDetailsRequiredValidation.class,
+          TransporterDetailsRequiredCEDorChedppValidation.class,},
       message = "{uk.gov.defra.tracesx.notificationschema.representation.partone.departuredate"
           + ".not.null}")
   @JsonSerialize(using = IsoDateSerializer.class)
@@ -293,7 +297,8 @@ public class PartOne {
   private LocalDate departureDate;
 
   @NotNull(
-      groups = {TransporterDetailsRequiredValidation.class,
+      groups = {TransporterDetailsRequiredCvedaValidation.class,
+          TransporterDetailsRequiredValidation.class,
           TransporterDetailsRequiredCEDorChedppValidation.class},
       message = "{uk.gov.defra.tracesx.notificationschema.representation.partone.departuretime"
           + ".not.null}")
@@ -302,14 +307,14 @@ public class PartOne {
   private LocalTime departureTime;
 
   @NotNull(
-      groups = {TransporterDetailsRequiredValidation.class},
+      groups = {TransporterDetailsRequiredCvedaValidation.class},
       message =
           "{uk.gov.defra.tracesx.notificationschema.representation.partone"
               + ".estimatedjourneytimeinminutes.not.null}")
   private Integer estimatedJourneyTimeInMinutes;
 
   @NotEmpty(
-      groups = TransporterDetailsRequiredValidation.class,
+      groups = TransporterDetailsRequiredCvedaValidation.class,
       message =
           "{uk.gov.defra.tracesx.notificationschema.representation.partone"
               + ".responsiblefortransport.not.empty}")

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/groups/TransporterDetailsRequiredCvedaValidation.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/groups/TransporterDetailsRequiredCvedaValidation.java
@@ -1,0 +1,5 @@
+package uk.gov.defra.tracesx.notificationschema.validation.groups;
+
+public interface TransporterDetailsRequiredCvedaValidation {
+
+}


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Kelly Moore |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [IMTA-11183: EU ChedA - Means of Transpor...](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/252) |
> | **GitLab MR Number** | [252](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/252) |
> | **Date Originally Opened** | Thu, 17 Feb 2022 |
> | **Approved on GitLab by** | Lewis Birks (Kainos), Reece Bennett (KAINOS), Stephen Donaghey (KAINOS) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: Ticket: https://eaflood.atlassian.net/browse/IMTA-11183

### :book: Changes:
For EU CHEDA:
- Create new `TransporterDetailsRequiredCvedaValidation` group to include all fields that are required for Cveda. This group will be conditionally added if Cveda notification is not high risk, or is high risk and means of transport before BCP if Airplane
- No longer using `TransporterDetailsRequiredValidation` for Cveda A(which was always added for Cveda). Economic Operator is always required for Cveda, therefore adding `NotificationCvedaFieldValidation` group.
- Reverting estimatedJourneyTime and responsibleForTransport to only required for Cveda Transport details