### PR TITLE
IMTA-13073: Added property to identify cloned document

### DIFF
--- a/imports-frontend-entities/src/entities/accompanying_document.js
+++ b/imports-frontend-entities/src/entities/accompanying_document.js
@@ -12,6 +12,7 @@ module.exports = class AccompanyingDocument {
     this.attachmentContentType = obj.attachmentContentType
     this.uploadUserId = obj.uploadUserId
     this.uploadOrganisationId = obj.uploadOrganisationId
+    this.externalReference = obj.externalReference
 
     return Object.seal(new Proxy(this, handler))
   }

--- a/notification-schema-core/resources/notification-schema.json
+++ b/notification-schema-core/resources/notification-schema.json
@@ -2497,6 +2497,10 @@
         "uploadOrganisationId": {
           "type": "string",
           "description": "The UUID for the organisation that the upload user is associated with"
+        },
+        "externalReference": {
+          "description": "External reference of accompanying document, which relates to a downstream service",
+          "$ref": "#/definitions/ExternalReference"
         }
       }
     },

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/AccompanyingDocument.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/AccompanyingDocument.java
@@ -38,4 +38,5 @@ public class AccompanyingDocument {
   private String attachmentContentType = null;
   private UUID uploadUserId = null;
   private UUID uploadOrganisationId = null;
+  private ExternalReference externalReference = null;
 }


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Zuzanna Megger (Kainos) |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [IMTA-13073: Added property to identify c...](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/292) |
> | **GitLab MR Number** | [292](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/292) |
> | **Date Originally Opened** | Wed, 16 Nov 2022 |
> | **Approved on GitLab by** | Blakeley, Paul (Kainos), Lewis Birks (Kainos), Nicholas Martin, lee mason (KAINOS) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: [Jira Ticket](https://eaflood.atlassian.net/browse/IMTA-13073)

### :chart_with_upwards_trend: [SonarQube Report](https://vss-sonarqube.azure.defra.cloud/dashboard?branch=feature%2FIMTA-13073-cloned-documents-separation&id=Imports-Notification-Schema)

### :building_construction: [Jenkins Pipeline](https://jenkins-imports.azure.defra.cloud/job/imports-notification-schema/job/feature%2FIMTA-13073-cloned-documents-separation/)

### :book: Changes:
* Added property to accompanyingDocument to identify cloned documents