### PR TITLE
IMTA-15329: Add movementReferenceNumber and transitDateTime to notification schema

### DIFF
--- a/imports-frontend-entities/package-lock.json
+++ b/imports-frontend-entities/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ipaffs/imports-frontend-entities",
-  "version": "1.0.287",
+  "version": "1.0.292",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@ipaffs/imports-frontend-entities",
-      "version": "1.0.287",
+      "version": "1.0.292",
       "license": "ISC",
       "dependencies": {
         "ajv": "6.12.6",

--- a/imports-frontend-entities/package.json
+++ b/imports-frontend-entities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipaffs/imports-frontend-entities",
-  "version": "1.0.287",
+  "version": "1.0.292",
   "repository": {
     "type": "git"
   },

--- a/imports-frontend-entities/src/entities/purpose.js
+++ b/imports-frontend-entities/src/entities/purpose.js
@@ -18,6 +18,7 @@ module.exports = class Purpose {
     this.exitDate = obj.exitDate
     this.finalBIP = obj.finalBIP
     this.purposeGroup = obj.purposeGroup
+    this.estimatedArrivalDateTimeAtPortOfExit = obj.estimatedArrivalDateTimeAtPortOfExit
 
     return Object.seal(new Proxy(this, handler))
   }

--- a/notification-schema-core/resources/notification-schema.json
+++ b/notification-schema-core/resources/notification-schema.json
@@ -592,6 +592,11 @@
                 "For Transfer To",
                 "For Import Re-Conformity Check"
               ]
+            },
+            "estimatedArrivalDateTimeAtPortOfExit": {
+              "type": "string",
+              "javaType": "java.time.LocalDateTime",
+              "description": "Estimated date time at port of exit"
             }
           }
         },
@@ -874,7 +879,8 @@
           "enum": [
             "E-CERT",
             "E-PHYTO",
-            "E-NOTIFICATION"
+            "E-NOTIFICATION",
+            "NCTS"
           ]
         },
         "reference": {

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/Purpose.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/Purpose.java
@@ -2,6 +2,9 @@ package uk.gov.defra.tracesx.notificationschema.representation;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.time.LocalDateTime;
 import java.util.List;
 import javax.validation.constraints.NotNull;
 import lombok.AccessLevel;
@@ -13,6 +16,8 @@ import uk.gov.defra.tracesx.notificationschema.representation.enumeration.ForImp
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.ForNonConformingEnum;
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.InternalMarketPurpose;
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.PurposeGroupEnum;
+import uk.gov.defra.tracesx.notificationschema.representation.serialisation.IsoDateTimeDeserializer;
+import uk.gov.defra.tracesx.notificationschema.representation.serialisation.IsoDateTimeSerializer;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCvedaEuFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationHighRiskEuCedFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationHighRiskFieldValidation;
@@ -55,4 +60,8 @@ public class Purpose {
           "{uk.gov.defra.tracesx.notificationschema.representation.partone.purpose.purposeGroup"
               + ".not.null}")
   private PurposeGroupEnum purposeGroup;
+
+  @JsonSerialize(using = IsoDateTimeSerializer.class)
+  @JsonDeserialize(using = IsoDateTimeDeserializer.class)
+  private LocalDateTime estimatedArrivalDateTimeAtPortOfExit;
 }

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ExternalSystem.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ExternalSystem.java
@@ -5,7 +5,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 public enum ExternalSystem {
   ECERT("E-CERT"),
   EPHYTO("E-PHYTO"),
-  ENOTIFICATION("E-NOTIFICATION");
+  ENOTIFICATION("E-NOTIFICATION"),
+  NCTS("NCTS");
 
   private final String value;
 

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ExternalSystemTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ExternalSystemTest.java
@@ -9,6 +9,7 @@ public class ExternalSystemTest {
   private final static String E_CERT = "E-CERT";
   private final static String E_PHYTO = "E-PHYTO";
   private final static String INVALID_STRING = "Invalid";
+  private final static String NCTS = "NCTS";
 
   @Test
   public void toString_ReturnsECertValue_WhenECertEnum() {
@@ -20,6 +21,12 @@ public class ExternalSystemTest {
   public void toString_ReturnsEPhytoValue_WhenEPhytoEnum() {
     String enumResult = ExternalSystem.EPHYTO.toString();
     assertEquals(enumResult, E_PHYTO);
+  }
+
+  @Test
+  public void toString_ReturnsNCTSValue_WhenNCTS() {
+    String enumResult = ExternalSystem.NCTS.toString();
+    assertEquals(enumResult, NCTS);
   }
 
   @Test
@@ -35,6 +42,12 @@ public class ExternalSystemTest {
   }
 
   @Test
+  public void getValue_ReturnsNCTSValue_WhenNCTS() {
+    String enumResult = ExternalSystem.NCTS.getValue();
+    assertEquals(enumResult, NCTS);
+  }
+
+  @Test
   public void fromValue_ReturnsECertEnum_WhenECertString() {
     ExternalSystem enumResult = ExternalSystem.fromValue(E_CERT);
     assertEquals(enumResult, ExternalSystem.ECERT);
@@ -44,6 +57,12 @@ public class ExternalSystemTest {
   public void fromValue_ReturnsEPhytoEnum_WhenEPhytoString() {
     ExternalSystem enumResult = ExternalSystem.fromValue(E_PHYTO);
     assertEquals(enumResult, ExternalSystem.EPHYTO);
+  }
+
+  @Test
+  public void fromValue_ReturnsNCTSEnum_WhenNCTSString() {
+    ExternalSystem enumResult = ExternalSystem.fromValue(NCTS);
+    assertEquals(enumResult, ExternalSystem.NCTS);
   }
 
   @Test


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Asad Khan (Kainos) |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [IMTA-15329: Add movementReferenceNumber ...](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/344) |
> | **GitLab MR Number** | [344](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/344) |
> | **Date Originally Opened** | Tue, 3 Oct 2023 |
> | **Approved on GitLab by** | Harrison Duffield (Kainos), Phani Yallam, Ryan Beattie (Kainos), Stephen Donaghey (KAINOS), niamh mclarnon (Kainos) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: [Jira Ticket](https://eaflood.atlassian.net/browse/IMTA-15329)

### :chart_with_upwards_trend: [SonarQube Report](https://vss-sonarqube.azure.defra.cloud/dashboard?branch=feature%2FIMTA-15329-schema-update-mrn-number-and-transit-date-time&id=Imports-Notification-Schema)

### :building_construction: [Jenkins Pipeline](https://jenkins-imports.azure.defra.cloud/job/imports-notification-schema/job/feature%2FIMTA-15329-schema-update-mrn-number-and-transit-date-time/)

### :book: Changes:

- Add external reference for NCTS
- partOne.purpose.estimatedArrivalDateTimeAtPortOfExit