### PR TITLE
IMTA-13643: Add requestId to trace bulk upload progress

### DIFF
--- a/imports-frontend-entities/package-lock.json
+++ b/imports-frontend-entities/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipaffs/imports-frontend-entities",
-  "version": "1.0.246",
+  "version": "1.0.256",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/imports-frontend-entities/package.json
+++ b/imports-frontend-entities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipaffs/imports-frontend-entities",
-  "version": "1.0.248",
+  "version": "1.0.256",
   "repository": {
     "type": "git"
   },

--- a/imports-frontend-entities/src/entities/notification.js
+++ b/imports-frontend-entities/src/entities/notification.js
@@ -42,6 +42,7 @@ module.exports = class Notification {
     this.riskDecisionLockingTime = obj.riskDecisionLockingTime;
     this.isRiskDecisionLocked = obj.isRiskDecisionLocked;
     this.isBulkUploadInProgress = obj.isBulkUploadInProgress;
+    this.requestId = obj.requestId;
 
     validate(this)
 

--- a/notification-schema-core/resources/notification-schema.json
+++ b/notification-schema-core/resources/notification-schema.json
@@ -828,6 +828,10 @@
     "isBulkUploadInProgress": {
       "type": "boolean",
       "description": "Boolean flag that indicates whether a bulk upload is in progress"
+    },
+    "requestId": {
+      "type": "string",
+      "description": "Request UUID to trace bulk upload"
     }
   },
   "definitions": {

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/Notification.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/Notification.java
@@ -161,4 +161,5 @@ public class Notification {
 
   private Boolean isRiskDecisionLocked;
   private Boolean isBulkUploadInProgress;
+  private String requestId;
 }


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Marina Tihova |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [IMTA-13643: Add requestId to trace bulk ...](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/302) |
> | **GitLab MR Number** | [302](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/302) |
> | **Date Originally Opened** | Thu, 2 Feb 2023 |
> | **Approved on GitLab by** | Eugene Fahy (Kainos), Reece Bennett (KAINOS), Zuzanna Megger (Kainos) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: [Jira Ticket](https://eaflood.atlassian.net/browse/IMTA-13643)

### :chart_with_upwards_trend: [SonarQube Report](https://vss-sonarqube.azure.defra.cloud/dashboard?branch=bugfix%2FIMTA-13643-bulk-upload-navigating-away-bug&id=Imports-Notification-Schema)

### :building_construction: [Jenkins Pipeline](https://jenkins-imports.azure.defra.cloud/job/imports-notification-schema/job/bugfix%2FIMTA-13643-bulk-upload-navigating-away-bug/)

### :book: Changes:

- Update schema to include `requestId`