### PR TITLE
IMTA-11904: Bumping package versions to reflect pom version

### DIFF
--- a/imports-frontend-entities/package-lock.json
+++ b/imports-frontend-entities/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipaffs/imports-frontend-entities",
-  "version": "1.0.231",
+  "version": "1.0.238",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/imports-frontend-entities/package.json
+++ b/imports-frontend-entities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipaffs/imports-frontend-entities",
-  "version": "1.0.231",
+  "version": "1.0.238",
   "repository": {
     "type": "git"
   },


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Sean Treanor (KAINOS) |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [IMTA-11904: Bumping package versions to ...](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/282) |
> | **GitLab MR Number** | [282](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/282) |
> | **Date Originally Opened** | Wed, 13 Jul 2022 |
> | **Approved on GitLab by** | Apurva Jhunjhunwala (Kainos), Carl Evans (KAINOS), Jahir, Sifat (KAINOS), Kelly Moore |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: Ticket: https://eaflood.atlassian.net/browse/IMTA-11904
### :book: Changes:
* Updating package version to align with pom version

### :chart_with_upwards_trend: SonarQube Report
[Click here](https://vss-sonarqube.azure.defra.cloud/dashboard?branch=feature/IMTA-11904-business-rules-validation&id=Imports-Notification-Schema) to view the SonarQube report.