### PR TITLE
IMTA-15335 consume updated risk assessment from risk engine for landbridge

### DIFF
--- a/imports-frontend-entities/package-lock.json
+++ b/imports-frontend-entities/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ipaffs/imports-frontend-entities",
-  "version": "1.0.292",
+  "version": "1.0.297",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@ipaffs/imports-frontend-entities",
-      "version": "1.0.292",
+      "version": "1.0.297",
       "license": "ISC",
       "dependencies": {
         "ajv": "6.12.6",

--- a/imports-frontend-entities/package.json
+++ b/imports-frontend-entities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipaffs/imports-frontend-entities",
-  "version": "1.0.293",
+  "version": "1.0.297",
   "repository": {
     "type": "git"
   },

--- a/imports-frontend-entities/src/entities/commodity_risk_result.js
+++ b/imports-frontend-entities/src/entities/commodity_risk_result.js
@@ -4,6 +4,7 @@ module.exports = class CommodityRiskResult {
   constructor(obj = {}) {
 
     this.riskDecision = obj.riskDecision
+    this.exitRiskDecision = obj.exitRiskDecision
     this.hmiDecision = obj.hmiDecision
     this.phsiDecision = obj.phsiDecision
     this.phsiClassification = obj.phsiClassification

--- a/notification-schema-core/resources/notification-schema.json
+++ b/notification-schema-core/resources/notification-schema.json
@@ -2682,6 +2682,15 @@
             "REENFORCED_CHECK"
           ]
         },
+        "exitRiskDecision": {
+          "type": "string",
+          "description": "Transit CHED - what is the commodity complement exit risk decision",
+          "enum": [
+            "REQUIRED",
+            "NOTREQUIRED",
+            "INCONCLUSIVE"
+          ]
+        },
         "hmiDecision": {
           "type": "string",
           "description": "HMI decision required",

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/CommodityRiskResult.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/CommodityRiskResult.java
@@ -21,6 +21,7 @@ import uk.gov.defra.tracesx.notificationschema.representation.enumeration.RiskDe
 public class CommodityRiskResult {
 
   private RiskDecision riskDecision;
+  private RiskDecision exitRiskDecision;
   private HmiDecision hmiDecision;
   private PhsiDecision phsiDecision;
   private PhsiClassification phsiClassification;


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | niamh mclarnon (Kainos) |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [IMTA-15335 consume updated risk assessme...](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/348) |
> | **GitLab MR Number** | [348](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/348) |
> | **Date Originally Opened** | Mon, 23 Oct 2023 |
> | **Approved on GitLab by** | Asad Khan (Kainos), Jonathan Magee, Josh Craig (Kainos), Ryan Beattie (Kainos), Stephen Donaghey (KAINOS) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: [Jira Ticket](https://eaflood.atlassian.net/browse/IMTA-15335)

### :chart_with_upwards_trend: [SonarQube Report](https://vss-sonarqube.azure.defra.cloud/dashboard?branch=feature%2FIMTA-15335-consume-updated-risk-assessment-from-risk-engine-for-landbridge&id=Imports-Notification-Schema)

### :building_construction: [Jenkins Pipeline](https://jenkins-imports.azure.defra.cloud/job/imports-notification-schema/job/feature%2FIMTA-15335-consume-updated-risk-assessment-from-risk-engine-for-landbridge/)

### :book: Changes:

- New field added of type RiskDecision
- Update package version