### PR TITLE
IMTA-11251: Separate validation messages for EU CHEDA

### DIFF
--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/Applicant.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/Applicant.java
@@ -10,6 +10,7 @@ import lombok.NoArgsConstructor;
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.AnalysisType;
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.ConservationOfSample;
 import uk.gov.defra.tracesx.notificationschema.validation.ErrorCodes;
+import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCvedaEuFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationHighRiskFieldValidation;
 
 import javax.validation.constraints.NotNull;
@@ -23,7 +24,12 @@ public class Applicant {
 
   private AnalysisType analysisType;
 
-  @NotNull(groups = NotificationHighRiskFieldValidation.class, message = ErrorCodes.NOT_NULL)
+  @NotNull(
+      groups = {
+          NotificationHighRiskFieldValidation.class,
+          NotificationCvedaEuFieldValidation.class
+      },
+      message = ErrorCodes.NOT_NULL)
   private String laboratory;
 
   private String laboratoryAddress;
@@ -31,16 +37,36 @@ public class Applicant {
   private String laboratoryEmail;
   private String laboratoryPhoneNumber;
 
-  @NotNull(groups = NotificationHighRiskFieldValidation.class, message = ErrorCodes.NOT_NULL)
+  @NotNull(
+      groups = {
+              NotificationHighRiskFieldValidation.class,
+              NotificationCvedaEuFieldValidation.class
+      },
+      message = ErrorCodes.NOT_NULL)
   private String sampleBatchNumber;
 
-  @NotNull(groups = NotificationHighRiskFieldValidation.class, message = ErrorCodes.NOT_NULL)
+  @NotNull(
+      groups = {
+              NotificationHighRiskFieldValidation.class,
+              NotificationCvedaEuFieldValidation.class
+      },
+      message = ErrorCodes.NOT_NULL)
   private Integer numberOfSamples;
 
-  @NotNull(groups = NotificationHighRiskFieldValidation.class, message = ErrorCodes.NOT_NULL)
+  @NotNull(
+      groups = {
+              NotificationHighRiskFieldValidation.class,
+              NotificationCvedaEuFieldValidation.class
+      },
+      message = ErrorCodes.NOT_NULL)
   private String sampleType;
 
-  @NotNull(groups = NotificationHighRiskFieldValidation.class, message = ErrorCodes.NOT_NULL)
+  @NotNull(
+      groups = {
+              NotificationHighRiskFieldValidation.class,
+              NotificationCvedaEuFieldValidation.class
+      },
+      message = ErrorCodes.NOT_NULL)
   private ConservationOfSample conservationOfSample;
 
   private Inspector inspector;

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/ApprovedEstablishment.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/ApprovedEstablishment.java
@@ -8,6 +8,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import uk.gov.defra.tracesx.notificationschema.validation.ErrorCodes;
+import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCvedaEuFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCvedaFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationHighRiskFieldValidation;
 
@@ -26,7 +27,12 @@ public class ApprovedEstablishment {
   @NotNull(groups = NotificationCvedaFieldValidation.class, message = ErrorCodes.NOT_NULL)
   private String name;
 
-  @NotNull(groups = NotificationHighRiskFieldValidation.class, message = ErrorCodes.NOT_NULL)
+  @NotNull(
+      groups = {
+          NotificationHighRiskFieldValidation.class,
+          NotificationCvedaEuFieldValidation.class
+      },
+      message = ErrorCodes.NOT_NULL)
   private String country;
 
   private List<String> types;

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/Commodities.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/Commodities.java
@@ -19,16 +19,15 @@ import uk.gov.defra.tracesx.notificationschema.validation.annotations.QuantityIm
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCedOrCvedpFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCedOrCvedpOrChedppFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationChedppFieldValidation;
+import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCvedaEuFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCvedaFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationHighRiskFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationLowRiskFieldValidation;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Stream;
 import javax.validation.Valid;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
@@ -127,7 +126,10 @@ public class Commodities {
   private Boolean includeNonAblactedAnimals = null;
 
   @NotNull(
-      groups = NotificationHighRiskFieldValidation.class,
+      groups = {
+          NotificationHighRiskFieldValidation.class,
+          NotificationCvedaEuFieldValidation.class
+      },
       message =
           "{uk.gov.defra.tracesx.notificationschema.representation.partone.commodities"
               + ".countryoforigin.not.null}")

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/ContactDetails.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/ContactDetails.java
@@ -8,10 +8,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import uk.gov.defra.tracesx.notificationschema.validation.annotations.ContactDetailsEmailOrTelephoneRequired;
-import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCedOrCvedpFieldValidation;
-import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationHighRiskEUDocumentCheckValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationHighRiskEuChedValidation;
-import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationHighRiskFieldValidation;
 
 import javax.validation.constraints.NotNull;
 

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/InternationalTelephone.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/InternationalTelephone.java
@@ -8,6 +8,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import uk.gov.defra.tracesx.notificationschema.validation.ErrorCodes;
+import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCvedaEuFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationHighRiskFieldValidation;
 
 import javax.validation.constraints.NotNull;
@@ -19,9 +20,19 @@ import javax.validation.constraints.NotNull;
 @AllArgsConstructor(access = AccessLevel.PUBLIC)
 public class InternationalTelephone {
 
-  @NotNull(groups = NotificationHighRiskFieldValidation.class, message = ErrorCodes.NOT_NULL)
+  @NotNull(
+      groups = {
+          NotificationHighRiskFieldValidation.class,
+          NotificationCvedaEuFieldValidation.class
+      },
+      message = ErrorCodes.NOT_NULL)
   private String countryCode;
 
-  @NotNull(groups = NotificationHighRiskFieldValidation.class, message = ErrorCodes.NOT_NULL)
+  @NotNull(
+      groups = {
+          NotificationHighRiskFieldValidation.class,
+          NotificationCvedaEuFieldValidation.class
+      },
+      message = ErrorCodes.NOT_NULL)
   private String subscriberNumber;
 }

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/MeansOfTransportAfterBip.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/MeansOfTransportAfterBip.java
@@ -9,11 +9,12 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.TransportMethod;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.TransporterDetailsRequiredCEDorChedppValidation;
-import uk.gov.defra.tracesx.notificationschema.validation.groups.TransporterDetailsRequiredCvedaValidation;
+import uk.gov.defra.tracesx.notificationschema.validation.groups.TransporterDetailsRequiredEuCvedaValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.TransporterDetailsRequiredValidation;
 
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
+
 
 @Builder
 @Data
@@ -26,17 +27,21 @@ public class MeansOfTransportAfterBip implements MeansOfTransport {
       message =
           "{uk.gov.defra.tracesx.notificationschema.representation.partone.meansoftransport.id"
               + ".not.empty}",
-      groups = {TransporterDetailsRequiredCvedaValidation.class,
+      groups = {TransporterDetailsRequiredEuCvedaValidation.class,
           TransporterDetailsRequiredValidation.class,
           TransporterDetailsRequiredCEDorChedppValidation.class})
   private String id = null;
 
   @NotNull(
       message =
+        "{uk.gov.defra.tracesx.notificationschema.representation.partone.meansoftransport.type"
+          + ".eucveda.not.null}",
+      groups = {TransporterDetailsRequiredEuCvedaValidation.class})
+  @NotNull(
+      message =
           "{uk.gov.defra.tracesx.notificationschema.representation.partone.meansoftransport.type"
               + ".not.null}",
-      groups = {TransporterDetailsRequiredCvedaValidation.class,
-          TransporterDetailsRequiredValidation.class,
+      groups = {TransporterDetailsRequiredValidation.class,
           TransporterDetailsRequiredCEDorChedppValidation.class})
   private TransportMethod type = null;
 
@@ -44,8 +49,10 @@ public class MeansOfTransportAfterBip implements MeansOfTransport {
       message =
           "{uk.gov.defra.tracesx.notificationschema.representation.partone.meansoftransport"
               + ".document.not.empty}",
-      groups = {TransporterDetailsRequiredCvedaValidation.class,
+      groups = {
+          TransporterDetailsRequiredEuCvedaValidation.class,
           TransporterDetailsRequiredValidation.class,
-          TransporterDetailsRequiredCEDorChedppValidation.class})
+          TransporterDetailsRequiredCEDorChedppValidation.class
+      })
   private String document = null;
 }

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/MeansOfTransportBeforeBip.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/MeansOfTransportBeforeBip.java
@@ -8,6 +8,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.TransportMethod;
+import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCvedaEuFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationHighRiskFieldValidation;
 
 import javax.validation.constraints.NotEmpty;
@@ -21,7 +22,10 @@ import javax.validation.constraints.NotNull;
 public class MeansOfTransportBeforeBip implements MeansOfTransport {
 
   @NotEmpty(
-      groups = NotificationHighRiskFieldValidation.class,
+      groups = {
+          NotificationHighRiskFieldValidation.class,
+          NotificationCvedaEuFieldValidation.class
+      },
       message =
           "{uk.gov.defra.tracesx.notificationschema.representation.partone"
               + ".meansoftransportfromentrypoint.id.not.empty}")
@@ -30,12 +34,20 @@ public class MeansOfTransportBeforeBip implements MeansOfTransport {
   @NotNull(
       groups = NotificationHighRiskFieldValidation.class,
       message =
+              "{uk.gov.defra.tracesx.notificationschema.representation.partone"
+                      + ".meansoftransportfromentrypoint.type.not.null}")
+  @NotNull(
+      groups = NotificationCvedaEuFieldValidation.class,
+      message =
           "{uk.gov.defra.tracesx.notificationschema.representation.partone"
-              + ".meansoftransportfromentrypoint.type.not.null}")
+              + ".meansoftransportfromentrypoint.type.eucveda.not.null}")
   private TransportMethod type = null;
 
   @NotEmpty(
-      groups = NotificationHighRiskFieldValidation.class,
+      groups = {
+          NotificationHighRiskFieldValidation.class,
+          NotificationCvedaEuFieldValidation.class
+      },
       message =
           "{uk.gov.defra.tracesx.notificationschema.representation.partone"
               + ".meansoftransportfromentrypoint.document.not.empty}")

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/Notification.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/Notification.java
@@ -22,9 +22,11 @@ import uk.gov.defra.tracesx.notificationschema.validation.annotations.ChedppEsti
 import uk.gov.defra.tracesx.notificationschema.validation.annotations.ValidStatus;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.BasicValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationChedppFieldValidation;
+import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCvedaEuFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationHighRiskFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationPart3FieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationVeterinaryValidation;
+
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -95,7 +97,12 @@ public class Notification {
 
   private Boolean isHighRiskEuImport;
 
-  @NotNull(groups = NotificationHighRiskFieldValidation.class, message = ErrorCodes.NOT_NULL)
+  @NotNull(
+      groups = {
+          NotificationHighRiskFieldValidation.class,
+          NotificationCvedaEuFieldValidation.class
+      },
+      message = ErrorCodes.NOT_NULL)
   private PartOne partOne;
 
   @ApiModelProperty(value = "Identification of the user checking the consignment")

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/NotificationSealsContainers.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/NotificationSealsContainers.java
@@ -7,6 +7,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCvedaEuFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationHighRiskFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationHighRiskNonChedppFieldValidation;
 
@@ -20,7 +21,10 @@ import javax.validation.constraints.NotBlank;
 public class NotificationSealsContainers {
 
   @NotBlank(
-      groups = NotificationHighRiskFieldValidation.class,
+      groups = {
+          NotificationHighRiskFieldValidation.class,
+          NotificationCvedaEuFieldValidation.class
+      },
       message = "Seal number cannot be empty")
   private String sealNumber;
 

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/PartOne.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/PartOne.java
@@ -40,6 +40,7 @@ import uk.gov.defra.tracesx.notificationschema.validation.annotations.NotNullWoo
 import uk.gov.defra.tracesx.notificationschema.validation.annotations.PhytosanitaryCertificateRequired;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCedFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationChedppFieldValidation;
+import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCvedaEuFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCvedaFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationHighRiskEuChedValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationHighRiskFieldValidation;
@@ -47,7 +48,7 @@ import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationLow
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationVeterinaryApprovedEstablishmentValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.PointOfEntryControlPointValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.TransporterDetailsRequiredCEDorChedppValidation;
-import uk.gov.defra.tracesx.notificationschema.validation.groups.TransporterDetailsRequiredCvedaValidation;
+import uk.gov.defra.tracesx.notificationschema.validation.groups.TransporterDetailsRequiredEuCvedaValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.TransporterDetailsRequiredValidation;
 
 import java.time.LocalDate;
@@ -112,7 +113,10 @@ public class PartOne {
 
   @Valid
   @NotNull(
-      groups = NotificationHighRiskFieldValidation.class,
+      groups = {
+          NotificationHighRiskFieldValidation.class,
+          NotificationCvedaEuFieldValidation.class
+      },
       message = "{uk.gov.defra.tracesx.notificationschema.representation.partone.personResponsible"
           + ".not.null}")
   private Party personResponsible;
@@ -128,7 +132,10 @@ public class PartOne {
   private Boolean consignmentArrived;
 
   @NotNull(
-      groups = NotificationHighRiskFieldValidation.class,
+      groups = {
+          NotificationHighRiskFieldValidation.class,
+          NotificationCvedaEuFieldValidation.class
+      },
       message = "{uk.gov.defra.tracesx.notificationschema.representation.partone.consignor"
           + ".not.null}")
   private EconomicOperator consignor;
@@ -138,13 +145,19 @@ public class PartOne {
   private EconomicOperator packer;
 
   @NotNull(
-      groups = NotificationHighRiskFieldValidation.class,
+      groups = {
+              NotificationHighRiskFieldValidation.class,
+              NotificationCvedaEuFieldValidation.class
+      },
       message = "{uk.gov.defra.tracesx.notificationschema.representation.partone.consignee"
           + ".not.null}")
   private EconomicOperator consignee;
 
   @NotNull(
-      groups = NotificationHighRiskFieldValidation.class,
+      groups = {
+              NotificationHighRiskFieldValidation.class,
+              NotificationCvedaEuFieldValidation.class
+      },
       message = "{uk.gov.defra.tracesx.notificationschema.representation.partone.importer"
           + ".not.null}")
   @NotNull(
@@ -156,7 +169,8 @@ public class PartOne {
   @NotNull(
       groups = {
           NotificationHighRiskFieldValidation.class,
-          NotificationLowRiskFieldValidation.class
+          NotificationLowRiskFieldValidation.class,
+          NotificationCvedaEuFieldValidation.class
       },
       message =
           "{uk.gov.defra.tracesx.notificationschema.representation.partone.deliveryaddress.not"
@@ -173,7 +187,10 @@ public class PartOne {
 
   @Valid
   @NotNull(
-      groups = NotificationHighRiskFieldValidation.class,
+      groups = {
+              NotificationHighRiskFieldValidation.class,
+              NotificationCvedaEuFieldValidation.class
+      },
       message = "{uk.gov.defra.tracesx.notificationschema.representation.partone.commodities"
           + ".not.null}")
   @ChedppMinValueKeyDataPair(
@@ -222,10 +239,17 @@ public class PartOne {
 
   @Valid
   @NotNull(
-      groups = NotificationHighRiskFieldValidation.class,
+      groups = {
+              NotificationHighRiskFieldValidation.class,
+              NotificationCvedaEuFieldValidation.class
+      },
       message = "{uk.gov.defra.tracesx.notificationschema.representation.partone.purpose.not.null}")
   private Purpose purpose;
 
+  @NotBlank(
+      groups = NotificationCvedaEuFieldValidation.class,
+      message = "{uk.gov.defra.tracesx.notificationschema.representation.partone.pointofentry"
+              + ".eucveda.not.null}")
   @NotBlank(
       groups = NotificationHighRiskFieldValidation.class,
       message = "{uk.gov.defra.tracesx.notificationschema.representation.partone.pointofentry"
@@ -241,7 +265,11 @@ public class PartOne {
   @NotNull(
       groups = NotificationHighRiskFieldValidation.class,
       message = "{uk.gov.defra.tracesx.notificationschema.representation.partone.arrivaldate"
-          + ".not.null}")
+              + ".not.null}")
+  @NotNull(
+      groups = NotificationCvedaEuFieldValidation.class,
+      message = "{uk.gov.defra.tracesx.notificationschema.representation.partone.arrivaldate"
+          + ".eucveda.not.null}")
   @NotNull(
       groups = NotificationLowRiskFieldValidation.class,
       message = "{uk.gov.defra.tracesx.notificationschema.representation.partone.euimp.arrivaldate"
@@ -254,13 +282,17 @@ public class PartOne {
       groups = NotificationHighRiskFieldValidation.class,
       message = "{uk.gov.defra.tracesx.notificationschema.representation.partone.arrivaltime"
           + ".not.null}")
+  @NotNull(
+      groups = NotificationCvedaEuFieldValidation.class,
+      message = "{uk.gov.defra.tracesx.notificationschema.representation.partone.arrivaltime"
+          + ".eucveda.not.null}")
   @JsonSerialize(using = IsoTimeSerializer.class)
   @JsonDeserialize(using = IsoTimeDeserializer.class)
   private LocalTime arrivalTime;
 
   @Valid
   @NotNull(
-      groups = {TransporterDetailsRequiredCvedaValidation.class,
+      groups = {TransporterDetailsRequiredEuCvedaValidation.class,
           TransporterDetailsRequiredValidation.class},
       message = "{uk.gov.defra.tracesx.notificationschema.representation.partone.transporter"
           + ".not.null}")
@@ -270,7 +302,7 @@ public class PartOne {
 
   @Valid
   @NotNull(
-      groups = {TransporterDetailsRequiredCvedaValidation.class,
+      groups = {TransporterDetailsRequiredEuCvedaValidation.class,
           TransporterDetailsRequiredValidation.class,
           TransporterDetailsRequiredCEDorChedppValidation.class},
       message =
@@ -280,14 +312,16 @@ public class PartOne {
 
   @Valid
   @NotNull(
-      groups = {NotificationHighRiskFieldValidation.class, NotificationCedFieldValidation.class},
+      groups = {NotificationHighRiskFieldValidation.class,
+          NotificationCedFieldValidation.class,
+          NotificationCvedaEuFieldValidation.class},
       message =
           "{uk.gov.defra.tracesx.notificationschema.representation.partone"
               + ".meansOfTransportFromEntryPoint.not.null}")
   private MeansOfTransportBeforeBip meansOfTransportFromEntryPoint;
 
   @NotNull(
-      groups = {TransporterDetailsRequiredCvedaValidation.class,
+      groups = {TransporterDetailsRequiredEuCvedaValidation.class,
           TransporterDetailsRequiredValidation.class,
           TransporterDetailsRequiredCEDorChedppValidation.class,},
       message = "{uk.gov.defra.tracesx.notificationschema.representation.partone.departuredate"
@@ -297,7 +331,7 @@ public class PartOne {
   private LocalDate departureDate;
 
   @NotNull(
-      groups = {TransporterDetailsRequiredCvedaValidation.class,
+      groups = {TransporterDetailsRequiredEuCvedaValidation.class,
           TransporterDetailsRequiredValidation.class,
           TransporterDetailsRequiredCEDorChedppValidation.class},
       message = "{uk.gov.defra.tracesx.notificationschema.representation.partone.departuretime"
@@ -307,14 +341,16 @@ public class PartOne {
   private LocalTime departureTime;
 
   @NotNull(
-      groups = {TransporterDetailsRequiredCvedaValidation.class},
+      groups = {TransporterDetailsRequiredValidation.class,
+          TransporterDetailsRequiredEuCvedaValidation.class},
       message =
           "{uk.gov.defra.tracesx.notificationschema.representation.partone"
               + ".estimatedjourneytimeinminutes.not.null}")
   private Integer estimatedJourneyTimeInMinutes;
 
   @NotEmpty(
-      groups = TransporterDetailsRequiredCvedaValidation.class,
+      groups = { TransporterDetailsRequiredEuCvedaValidation.class,
+          TransporterDetailsRequiredValidation.class},
       message =
           "{uk.gov.defra.tracesx.notificationschema.representation.partone"
               + ".responsiblefortransport.not.empty}")

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/Party.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/Party.java
@@ -9,6 +9,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.PartyType;
 import uk.gov.defra.tracesx.notificationschema.validation.ErrorCodes;
+import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCvedaEuFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCvedaFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationHighRiskFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationHighRiskNonChedppFieldValidation;
@@ -33,7 +34,8 @@ public class Party {
 
   private String companyName;
 
-  @NotEmpty(groups = NotificationHighRiskNonChedppFieldValidation.class,
+  @NotEmpty(
+      groups = NotificationHighRiskNonChedppFieldValidation.class,
       message = "{uk.gov.defra.tracesx.notificationschema.representation.partone.personResponsible"
       + ".address.not.empty}")
   private List<String> address;
@@ -41,7 +43,12 @@ public class Party {
   private String county;
   private String postCode;
 
-  @NotNull(groups = NotificationHighRiskFieldValidation.class, message = ErrorCodes.NOT_NULL)
+  @NotNull(
+      groups = {
+              NotificationHighRiskFieldValidation.class,
+              NotificationCvedaEuFieldValidation.class
+      },
+      message = ErrorCodes.NOT_NULL)
   private String country;
 
   private String city;

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/Purpose.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/Purpose.java
@@ -11,6 +11,7 @@ import uk.gov.defra.tracesx.notificationschema.representation.enumeration.ForImp
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.ForNonConformingEnum;
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.InternalMarketPurpose;
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.PurposeGroupEnum;
+import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCvedaEuFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationHighRiskFieldValidation;
 
 import java.util.List;
@@ -38,7 +39,10 @@ public class Purpose {
   private String finalBIP;
 
   @NotNull(
-      groups = NotificationHighRiskFieldValidation.class,
+      groups = {
+          NotificationHighRiskFieldValidation.class,
+          NotificationCvedaEuFieldValidation.class
+      },
       message =
           "{uk.gov.defra.tracesx.notificationschema.representation.partone.purpose.purposeGroup"
               + ".not.null}")

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/UserInformation.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/UserInformation.java
@@ -8,6 +8,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import uk.gov.defra.tracesx.notificationschema.validation.ErrorCodes;
+import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCvedaEuFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationHighRiskFieldValidation;
 
 import javax.validation.constraints.NotNull;
@@ -19,10 +20,20 @@ import javax.validation.constraints.NotNull;
 @AllArgsConstructor(access = AccessLevel.PUBLIC)
 public class UserInformation {
 
-  @NotNull(groups = NotificationHighRiskFieldValidation.class, message = ErrorCodes.NOT_NULL)
+  @NotNull(
+      groups = {
+          NotificationHighRiskFieldValidation.class,
+          NotificationCvedaEuFieldValidation.class
+      },
+      message = ErrorCodes.NOT_NULL)
   private String displayName;
 
-  @NotNull(groups = NotificationHighRiskFieldValidation.class, message = ErrorCodes.NOT_NULL)
+  @NotNull(
+      groups = {
+          NotificationHighRiskFieldValidation.class,
+          NotificationCvedaEuFieldValidation.class
+      },
+      message = ErrorCodes.NOT_NULL)
   private String userId;
 
   private Boolean isControlUser;

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/groups/NotificationCvedaEuFieldValidation.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/groups/NotificationCvedaEuFieldValidation.java
@@ -1,5 +1,4 @@
 package uk.gov.defra.tracesx.notificationschema.validation.groups;
 
-public interface TransporterDetailsRequiredCvedaValidation {
-
+public interface NotificationCvedaEuFieldValidation {
 }

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/groups/TransporterDetailsRequiredEuCvedaValidation.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/groups/TransporterDetailsRequiredEuCvedaValidation.java
@@ -1,0 +1,5 @@
+package uk.gov.defra.tracesx.notificationschema.validation.groups;
+
+public interface TransporterDetailsRequiredEuCvedaValidation {
+
+}


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Kelly Moore |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [IMTA-11251: Separate validation messages...](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/254) |
> | **GitLab MR Number** | [254](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/254) |
> | **Date Originally Opened** | Tue, 1 Mar 2022 |
> | **Approved on GitLab by** | Joshua Craig (Kainos), Reece Bennett (KAINOS), Stephen Donaghey (KAINOS), lee mason (KAINOS) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: Ticket: https://eaflood.atlassian.net/browse/IMTA-11251

### :book: Changes:
* Create new validation group for EU CHEDA `NotificationCvedaEUFieldValidation`
  * `NotificationHighRiskFieldValidation` handles a lot of common fields for all CHEDs. Fields that have wording changes for EU CHEDA's were included in this class. Adding `NotificationCvedaEUFieldValidation` to all fields that have `NotificationHighRiskFieldValidation` and then specifying separate messages for EU CHEDA fields in line with content changes in frontend 
  * Conditionally adding `NotificationHighRiskFieldValidation` or `NotificationCvedaEUFieldValidation` in `notification-ms`

Related MRs:
https://giteux.azure.defra.cloud/imports/frontend-notification/merge_requests/1484/
https://giteux.azure.defra.cloud/imports/notification-microservice/merge_requests/877