### PR TITLE
IMTA-14706: Cheda animal certified as validation fix

### DIFF
--- a/imports-frontend-entities/package-lock.json
+++ b/imports-frontend-entities/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ipaffs/imports-frontend-entities",
-  "version": "1.0.284",
+  "version": "1.0.285",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@ipaffs/imports-frontend-entities",
-      "version": "1.0.284",
+      "version": "1.0.285",
       "license": "ISC",
       "dependencies": {
         "ajv": "6.12.6",

--- a/imports-frontend-entities/package.json
+++ b/imports-frontend-entities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipaffs/imports-frontend-entities",
-  "version": "1.0.283",
+  "version": "1.0.285",
   "repository": {
     "type": "git"
   },

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/Commodities.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/Commodities.java
@@ -126,8 +126,12 @@ public class Commodities {
   private String consignedCountry = null;
 
   @NotNull(
-      groups = {NotificationCvedaFieldValidation.class, NotificationCvedaEuFieldValidation.class,
-          NotificationLowRiskFieldValidation.class},
+      groups = {NotificationLowRiskFieldValidation.class},
+      message =
+          "{uk.gov.defra.tracesx.notificationschema.representation.partone.commodities"
+              + ".purpose.not.null}")
+  @NotNull(
+      groups = {NotificationCvedaFieldValidation.class, NotificationCvedaEuFieldValidation.class},
       message =
           "{uk.gov.defra.tracesx.notificationschema.representation.partone.commodities"
               + ".animalscertifiedas.not.null}")


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Carl Evans (KAINOS) |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [IMTA-14706: Cheda animal certified as va...](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/334) |
> | **GitLab MR Number** | [334](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/334) |
> | **Date Originally Opened** | Fri, 4 Aug 2023 |
> | **Approved on GitLab by** | Apurva Jhunjhunwala (Kainos), Eugene Fahy (Kainos), Toyin Ajani (Kainos) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: [Jira Ticket](https://eaflood.atlassian.net/browse/IMTA-14706)

### :chart_with_upwards_trend: [SonarQube Report](https://vss-sonarqube.azure.defra.cloud/dashboard?branch=bugfix%2FIMTA-14706-cheda-animalcertifiedas-validation&id=Imports-Notification-Schema)

### :book: Changes:

- Fixed groups for animal certified as validation