### PR TITLE
IMTA-12961 cheda journey identification detail missing in json

### DIFF
--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/Identifier.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/Identifier.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 
 @Builder
 @Data
-@JsonInclude(Include.NON_EMPTY)
+@JsonInclude(Include.NON_NULL)
 @NoArgsConstructor(access = AccessLevel.PUBLIC)
 @AllArgsConstructor(access = AccessLevel.PUBLIC)
 public class Identifier {


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Jana Latzberg (Kainos) |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [IMTA-12961 cheda journey identification ...](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/385) |
> | **GitLab MR Number** | [385](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/385) |
> | **Date Originally Opened** | Wed, 14 Feb 2024 |
> | **Approved on GitLab by** | Harrison Duffield (Kainos), Lewis Birks (Kainos), Thomas Seelig (Kainos) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: [Jira Ticket](https://eaflood.atlassian.net/browse/IMTA-12961)

### :chart_with_upwards_trend: [SonarQube Report](https://vss-sonarqube.azure.defra.cloud/dashboard?branch=bugfix%2FIMTA-12961-cheda-journey-identification-detail-missing-in-json&id=Imports-Notification-Schema)

### :building_construction: [Jenkins Pipeline](https://jenkins-imports.azure.defra.cloud/job/imports-notification-schema/job/bugfix%2FIMTA-12961-cheda-journey-identification-detail-missing-in-json/)

### :book: Changes:
* Allow empty data map
![Screenshot_2024-02-14_at_14.29.13](/uploads/a8bf25682ba8faeb15e5d5684df12e54/Screenshot_2024-02-14_at_14.29.13.png)

### :white_check_mark: Selenium Test Run:
Sanity and Regression selenium test
https://jenkins-imports.azure.defra.cloud/job/Run_Selenium_Tests/7985/cucumber-html-reports/overview-features.html
https://jenkins-imports.azure.defra.cloud/job/Run_Selenium_Tests/7984/cucumber-html-reports/overview-features.html