### PR TITLE
IMTA-14428: implement library snapshot deployment to artifactory

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,8 +25,12 @@
     <equalsverifier.version>2.4.8</equalsverifier.version>
     <git-build-hook-maven-plugin.version>3.3.0</git-build-hook-maven-plugin.version>
     <maven.checkstyle.version>3.2.1</maven.checkstyle.version>
+    <maven.deploy.plugin.version>3.1.1</maven.deploy.plugin.version>
+    <maven.help.plugin.version>3.4.0</maven.help.plugin.version>
+    <maven.jar.plugin.version>3.3.0</maven.jar.plugin.version>
     <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
     <maven-remote-resources-plugin.version>3.0.0</maven-remote-resources-plugin.version>
+    <maven.versions.plugin.version>2.16.0</maven.versions.plugin.version>
     <shared-resources.version>1.0.0</shared-resources.version>
     <swagger.annotations.version>1.5.17</swagger.annotations.version>
   </properties>
@@ -45,6 +49,11 @@
   </scm>
 
   <distributionManagement>
+    <snapshotRepository>
+      <id>release</id>
+      <name>Snapshots</name>
+      <url>https://artifactoryv2.azure.defra.cloud/artifactory/maven-snapshots-local</url>
+    </snapshotRepository>
     <repository>
       <id>release</id>
       <name>Releases</name>
@@ -71,6 +80,21 @@
     <pluginManagement>
       <plugins>
         <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>${maven.deploy.plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>${maven.jar.plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-help-plugin</artifactId>
+          <version>${maven.help.plugin.version}</version>
+        </plugin>
+        <plugin>
           <artifactId>maven-release-plugin</artifactId>
           <version>${maven.release.plugin.version}</version>
           <configuration>
@@ -78,6 +102,11 @@
             <tagNameFormat>@{project.version}</tagNameFormat>
             <releaseProfiles>release</releaseProfiles>
           </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>versions-maven-plugin</artifactId>
+          <version>${maven.versions.plugin.version}</version>
         </plugin>
         <plugin>
           <groupId>com.rudikershaw.gitbuildhook</groupId>


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Odran Muldoon (Kainos) |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [IMTA-14428: implement library snapshot d...](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/330) |
> | **GitLab MR Number** | [330](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/330) |
> | **Date Originally Opened** | Tue, 25 Jul 2023 |
> | **Approved on GitLab by** | Apurva Jhunjhunwala (Kainos), Eugene Fahy (Kainos), Lewis Birks (Kainos) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: [Jira Ticket](https://eaflood.atlassian.net/browse/IMTA-14428)

### :chart_with_upwards_trend: [SonarQube Report](https://vss-sonarqube.azure.defra.cloud/dashboard?branch=feature%2FIMTA-14428-implement-library-snapshot-deployment-to-artifactory&id=Imports-Notification-Schema)

### :building_construction: [Jenkins Pipeline](https://jenkins-imports.azure.defra.cloud/job/imports-notification-schema/job/feature%252FIMTA-14428-implement-library-snapshot-deployment-to-artifactory/)

### :book: Changes:
* Adding maven deploy and JAR plugins to support the upload of library snapshots to artifactory