### PR TITLE
IMTA-15009 Extend notification data schema to include new risk services fields

### DIFF
--- a/imports-frontend-entities/package-lock.json
+++ b/imports-frontend-entities/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ipaffs/imports-frontend-entities",
-  "version": "1.0.285",
+  "version": "1.0.287",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@ipaffs/imports-frontend-entities",
-      "version": "1.0.285",
+      "version": "1.0.287",
       "license": "ISC",
       "dependencies": {
         "ajv": "6.12.6",

--- a/imports-frontend-entities/package.json
+++ b/imports-frontend-entities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipaffs/imports-frontend-entities",
-  "version": "1.0.285",
+  "version": "1.0.287",
   "repository": {
     "type": "git"
   },

--- a/imports-frontend-entities/src/entities/journey_risk_categorisation.js
+++ b/imports-frontend-entities/src/entities/journey_risk_categorisation.js
@@ -1,0 +1,13 @@
+const handler = require('./base/handler')
+
+module.exports = class JourneyRiskCategorisation {
+
+  constructor(obj = {}) {
+
+    this.riskLevel = obj.riskLevel
+    this.riskLevelMethod = obj.riskLevelMethod
+    this.riskLevelDateTime = obj.riskLevelDateTime
+
+    return Object.seal(new Proxy(this, handler))
+  }
+}

--- a/imports-frontend-entities/src/entities/notification.js
+++ b/imports-frontend-entities/src/entities/notification.js
@@ -10,6 +10,7 @@ const ConsignmentValidation = require('./consignment_validation')
 const ExternalReference = require('./external_reference')
 const SplitConsignment = require('./split_consignment')
 const RiskAssessment = require('./risk_assessment')
+const JourneyRiskCategorisation = require('./journey_risk_categorisation.js')
 
 module.exports = class Notification {
   constructor(obj = {}) {
@@ -35,6 +36,7 @@ module.exports = class Notification {
     this.decisionDate = obj.decisionDate
     this.consignmentValidation = getConsignmentValidation(_.get(obj, 'consignmentValidation', []))
     this.riskAssessment = obj.riskAssessment ? new RiskAssessment(obj.riskAssessment) : undefined
+    this.journeyRiskCategorisation = obj.journeyRiskCategorisation ? new JourneyRiskCategorisation(obj.journeyRiskCategorisation) : undefined
     this.replaces = obj.replaces
     this.replacedBy = obj.replacedBy
     this.lastUpdatedBy = obj.lastUpdatedBy

--- a/notification-schema-core/resources/notification-schema.json
+++ b/notification-schema-core/resources/notification-schema.json
@@ -99,6 +99,10 @@
       "$ref": "#/definitions/RiskAssessmentResult",
       "description": "Result of risk assessment by the risk scorer"
     },
+    "journeyRiskCategorisation": {
+      "$ref": "#/definitions/JourneyRiskCategorisationResult",
+      "description": "Details of the risk categorisation level for a notification"
+    },
     "isHighRiskEuImport": {
       "type": "boolean",
       "description": "Is this notification a high risk notification from the EU/EEA?"
@@ -2745,6 +2749,34 @@
         "phsiRuleType": {
           "type": "string",
           "description": "Rule type for PHSI checks"
+        }
+      }
+    },
+    "JourneyRiskCategorisationResult": {
+      "type": "object",
+      "description": "Details of the risk categorisation level for a notification",
+      "properties": {
+        "riskLevel": {
+          "type": "string",
+          "description": "Risk Level is defined using enum values High,Medium,Low",
+          "enum": [
+            "High",
+            "Medium",
+            "Low"
+          ]
+        },
+        "riskLevelMethod": {
+          "type": "string",
+          "description": "Indicator of whether the risk level was determined by the system or by the user",
+          "enum": [
+            "System",
+            "User"
+          ]
+        },
+        "riskLevelDateTime": {
+          "type": "string",
+          "javaType": "java.time.LocalDateTime",
+          "description": "The date and time the risk level has been set for a notification"
         }
       }
     }

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/JourneyRiskCategorisation.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/JourneyRiskCategorisation.java
@@ -1,0 +1,29 @@
+package uk.gov.defra.tracesx.notificationschema.representation;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import uk.gov.defra.tracesx.notificationschema.representation.serialisation.IsoDateTimeDeserializer;
+import uk.gov.defra.tracesx.notificationschema.representation.serialisation.IsoDateTimeSerializer;
+
+@Builder
+@Data
+@JsonInclude(Include.NON_EMPTY)
+@NoArgsConstructor(access = AccessLevel.PUBLIC)
+@AllArgsConstructor(access = AccessLevel.PUBLIC)
+public class JourneyRiskCategorisation {
+
+  private String riskLevel;
+  private String riskLevelMethod;
+
+  @JsonSerialize(using = IsoDateTimeSerializer.class)
+  @JsonDeserialize(using = IsoDateTimeDeserializer.class)
+  private LocalDateTime riskLevelDateTime;
+}

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/Notification.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/Notification.java
@@ -93,6 +93,8 @@ public class Notification {
 
   private RiskAssessment riskAssessment;
 
+  private JourneyRiskCategorisation journeyRiskCategorisation;
+
   private Boolean childNotification;
 
   private Boolean isHighRiskEuImport;


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Apurva Jhunjhunwala (Kainos) |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [IMTA-15009 Extend notification data sche...](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/336) |
> | **GitLab MR Number** | [336](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/336) |
> | **Date Originally Opened** | Mon, 4 Sep 2023 |
> | **Approved on GitLab by** | Eugene Fahy (Kainos), Odran Muldoon (Kainos), Toyin Ajani (Kainos) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: Ticket: https://eaflood.atlassian.net/browse/IMTA-15009

### :construction_site: [Jenkins build](https://jenkins-imports.azure.defra.cloud/job/imports-notification-schema/job/feature%252FIMTA-15009-Extend-notification-schema-for-new-risk-services/)

### :chart_with_upwards_trend: [Sonarqube report](https://vss-sonarqube.azure.defra.cloud/dashboard?branch=feature%2FIMTA-15009-Extend-notification-schema-for-new-risk-services&id=Imports-Notification-Schema)

### :book: Changes:
* Added new object to notification schema to include new risk services.