### PR TITLE
IMTA-15352: Added catch certificate schema changes

### DIFF
--- a/imports-frontend-entities/package-lock.json
+++ b/imports-frontend-entities/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ipaffs/imports-frontend-entities",
-  "version": "1.0.302",
+  "version": "1.0.308",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@ipaffs/imports-frontend-entities",
-      "version": "1.0.302",
+      "version": "1.0.308",
       "license": "ISC",
       "dependencies": {
         "ajv": "6.12.6",

--- a/imports-frontend-entities/package.json
+++ b/imports-frontend-entities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipaffs/imports-frontend-entities",
-  "version": "1.0.302",
+  "version": "1.0.308",
   "repository": {
     "type": "git"
   },

--- a/imports-frontend-entities/src/entities/catch_certificate_attachment.js
+++ b/imports-frontend-entities/src/entities/catch_certificate_attachment.js
@@ -1,0 +1,13 @@
+const handler = require('./base/handler')
+const CatchCertificateDetails = require('./catch_certificate_details')
+const {getList} = require("../utils/list");
+
+module.exports = class CatchCertificateAttachment {
+    constructor(obj = {}) {
+
+        this.attachmentId = obj.attachmentId
+        this.catchCertificateDetails = getList(obj.catchCertificateDetails ?? [], CatchCertificateDetails)
+
+        return Object.seal(new Proxy(this, handler))
+    }
+}

--- a/imports-frontend-entities/src/entities/catch_certificate_details.js
+++ b/imports-frontend-entities/src/entities/catch_certificate_details.js
@@ -1,0 +1,15 @@
+const _ = require("lodash");
+const handler = require("./base/handler");
+
+module.exports = class CatchCertificateAttachment {
+    constructor(obj = {}) {
+
+        this.catchCertificateId = obj.catchCertificateId
+        this.catchCertificateReference = obj.catchCertificateReference
+        this.dateofIssue = obj.dateofIssue
+        this.flagState = obj.flagState
+        this.species = _.get(obj, 'species', [])
+
+        return Object.seal(new Proxy(this, handler))
+    }
+}

--- a/imports-frontend-entities/src/entities/veterinary_information.js
+++ b/imports-frontend-entities/src/entities/veterinary_information.js
@@ -2,6 +2,7 @@ const _ = require('lodash')
 const handler = require('./base/handler')
 const AccompanyingDocument = require('./accompanying_document')
 const ApprovedEstablishment = require('./approved_establishment')
+const CatchCertificateAttachment = require('./catch_certificate_attachment')
 const IdentificationDetail = require('./identification_detail')
 const { getList } = require('../utils/list')
 
@@ -15,6 +16,7 @@ module.exports = class VeterinaryInformation {
     this.veterinaryDocumentIssueDate = obj.veterinaryDocumentIssueDate
     this.accompanyingDocumentNumbers = _.get(obj, 'accompanyingDocumentNumbers', [])
     this.accompanyingDocuments = getList(_.get(obj, 'accompanyingDocuments', []), AccompanyingDocument)
+    this.catchCertificateAttachments = getList(obj.catchCertificateAttachments ?? [], CatchCertificateAttachment)
     this.identificationDetails = getIdentificationDetails(
         _.get(obj, 'identificationDetails', []))
 

--- a/imports-frontend-entities/test/entities_test.js
+++ b/imports-frontend-entities/test/entities_test.js
@@ -58,6 +58,8 @@ const InspectionOverride = require('../src/entities/inspection_override')
 const ExternalReference = require('../src/entities/external_reference')
 const RiskAssessment = require('../src/entities/risk_assessment')
 const SealCheck = require('../src/entities/seal_check')
+const CatchCertificateAttachment = require('../src/entities/catch_certificate_attachment')
+const CatchCertificateDetails = require('../src/entities/catch_certificate_details')
 
 describe('Entities: ', () => {
 
@@ -116,7 +118,9 @@ describe('Entities: ', () => {
     InspectionOverride,
     ExternalReference,
     RiskAssessment,
-    SealCheck
+    SealCheck,
+    CatchCertificateAttachment,
+    CatchCertificateDetails
   ]
 
   it('are capable of storing data', () => {

--- a/notification-schema-core/resources/notification-schema.json
+++ b/notification-schema-core/resources/notification-schema.json
@@ -703,6 +703,13 @@
                 "$ref": "#/definitions/AccompanyingDocument"
               }
             },
+            "catchCertificateAttachments": {
+              "type": "array",
+              "description": "Catch certificate attachments",
+              "items": {
+                "$ref": "#/definitions/CatchCertificateAttachment"
+              }
+            },
             "identificationDetails": {
               "type": "array",
               "description": "Details helpful for identification",
@@ -2556,6 +2563,55 @@
         "externalReference": {
           "description": "External reference of accompanying document, which relates to a downstream service",
           "$ref": "#/definitions/ExternalReference"
+        }
+      }
+    },
+    "CatchCertificateAttachment": {
+      "type": "object",
+      "javaType": "uk.gov.defra.tracesx.notificationschema.representation.CatchCertificateAttachment",
+      "description": "Catch certificate attachment",
+      "properties": {
+        "attachmentId": {
+          "type": "string",
+          "description": "The UUID of the uploaded catch certificate file in blob storage"
+        },
+        "CatchCertificateDetails": {
+          "type": "array",
+          "description": "List of catch certificate details",
+          "items": {
+            "$ref": "#/definitions/CatchCertificateDetails"
+          }
+        }
+      }
+    },
+    "CatchCertificateDetails": {
+      "type": "object",
+      "javaType": "uk.gov.defra.tracesx.notificationschema.representation.CatchCertificateDetails",
+      "description": "Catch certificate details for uploaded attachment",
+      "properties": {
+        "catchCertificateId": {
+          "type": "string",
+          "description": "The UUID of the catch certificate"
+        },
+        "catchCertificateReference": {
+          "type": "string",
+          "description": "Catch certificate reference"
+        },
+        "dateOfIssue": {
+          "type": "string",
+          "javaType": "java.time.LocalDate",
+          "description": "Catch certificate date of issue"
+        },
+        "flagState": {
+          "type": "string",
+          "description": "Catch certificate flag state of catching vessel(s)"
+        },
+        "species": {
+          "type": "array",
+          "description": "List of species imported under this catch certificate",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/CatchCertificateAttachment.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/CatchCertificateAttachment.java
@@ -1,0 +1,17 @@
+package uk.gov.defra.tracesx.notificationschema.representation;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.List;
+import lombok.Builder;
+import lombok.Data;
+import lombok.extern.jackson.Jacksonized;
+
+@Builder
+@Data
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+@Jacksonized
+public class CatchCertificateAttachment {
+
+  private String attachmentId;
+  private List<CatchCertificateDetails> catchCertificateDetails;
+}

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/CatchCertificateDetails.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/CatchCertificateDetails.java
@@ -1,0 +1,30 @@
+package uk.gov.defra.tracesx.notificationschema.representation;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+import lombok.Builder;
+import lombok.Data;
+import lombok.extern.jackson.Jacksonized;
+import uk.gov.defra.tracesx.notificationschema.representation.serialisation.IsoDateDeserializer;
+import uk.gov.defra.tracesx.notificationschema.representation.serialisation.IsoDateSerializer;
+
+@Builder
+@Data
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+@Jacksonized
+public class CatchCertificateDetails {
+
+  private UUID catchCertificateId;
+  private String catchCertificateReference;
+
+  @JsonSerialize(using = IsoDateSerializer.class)
+  @JsonDeserialize(using = IsoDateDeserializer.class)
+  private LocalDate dateOfIssue;
+
+  private String flagState;
+  private List<String> species;
+}

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/VeterinaryInformation.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/VeterinaryInformation.java
@@ -38,6 +38,8 @@ public class VeterinaryInformation {
   @Valid
   private List<AccompanyingDocument> accompanyingDocuments;
 
+  private List<CatchCertificateAttachment> catchCertificateAttachments;
+
   private List<NotificationIdentificationDetails> identificationDetails;
 
   @JsonSerialize(using = IsoDateSerializer.class)


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | kalpana muddapu (Kainos) |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [IMTA-15352: Added catch certificate sche...](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/356) |
> | **GitLab MR Number** | [356](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/356) |
> | **Date Originally Opened** | Tue, 21 Nov 2023 |
> | **Approved on GitLab by** | Lewis Birks (Kainos), Mayuresh Kadu, Toyin Ajani (Kainos) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: [Jira Ticket](https://eaflood.atlassian.net/browse/IMTA-15352)

### :chart_with_upwards_trend: [SonarQube Report](https://vss-sonarqube.azure.defra.cloud/dashboard?branch=feature%2FIMTA-15352-catch-cetificate-schema-change&id=Imports-Notification-Schema)

### :building_construction: [Jenkins Pipeline](https://jenkins-imports.azure.defra.cloud/job/imports-notification-schema/job/feature%2FIMTA-15352-catch-cetificate-schema-change/)

### :book: Changes:

- Added schema change for catch certificate attachments