### PR TITLE
IMTA-12961-Update schema to allow empty data object

### DIFF
--- a/imports-frontend-entities/package.json
+++ b/imports-frontend-entities/package.json
@@ -23,6 +23,7 @@
   "publishConfig": {
     "registry": "https://artifactoryv2.azure.defra.cloud/artifactory/api/npm/npm-snapshots-local/"
   },
+
   "author": "",
   "license": "ISC",
   "devDependencies": {

--- a/imports-frontend-entities/package.json
+++ b/imports-frontend-entities/package.json
@@ -23,7 +23,6 @@
   "publishConfig": {
     "registry": "https://artifactoryv2.azure.defra.cloud/artifactory/api/npm/npm-snapshots-local/"
   },
-
   "author": "",
   "license": "ISC",
   "devDependencies": {

--- a/imports-frontend-entities/package.json
+++ b/imports-frontend-entities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipaffs/imports-frontend-entities",
-  "version": "1.0.318",
+  "version": "1.0.319",
   "repository": {
     "type": "git"
   },

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/Identifier.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/Identifier.java
@@ -11,7 +11,6 @@ import lombok.NoArgsConstructor;
 
 @Builder
 @Data
-@JsonInclude(Include.NON_EMPTY)
 @NoArgsConstructor(access = AccessLevel.PUBLIC)
 @AllArgsConstructor(access = AccessLevel.PUBLIC)
 public class Identifier {


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Jana Latzberg (Kainos) |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [IMTA-12961-Update schema to allow empty ...](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/381) |
> | **GitLab MR Number** | [381](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/381) |
> | **Date Originally Opened** | Tue, 13 Feb 2024 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **closed** on GitLab

## Original Description

### :link: [Jira Ticket](https://eaflood.atlassian.net/browse/IMTA-12961)

### :chart_with_upwards_trend: [SonarQube Report](https://vss-sonarqube.azure.defra.cloud/dashboard?branch=bugfix%2FIMTA-12961-cheda-journey-identification-detail-missing-in-the-json-message&id=Imports-Notification-Schema)

### :building_construction: [Jenkins Pipeline](https://jenkins-imports.azure.defra.cloud/job/imports-notification-schema/job/bugfix%2FIMTA-12961-cheda-journey-identification-detail-missing-in-the-json-message/)

### :book: Changes:
* <INSERT CHANGES HERE>
* <INSERT CHANGES HERE>

### :white_check_mark: Selenium Test Run:

PENDING