### PR TITLE
IMTA-11610: removed recently added notification flag

### DIFF
--- a/imports-frontend-entities/package-lock.json
+++ b/imports-frontend-entities/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipaffs/imports-frontend-entities",
-  "version": "1.0.203",
+  "version": "1.0.221",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/imports-frontend-entities/package.json
+++ b/imports-frontend-entities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipaffs/imports-frontend-entities",
-  "version": "1.0.220",
+  "version": "1.0.221",
   "repository": {
     "type": "git"
   },

--- a/imports-frontend-entities/src/entities/notification.js
+++ b/imports-frontend-entities/src/entities/notification.js
@@ -31,7 +31,6 @@ module.exports = class Notification {
     this.splitConsignment = obj.splitConsignment ? new SplitConsignment(obj.splitConsignment) : undefined
     this.childNotification = obj.childNotification
     this.isHighRiskEuImport = obj.isHighRiskEuImport
-    this.chedaIncludesEuImpData = obj.chedaIncludesEuImpData
     this.partOne = _.get(obj, 'partOne') ? new PartOne(obj.partOne) : undefined
     this.partTwo = _.get(obj, 'partTwo') ? new PartTwo(obj.partTwo) : undefined
     this.partThree = _.get(obj, 'partThree') ? new PartThree(obj.partThree)

--- a/notification-schema-core/resources/notification-schema.json
+++ b/notification-schema-core/resources/notification-schema.json
@@ -103,10 +103,6 @@
       "type": "boolean",
       "description": "Is this notification a high risk notification from the EU/EEA?"
     },
-    "chedaIncludesEuImpData": {
-      "type": "boolean",
-      "description": "Flag to record whether CHEDA notification should include EU IMP data"
-    },
     "partOne": {
       "javaType": "uk.gov.defra.tracesx.notification.api.PartOne",
       "properties": {

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/Notification.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/Notification.java
@@ -97,8 +97,6 @@ public class Notification {
 
   private Boolean isHighRiskEuImport;
 
-  private Boolean chedaIncludesEuImpData;
-
   @NotNull(
       groups = {
           NotificationHighRiskFieldValidation.class,


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Piotr Dudkiewicz |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [IMTA-11610: removed recently added notif...](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/261) |
> | **GitLab MR Number** | [261](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/261) |
> | **Date Originally Opened** | Tue, 29 Mar 2022 |
> | **Approved on GitLab by** | Blakeley, Paul (Kainos), James Taylor, Lewis Birks (Kainos), Sean Treanor (KAINOS) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: Ticket: <https://eaflood.atlassian.net/browse/IMTA-11610>

### :book: Changes:
* removed `chedaIncludesEuImpData` notification flag as `isHighRiskEuImport` will be used instead