### PR TITLE
IMTA-11305 CHEDA Purpose - Add sub options to internal market

### DIFF
--- a/notification-schema-core/resources/notification-schema.json
+++ b/notification-schema-core/resources/notification-schema.json
@@ -481,7 +481,19 @@
                 "Human Consumption",
                 "Pharmaceutical Use",
                 "Technical Use",
-                "Other"
+                "Other",
+                "Commercial Sale",
+                "Rescue",
+                "Breeding",
+                "Research",
+                "Racing or Competition",
+                "Approved Premises or Body",
+                "Companion Animal not for Resale or Rehoming",
+                "Production",
+                "Slaughter",
+                "Fattening",
+                "Game Restocking",
+                "Registered Horses"
               ]
             },
             "thirdCountryTranshipment": {

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/InternalMarketPurpose.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/InternalMarketPurpose.java
@@ -7,7 +7,19 @@ public enum InternalMarketPurpose {
   HUMAN_CONSUMPTION("Human Consumption"),
   PHARMACEUTICAL_USE("Pharmaceutical Use"),
   TECHNICAL_USE("Technical Use"),
-  OTHER("Other");
+  OTHER("Other"),
+  COMMERCIAL_SALE("Commercial Sale"),
+  RESCUE("Rescue"),
+  BREEDING("Breeding"),
+  RESEARCH("Research"),
+  RACING("Racing or Competition"),
+  APPROVED_PREMISES("Approved Premises or Body"),
+  COMPANION_ANIMAL("Companion Animal not for Resale or Rehoming"),
+  PRODUCTION("Production"),
+  SLAUGHTER("Slaughter"),
+  FATTENING("Fattening"),
+  GAME_RESTOCKING("Game Restocking"),
+  REGISTERED_HORSES("Registered Horses");
 
   private String value;
 

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/InternalMarketPurposeTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/InternalMarketPurposeTest.java
@@ -1,7 +1,6 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 
@@ -11,29 +10,81 @@ public class InternalMarketPurposeTest {
 
   @Test
   public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
-    String enumResult = InternalMarketPurpose.OTHER.toString();
-
-    assertEquals(enumResult, OTHER_STRING);
+    assertThat(InternalMarketPurpose.OTHER.toString()).isEqualTo(OTHER_STRING);
   }
 
   @Test
   public void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
-    String enumResult = InternalMarketPurpose.OTHER.getValue();
-
-    assertEquals(enumResult, OTHER_STRING);
+    assertThat(InternalMarketPurpose.OTHER.getValue()).isEqualTo(OTHER_STRING);
   }
 
   @Test
   public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
-    InternalMarketPurpose enumResult = InternalMarketPurpose.fromValue(OTHER_STRING);
-
-    assertEquals(enumResult, InternalMarketPurpose.OTHER);
+    assertThat(InternalMarketPurpose.fromValue(OTHER_STRING)).isEqualTo(InternalMarketPurpose.OTHER);
   }
 
   @Test
   public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
-    InternalMarketPurpose enumResult = InternalMarketPurpose.fromValue(INVALID_STRING);
+    assertThat(InternalMarketPurpose.fromValue(INVALID_STRING)).isNull();
+  }
 
-    assertNull(enumResult);
+  @Test
+  public void givenCommercialSale_whenToStringCalled_shouldReturnStringValue() {
+    assertThat(InternalMarketPurpose.COMMERCIAL_SALE.toString()).hasToString("Commercial Sale");
+  }
+
+  @Test
+  public void givenRescue_whenToStringCalled_shouldReturnStringValue() {
+    assertThat(InternalMarketPurpose.RESCUE.toString()).hasToString("Rescue");
+  }
+
+  @Test
+  public void givenBreeding_whenToStringCalled_shouldReturnStringValue() {
+    assertThat(InternalMarketPurpose.BREEDING.toString()).hasToString("Breeding");
+  }
+
+  @Test
+  public void givenResearch_whenToStringCalled_shouldReturnStringValue() {
+    assertThat(InternalMarketPurpose.RESEARCH.toString()).hasToString("Research");
+  }
+
+  @Test
+  public void givenRacing_whenToStringCalled_shouldReturnStringValue() {
+    assertThat(InternalMarketPurpose.RACING.toString()).hasToString("Racing or Competition");
+  }
+
+  @Test
+  public void givenPremises_whenToStringCalled_shouldReturnStringValue() {
+    assertThat(InternalMarketPurpose.APPROVED_PREMISES.toString()).hasToString("Approved Premises or Body");
+  }
+
+  @Test
+  public void givenCompanion_whenToStringCalled_shouldReturnStringValue() {
+    assertThat(InternalMarketPurpose.COMPANION_ANIMAL.toString()).hasToString("Companion Animal not for Resale or Rehoming");
+  }
+
+  @Test
+  public void givenProduction_whenToStringCalled_shouldReturnStringValue() {
+    assertThat(InternalMarketPurpose.PRODUCTION.toString()).hasToString("Production");
+  }
+
+  @Test
+  public void givenSlaughter_whenToStringCalled_shouldReturnStringValue() {
+    assertThat(InternalMarketPurpose.SLAUGHTER.toString()).hasToString("Slaughter");
+  }
+
+  @Test
+  public void givenFattening_whenToStringCalled_shouldReturnStringValue() {
+    assertThat(InternalMarketPurpose.FATTENING.toString()).hasToString("Fattening");
+  }
+
+  @Test
+  public void givenRestocking_whenToStringCalled_shouldReturnStringValue() {
+    assertThat(InternalMarketPurpose.GAME_RESTOCKING.toString()).hasToString("Game Restocking");
+  }
+
+  @Test
+  public void givenHoses_whenToStringCalled_shouldReturnStringValue() {
+    assertThat(InternalMarketPurpose.REGISTERED_HORSES.toString()).hasToString("Registered Horses");
   }
 }


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | kingsley.Osime (Kainos) |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [IMTA-11305 CHEDA Purpose - Add sub optio...](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/258) |
> | **GitLab MR Number** | [258](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/258) |
> | **Date Originally Opened** | Tue, 22 Mar 2022 |
> | **Approved on GitLab by** | Ben Doherty (Kainos), Reece Bennett (KAINOS), Stephen Donaghey (KAINOS) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: Ticket: <https://eaflood.atlassian.net/browse/IMTA-11305>

### :book: Changes:
* Updated `InternalMarketPurpose.java`
* Updated schema definition file
* Updated unit tests