### PR TITLE
IMTA-14998: add validation for chedp latest health certificate

### DIFF
--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/Notification.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/Notification.java
@@ -26,8 +26,10 @@ import uk.gov.defra.tracesx.notificationschema.validation.ErrorCodes;
 import uk.gov.defra.tracesx.notificationschema.validation.ValidationMessageCode;
 import uk.gov.defra.tracesx.notificationschema.validation.annotations.AccompanyingDocuments;
 import uk.gov.defra.tracesx.notificationschema.validation.annotations.ChedppEstimatedArrivalAtBcp;
+import uk.gov.defra.tracesx.notificationschema.validation.annotations.LatestVeterinaryHealthCertificateRequired;
 import uk.gov.defra.tracesx.notificationschema.validation.annotations.ValidStatus;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.BasicValidation;
+import uk.gov.defra.tracesx.notificationschema.validation.groups.LatestVeterinaryHealthCertificateRequiredValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationChedppFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCvedaEuFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationHighRiskEuCedFieldValidation;
@@ -47,6 +49,8 @@ import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationVet
     groups = NotificationChedppFieldValidation.class,
     message = "{uk.gov.defra.tracesx.notificationschema.representation.partone"
         + ".estimatedarrivalatbcp.must.be.in.future}")
+@LatestVeterinaryHealthCertificateRequired(
+    groups = LatestVeterinaryHealthCertificateRequiredValidation.class)
 public class Notification {
 
   @ApiModelProperty(value = "The INS id number for this notification.")

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/LatestVeterinaryHealthCertificateRequired.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/LatestVeterinaryHealthCertificateRequired.java
@@ -1,0 +1,27 @@
+package uk.gov.defra.tracesx.notificationschema.validation.annotations;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+@Target({ElementType.FIELD, TYPE, ANNOTATION_TYPE})
+@Retention(RUNTIME)
+@Constraint(validatedBy = LatestVeterinaryHealthCertificateRequiredValidator.class)
+@Documented
+public @interface LatestVeterinaryHealthCertificateRequired {
+
+  String message() default "{uk.gov.defra.tracesx.notificationschema.representation.partone"
+    + ".veterinaryInformation.properties.accompanyingDocuments.must.have.latest.veterinary"
+      + ".document}";
+
+  Class<?>[] groups() default {};
+
+  Class<? extends Payload>[] payload() default {};
+}

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/LatestVeterinaryHealthCertificateRequiredValidator.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/LatestVeterinaryHealthCertificateRequiredValidator.java
@@ -1,0 +1,55 @@
+package uk.gov.defra.tracesx.notificationschema.validation.annotations;
+
+import java.util.Collection;
+import java.util.Optional;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import uk.gov.defra.tracesx.notificationschema.representation.AccompanyingDocument;
+import uk.gov.defra.tracesx.notificationschema.representation.JourneyRiskCategorisation;
+import uk.gov.defra.tracesx.notificationschema.representation.Notification;
+import uk.gov.defra.tracesx.notificationschema.representation.VeterinaryInformation;
+import uk.gov.defra.tracesx.notificationschema.representation.enumeration.DocumentType;
+
+public class LatestVeterinaryHealthCertificateRequiredValidator
+    implements ConstraintValidator<LatestVeterinaryHealthCertificateRequired, Notification> {
+
+  private static final String RISK_LEVEL_HIGH = "High";
+  private static final String RISK_LEVEL_MEDIUM = "Medium";
+
+  private boolean isMediumOrHighRiskConsignment(
+      JourneyRiskCategorisation journeyRiskCategorisation) {
+
+    return Optional.ofNullable(journeyRiskCategorisation)
+      .map(JourneyRiskCategorisation::getRiskLevel)
+      .map(riskLevel -> riskLevel.equals(RISK_LEVEL_HIGH) || riskLevel.equals(RISK_LEVEL_MEDIUM))
+      .orElse(false);
+  }
+
+  private boolean hasLatestVeterinaryHealthCertificate(
+      VeterinaryInformation veterinaryInformation) {
+
+    return Optional.ofNullable(veterinaryInformation)
+      .map(VeterinaryInformation::getAccompanyingDocuments)
+      .stream()
+      .flatMap(Collection::stream)
+      .map(AccompanyingDocument::getDocumentType)
+      .anyMatch(documentType -> documentType.equals(
+        DocumentType.LATEST_VETERINARY_HEALTH_CERTIFICATE));
+  }
+
+  @Override
+  public boolean isValid(Notification notification,
+      ConstraintValidatorContext constraintValidatorContext) {
+
+    VeterinaryInformation veterinaryInformation =
+        notification.getPartOne().getVeterinaryInformation();
+    JourneyRiskCategorisation journeyRiskCategorisation =
+        notification.getJourneyRiskCategorisation();
+
+    if (isMediumOrHighRiskConsignment(journeyRiskCategorisation)) {
+      return hasLatestVeterinaryHealthCertificate(veterinaryInformation);
+    } else {
+      return true;
+    }
+  }
+}

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/groups/LatestVeterinaryHealthCertificateRequiredValidation.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/groups/LatestVeterinaryHealthCertificateRequiredValidation.java
@@ -1,0 +1,5 @@
+package uk.gov.defra.tracesx.notificationschema.validation.groups;
+
+public interface LatestVeterinaryHealthCertificateRequiredValidation {
+
+}

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/LatestVeterinaryHealthCertificateRequiredValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/LatestVeterinaryHealthCertificateRequiredValidatorTest.java
@@ -1,0 +1,117 @@
+package uk.gov.defra.tracesx.notificationschema.validation.annotations;
+
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.defra.tracesx.notificationschema.representation.AccompanyingDocument;
+import uk.gov.defra.tracesx.notificationschema.representation.JourneyRiskCategorisation;
+import uk.gov.defra.tracesx.notificationschema.representation.Notification;
+import uk.gov.defra.tracesx.notificationschema.representation.PartOne;
+import uk.gov.defra.tracesx.notificationschema.representation.VeterinaryInformation;
+import uk.gov.defra.tracesx.notificationschema.representation.enumeration.DocumentType;
+
+import java.time.LocalDate;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class LatestVeterinaryHealthCertificateRequiredValidatorTest {
+
+  private LatestVeterinaryHealthCertificateRequiredValidator validator;
+  private Notification notification;
+
+  private static final String RISK_LEVEL_HIGH = "High";
+  private static final String RISK_LEVEL_MEDIUM = "Medium";
+  private static final String RISK_LEVEL_LOW = "Low";
+
+  @Before
+  public void setup() {
+    validator = new LatestVeterinaryHealthCertificateRequiredValidator();
+    notification = new Notification();
+    JourneyRiskCategorisation journeyRiskCategorisation = new JourneyRiskCategorisation();
+    journeyRiskCategorisation.setRiskLevel(RISK_LEVEL_HIGH);
+    AccompanyingDocument accompanyingDocument = new AccompanyingDocument();
+    accompanyingDocument.setDocumentReference("referenceNumber");
+    accompanyingDocument.setDocumentIssueDate(LocalDate.now());
+    accompanyingDocument.setDocumentType(DocumentType.LATEST_VETERINARY_HEALTH_CERTIFICATE);
+    VeterinaryInformation veterinaryInformation = new VeterinaryInformation();
+    veterinaryInformation.setAccompanyingDocuments(Collections.singletonList(accompanyingDocument));
+    notification.setJourneyRiskCategorisation(journeyRiskCategorisation);
+    notification.setPartOne(new PartOne());
+    notification.getPartOne().setVeterinaryInformation(veterinaryInformation);
+  }
+
+  @Test
+  public void isValid_ReturnsTrue_WhenRiskLevelHighAndContainsLatestHealthCertificate() {
+    assertThat(validator.isValid(notification, null)).isTrue();
+  }
+
+  @Test
+  public void isValid_ReturnsTrue_WhenRiskLevelMediumAndContainsLatestHealthCertificate() {
+    notification.getJourneyRiskCategorisation().setRiskLevel(RISK_LEVEL_MEDIUM);
+    assertThat(validator.isValid(notification, null)).isTrue();
+  }
+
+  @Test
+  public void isValid_ReturnsFalse_WhenRiskLevelHighAndDoesNotContainLatestHealthCertificate() {
+    notification.getPartOne().getVeterinaryInformation().getAccompanyingDocuments().get(0).
+      setDocumentType(DocumentType.AIR_WAYBILL);
+    assertThat(validator.isValid(notification, null)).isFalse();
+  }
+
+  @Test
+  public void isValid_ReturnsFalse_WhenRiskLevelMediumAndDoesNotContainLatestHealthCertificate() {
+    notification.getJourneyRiskCategorisation().setRiskLevel(RISK_LEVEL_MEDIUM);
+    notification.getPartOne().getVeterinaryInformation().setAccompanyingDocuments(null);
+    assertThat(validator.isValid(notification, null)).isFalse();
+  }
+
+  @Test
+  public void isValid_ReturnsFalse_WhenRiskLevelMediumAndDocTypeIsNotLatestHealthCert() {
+    notification.getJourneyRiskCategorisation().setRiskLevel(RISK_LEVEL_MEDIUM);
+    notification.getPartOne().getVeterinaryInformation().getAccompanyingDocuments().get(0)
+      .setDocumentType(DocumentType.AIR_WAYBILL);
+    assertThat(validator.isValid(notification, null)).isFalse();
+  }
+
+  @Test
+  public void isValid_ReturnsTrue_WhenRiskLevelLowAndContainsLatestHealthCertificate() {
+    notification.getJourneyRiskCategorisation().setRiskLevel(RISK_LEVEL_LOW);
+    notification.getPartOne().getVeterinaryInformation().getAccompanyingDocuments().get(0)
+            .setDocumentReference("LatestHealthCertificate");
+    assertThat(validator.isValid(notification, null)).isTrue();
+  }
+
+  @Test
+  public void isValid_ReturnsTrue_WhenRiskLevelLowAndDoesNotContainLatestHealthCertificate() {
+    notification.getJourneyRiskCategorisation().setRiskLevel(RISK_LEVEL_LOW);
+    notification.getPartOne().getVeterinaryInformation().getAccompanyingDocuments().get(0).
+            setDocumentType(DocumentType.AIR_WAYBILL);
+    assertThat(validator.isValid(notification, null)).isTrue();
+  }
+
+  @Test
+  public void isValid_ReturnsTrue_WhenRiskLevelNotSetAndContainsLatestHealthCertificate() {
+    notification.getJourneyRiskCategorisation().setRiskLevel(null);
+    assertThat(validator.isValid(notification, null)).isTrue();
+  }
+
+  @Test
+  public void isValid_ReturnsTrue_WhenRiskLevelNotSetAndDoesNotContainLatestHealthCertificate() {
+    notification.getJourneyRiskCategorisation().setRiskLevel(null);
+    notification.getPartOne().getVeterinaryInformation().setAccompanyingDocuments(null);
+    assertThat(validator.isValid(notification, null)).isTrue();
+  }
+
+  @Test
+  public void isValid_ReturnsTrue_WhenNoJourneyRiskCategorisationObjectExistsAndContainsLatestHealthCertificate() {
+    notification.setJourneyRiskCategorisation(null);
+    assertThat(validator.isValid(notification, null)).isTrue();
+  }
+
+  @Test
+  public void isValid_ReturnsFalse_WhenRiskLevelIsHighAndNoVeterinaryInformationExists() {
+    notification.getPartOne().setVeterinaryInformation(null);
+    assertThat(validator.isValid(notification, null)).isFalse();
+  }
+
+}


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Odran Muldoon (Kainos) |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [IMTA-14998: add validation for chedp lat...](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/340) |
> | **GitLab MR Number** | [340](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/340) |
> | **Date Originally Opened** | Fri, 22 Sep 2023 |
> | **Approved on GitLab by** | Abhishek Dutt (Kainos), Apurva Jhunjhunwala (Kainos), Carl Evans (KAINOS) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: [Jira Ticket](https://eaflood.atlassian.net/browse/IMTA-14998)

### :chart_with_upwards_trend: [SonarQube Report](https://vss-sonarqube.azure.defra.cloud/dashboard?branch=feature%2FIMTA-14998-add-validation-message-for-chedp-veterinary-health-certificates&id=Imports-Notification-Schema)

### :building_construction: [Jenkins Pipeline](https://jenkins-imports.azure.defra.cloud/job/imports-notification-schema/job/feature%252FIMTA-14998-add-validation-message-for-chedp-veterinary-health-certificates/)

### :book: Changes:
* make latest veterinary health certificate required in part 2, for high and medium risk chedp consignments