### PR TITLE
IMTA-17055 add autoClearedDateTime to notification.partTwo

### DIFF
--- a/imports-frontend-entities/package-lock.json
+++ b/imports-frontend-entities/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipaffs/imports-frontend-entities",
-  "version": "1.0.319",
+  "version": "1.0.320",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/imports-frontend-entities/package.json
+++ b/imports-frontend-entities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipaffs/imports-frontend-entities",
-  "version": "1.0.319",
+  "version": "1.0.320",
   "repository": {
     "type": "git"
   },

--- a/imports-frontend-entities/src/entities/part_two.js
+++ b/imports-frontend-entities/src/entities/part_two.js
@@ -47,6 +47,7 @@ module.exports = class PartTwo {
     this.inspectionRequired = obj.inspectionRequired
     this.inspectionOverride = _.get(obj, 'inspectionOverride')
         ? new InspectionOverride(obj.inspectionOverride) : undefined
+    this.autoClearedDateTime = obj.autoClearedDateTime
 
     return Object.seal(new Proxy(this, handler))
   }

--- a/notification-schema-core/resources/notification-schema.json
+++ b/notification-schema-core/resources/notification-schema.json
@@ -1485,6 +1485,11 @@
         "inspectionOverride": {
           "$ref": "#/definitions/InspectionOverride",
           "description": "Details about the manual inspection override"
+        },
+        "autoClearedDateTime": {
+          "type": "string",
+          "javaType": "java.time.LocalDateTime",
+          "description": "Date of autoclearance"
         }
       }
     },

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/PartTwo.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/PartTwo.java
@@ -119,4 +119,8 @@ public class PartTwo {
   private InspectionRequired inspectionRequired;
 
   private InspectionOverride inspectionOverride;
+
+  @JsonSerialize(using = IsoOffsetDateTimeSerializer.class)
+  @JsonDeserialize(using = IsoOffsetDateTimeDeserializer.class)
+  private LocalDateTime autoClearedDateTime;
 }


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Maciej Trzasalski (Kainos) |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [IMTA-17055 add autoClearedDateTime to no...](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/395) |
> | **GitLab MR Number** | [395](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/395) |
> | **Date Originally Opened** | Fri, 15 Mar 2024 |
> | **Approved on GitLab by** | Apurva Jhunjhunwala (Kainos), Josh Craig (Kainos), Shawn Chan (Kainos), niamh mclarnon (Kainos) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: [Jira Ticket](https://eaflood.atlassian.net/browse/IMTA-17055)

### :chart_with_upwards_trend: [SonarQube Report](https://vss-sonarqube.azure.defra.cloud/dashboard?branch=feature%2FIMTA-17055-schema-change-autoclearance-identifier&id=Imports-Notification-Schema)

### :building_construction: [Jenkins Pipeline](https://jenkins-imports.azure.defra.cloud/job/imports-notification-schema/job/feature%2FIMTA-17055-schema-change-autoclearance-identifier/)

### :book: Changes:

- add autoclearance date