### PR TITLE
IMTA-14492: Add originalEstimatedDateTime to part one

### DIFF
--- a/imports-frontend-entities/package-lock.json
+++ b/imports-frontend-entities/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ipaffs/imports-frontend-entities",
-  "version": "1.0.280",
+  "version": "1.0.281",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@ipaffs/imports-frontend-entities",
-      "version": "1.0.280",
+      "version": "1.0.281",
       "license": "ISC",
       "dependencies": {
         "ajv": "6.12.6",

--- a/imports-frontend-entities/package.json
+++ b/imports-frontend-entities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipaffs/imports-frontend-entities",
-  "version": "1.0.280",
+  "version": "1.0.281",
   "repository": {
     "type": "git"
   },

--- a/imports-frontend-entities/src/entities/part_one.js
+++ b/imports-frontend-entities/src/entities/part_one.js
@@ -79,6 +79,7 @@ module.exports = class PartOne {
     this.portOfExitDate = obj.portOfExitDate
     this.contactDetails = obj.contactDetails
     this.nominatedContacts = getList(_.get(obj, 'nominatedContacts', []), NominatedContact)
+    this.originalEstimatedDateTime = obj.originalEstimatedDateTime
 
     return Object.seal(new Proxy(this, handler))
   }

--- a/notification-schema-core/resources/notification-schema.json
+++ b/notification-schema-core/resources/notification-schema.json
@@ -785,6 +785,11 @@
           "items": {
             "$ref": "#/definitions/NominatedContact"
           }
+        },
+        "originalEstimatedDateTime": {
+          "type": "string",
+          "javaType": "java.time.LocalDateTime",
+          "description": "Original estimated date time of arrival"
         }
       }
     },

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/PartOne.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/PartOne.java
@@ -407,4 +407,8 @@ public class PartOne {
       message = "{uk.gov.defra.tracesx.notificationschema.representation.partone"
           + ".transportercontactdetails.not.empty}")
   private List<NominatedContact> nominatedContacts;
+
+  @JsonSerialize(using = IsoOffsetDateTimeSerializer.class)
+  @JsonDeserialize(using = IsoOffsetDateTimeDeserializer.class)
+  private LocalDateTime originalEstimatedDateTime;
 }


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Asad Khan (Kainos) |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [IMTA-14492: Add originalEstimatedDateTim...](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/329) |
> | **GitLab MR Number** | [329](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/329) |
> | **Date Originally Opened** | Mon, 10 Jul 2023 |
> | **Approved on GitLab by** | Carl Evans (KAINOS), Jonathan Magee, Stephen Donaghey (KAINOS) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: [Jira Ticket](https://eaflood.atlassian.net/browse/IMTA-14492)

### :chart_with_upwards_trend: [SonarQube Report](https://vss-sonarqube.azure.defra.cloud/dashboard?branch=feature%2FIMTA-14492-new-field-in-schema-for-old-estimated-date-and-time-of-arrival&id=Imports-Notification-Schema)

### :building_construction: [Jenkins Pipeline](https://jenkins-imports.azure.defra.cloud/job/imports-notification-schema/job/feature%2FIMTA-14492-new-field-in-schema-for-old-estimated-date-and-time-of-arrival/)

### :book: Changes:
- Add originalEstimatedDateTime to part one