### PR TITLE
IMTA-15331: Split estimatedArrivalDateTimeAtPortOfExit into separate date time fields

### DIFF
--- a/imports-frontend-entities/package-lock.json
+++ b/imports-frontend-entities/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ipaffs/imports-frontend-entities",
-  "version": "1.0.297",
+  "version": "1.0.298",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@ipaffs/imports-frontend-entities",
-      "version": "1.0.297",
+      "version": "1.0.298",
       "license": "ISC",
       "dependencies": {
         "ajv": "6.12.6",

--- a/imports-frontend-entities/package.json
+++ b/imports-frontend-entities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipaffs/imports-frontend-entities",
-  "version": "1.0.297",
+  "version": "1.0.298",
   "repository": {
     "type": "git"
   },

--- a/imports-frontend-entities/src/entities/purpose.js
+++ b/imports-frontend-entities/src/entities/purpose.js
@@ -18,7 +18,8 @@ module.exports = class Purpose {
     this.exitDate = obj.exitDate
     this.finalBIP = obj.finalBIP
     this.purposeGroup = obj.purposeGroup
-    this.estimatedArrivalDateTimeAtPortOfExit = obj.estimatedArrivalDateTimeAtPortOfExit
+    this.estimatedArrivalDateAtPortOfExit = obj.estimatedArrivalDateAtPortOfExit
+    this.estimatedArrivalTimeAtPortOfExit = obj.estimatedArrivalTimeAtPortOfExit
 
     return Object.seal(new Proxy(this, handler))
   }

--- a/notification-schema-core/resources/notification-schema.json
+++ b/notification-schema-core/resources/notification-schema.json
@@ -593,10 +593,15 @@
                 "For Import Re-Conformity Check"
               ]
             },
-            "estimatedArrivalDateTimeAtPortOfExit": {
+            "estimatedArrivalDateAtPortOfExit": {
               "type": "string",
-              "javaType": "java.time.LocalDateTime",
-              "description": "Estimated date time at port of exit"
+              "javaType": "java.time.LocalDate",
+              "description": "Estimated date at port of exit"
+            },
+            "estimatedArrivalTimeAtPortOfExit": {
+              "type": "string",
+              "javaType": "java.time.LocalTime",
+              "description": "Estimated time at port of exit"
             }
           }
         },

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/Purpose.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/Purpose.java
@@ -4,7 +4,8 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import java.time.LocalDateTime;
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 import javax.validation.constraints.NotNull;
 import lombok.AccessLevel;
@@ -16,8 +17,10 @@ import uk.gov.defra.tracesx.notificationschema.representation.enumeration.ForImp
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.ForNonConformingEnum;
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.InternalMarketPurpose;
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.PurposeGroupEnum;
-import uk.gov.defra.tracesx.notificationschema.representation.serialisation.IsoDateTimeDeserializer;
-import uk.gov.defra.tracesx.notificationschema.representation.serialisation.IsoDateTimeSerializer;
+import uk.gov.defra.tracesx.notificationschema.representation.serialisation.IsoDateDeserializer;
+import uk.gov.defra.tracesx.notificationschema.representation.serialisation.IsoDateSerializer;
+import uk.gov.defra.tracesx.notificationschema.representation.serialisation.IsoTimeDeserializer;
+import uk.gov.defra.tracesx.notificationschema.representation.serialisation.IsoTimeSerializer;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationChedppFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCvedaEuFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationHighRiskEuCedFieldValidation;
@@ -63,7 +66,11 @@ public class Purpose {
               + ".not.null}")
   private PurposeGroupEnum purposeGroup;
 
-  @JsonSerialize(using = IsoDateTimeSerializer.class)
-  @JsonDeserialize(using = IsoDateTimeDeserializer.class)
-  private LocalDateTime estimatedArrivalDateTimeAtPortOfExit;
+  @JsonSerialize(using = IsoDateSerializer.class)
+  @JsonDeserialize(using = IsoDateDeserializer.class)
+  private LocalDate estimatedArrivalDateAtPortOfExit;
+
+  @JsonSerialize(using = IsoTimeSerializer.class)
+  @JsonDeserialize(using = IsoTimeDeserializer.class)
+  private LocalTime estimatedArrivalTimeAtPortOfExit;
 }


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Asad Khan (Kainos) |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [IMTA-15331: Split estimatedArrivalDateTi...](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/350) |
> | **GitLab MR Number** | [350](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/350) |
> | **Date Originally Opened** | Mon, 30 Oct 2023 |
> | **Approved on GitLab by** | Josh Craig (Kainos), Stephen Donaghey (KAINOS), prabash balasuriya (kainos) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: [Jira Ticket](https://eaflood.atlassian.net/browse/IMTA-15331)

### :chart_with_upwards_trend: [SonarQube Report](https://vss-sonarqube.azure.defra.cloud/dashboard?branch=feature%2FIMTA-15331-breakup-esitmated-arrival-date-time-at-poe&id=Imports-Notification-Schema)

### :building_construction: [Jenkins Pipeline](https://jenkins-imports.azure.defra.cloud/job/imports-notification-schema/job/feature%2FIMTA-15331-breakup-esitmated-arrival-date-time-at-poe/)

### :book: Changes:
- Split estimatedArrivalDateTimeAtPortOfExit into separate date time fields