### PR TITLE
IMTA-11330: Seal number optional for CHEDP

### DIFF
--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/NotificationSealsContainers.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/NotificationSealsContainers.java
@@ -8,8 +8,10 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import uk.gov.defra.tracesx.notificationschema.validation.annotations.ChedppSealsAndContainers;
+import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCedFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationChedppFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCvedaEuFieldValidation;
+import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCvedaFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationHighRiskNonChedppFieldValidation;
 
 import javax.validation.constraints.NotBlank;
@@ -25,7 +27,8 @@ public class NotificationSealsContainers {
 
   @NotBlank(
       groups = {
-          NotificationHighRiskNonChedppFieldValidation.class,
+          NotificationCedFieldValidation.class,
+          NotificationCvedaFieldValidation.class,
           NotificationCvedaEuFieldValidation.class
       },
       message = "Seal number cannot be empty")


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | kamil mojek (KAINOS) |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [IMTA-11330: Seal number optional for CHE...](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/283) |
> | **GitLab MR Number** | [283](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/283) |
> | **Date Originally Opened** | Thu, 28 Jul 2022 |
> | **Approved on GitLab by** | Ben Doherty (Kainos), Nicholas Martin, lee mason (KAINOS), ramkumar ramagopal (Kainos) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: ticket: https://eaflood.atlassian.net/browse/IMTA-11330

### :book: Changes:

- Seal number is now optional for CHEDP

### :chart_with_upwards_trend: SonarQube Report

[Click here](https://vss-sonarqube.azure.defra.cloud/dashboard?branch=feature%2FIMTA-11330-seal-number-not-mandatory&id=Imports-Notification-Schema) to view the SonarQube report.