### PR TITLE
IMTA-14492 Create new field in schema for old estimated date and time of arrival

### DIFF
--- a/imports-frontend-entities/package.json
+++ b/imports-frontend-entities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipaffs/imports-frontend-entities",
-  "version": "1.0.279",
+  "version": "1.0.280",
   "repository": {
     "type": "git"
   },

--- a/imports-frontend-entities/src/entities/part_one.js
+++ b/imports-frontend-entities/src/entities/part_one.js
@@ -79,7 +79,7 @@ module.exports = class PartOne {
     this.portOfExitDate = obj.portOfExitDate
     this.contactDetails = obj.contactDetails
     this.nominatedContacts = getList(_.get(obj, 'nominatedContacts', []), NominatedContact)
-
+    this.originalEstimatedDateTime = obj.originalEstimatedDateTime
     return Object.seal(new Proxy(this, handler))
   }
 }

--- a/notification-schema-core/resources/notification-schema.json
+++ b/notification-schema-core/resources/notification-schema.json
@@ -785,6 +785,11 @@
           "items": {
             "$ref": "#/definitions/NominatedContact"
           }
+        },
+        "originalEstimatedDateTime": {
+          "type": "string",
+          "javaType": "java.time.LocalDateTime",
+          "description": "Original estimated date and time of arrival entered"
         }
       }
     },

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/PartOne.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/PartOne.java
@@ -28,6 +28,8 @@ import lombok.NoArgsConstructor;
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.TypeOfImp;
 import uk.gov.defra.tracesx.notificationschema.representation.serialisation.IsoDateDeserializer;
 import uk.gov.defra.tracesx.notificationschema.representation.serialisation.IsoDateSerializer;
+import uk.gov.defra.tracesx.notificationschema.representation.serialisation.IsoDateTimeDeserializer;
+import uk.gov.defra.tracesx.notificationschema.representation.serialisation.IsoDateTimeSerializer;
 import uk.gov.defra.tracesx.notificationschema.representation.serialisation.IsoOffsetDateTimeDeserializer;
 import uk.gov.defra.tracesx.notificationschema.representation.serialisation.IsoOffsetDateTimeSerializer;
 import uk.gov.defra.tracesx.notificationschema.representation.serialisation.IsoTimeDeserializer;
@@ -394,4 +396,8 @@ public class PartOne {
       message = "{uk.gov.defra.tracesx.notificationschema.representation.partone"
           + ".transportercontactdetails.not.empty}")
   private List<NominatedContact> nominatedContacts;
+
+  @JsonSerialize(using = IsoDateTimeSerializer.class)
+  @JsonDeserialize(using = IsoDateTimeDeserializer.class)
+  private LocalDateTime originalEstimatedDateTime;
 }


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Jonathan Magee |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [IMTA-14492 Create new field in schema fo...](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/327) |
> | **GitLab MR Number** | [327](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/327) |
> | **Date Originally Opened** | Wed, 5 Jul 2023 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **closed** on GitLab

## Original Description

### :link: [Jira Ticket](https://eaflood.atlassian.net/browse/IMTA-14492)

### :chart_with_upwards_trend: [SonarQube Report](https://vss-sonarqube.azure.defra.cloud/dashboard?branch=feature%2FIMTA-14492-Create-new-field-in-schema-for-old-estimated-date-and-time-of-arrival&id=Imports-Notification-Schema)

### :building_construction: [Jenkins Pipeline](https://jenkins-imports.azure.defra.cloud/job/imports-notification-schema/job/feature%2FIMTA-14492-Create-new-field-in-schema-for-old-estimated-date-and-time-of-arrival/)

### :book: Changes:

- Create new field in schema for old estimated date and time of arrival