### PR TITLE
IMTA-19028 Schema update for transporter contact

### DIFF
--- a/imports-frontend-entities/package-lock.json
+++ b/imports-frontend-entities/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ipaffs/imports-frontend-entities",
-  "version": "1.0.334",
+  "version": "1.0.335",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@ipaffs/imports-frontend-entities",
-      "version": "1.0.334",
+      "version": "1.0.335",
       "license": "ISC",
       "dependencies": {
         "ajv": "6.12.6",

--- a/imports-frontend-entities/package.json
+++ b/imports-frontend-entities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipaffs/imports-frontend-entities",
-  "version": "1.0.334",
+  "version": "1.0.335",
   "repository": {
     "type": "git"
   },

--- a/imports-frontend-entities/src/entities/part_one.js
+++ b/imports-frontend-entities/src/entities/part_one.js
@@ -73,6 +73,7 @@ module.exports = class PartOne {
     this.isChargeable = obj.isChargeable
     this.wasChargeable = obj.wasChargeable
     this.provideCtcMrn = obj.provideCtcMrn
+    this.storeTransporterContact = obj.storeTransporterContact
 
     return Object.seal(new Proxy(this, handler))
   }

--- a/notification-schema-core/resources/notification-schema.json
+++ b/notification-schema-core/resources/notification-schema.json
@@ -935,6 +935,14 @@
             "YES_ADD_LATER",
             "NO"
           ]
+        },
+        "storeTransporterContact": {
+          "type": "string",
+          "description": "Select whether the importer wishes to store transporter contact details",
+          "enum": [
+            "YES",
+            "NO"
+          ]
         }
       }
     },

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/PartOne.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/PartOne.java
@@ -25,6 +25,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.ProvideCtcMrnEnum;
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.RetrospectiveCloningMergeMethod;
+import uk.gov.defra.tracesx.notificationschema.representation.enumeration.StoreTransporterContactEnum;
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.TypeOfImp;
 import uk.gov.defra.tracesx.notificationschema.representation.serialisation.IsoDateDeserializer;
 import uk.gov.defra.tracesx.notificationschema.representation.serialisation.IsoDateSerializer;
@@ -68,6 +69,7 @@ import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationVet
 import uk.gov.defra.tracesx.notificationschema.validation.groups.PhytosanitaryCertificateRequiredValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.PointOfEntryControlPointValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.ProvideCtcMrnValidation;
+import uk.gov.defra.tracesx.notificationschema.validation.groups.StoreTransporterContactValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.TransporterDetailsRequiredCEDValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.TransporterDetailsRequiredCHEDPPValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.TransporterDetailsRequiredCvedaValidation;
@@ -621,4 +623,12 @@ public class PartOne {
           + ".not.null}"
   )
   private ProvideCtcMrnEnum provideCtcMrn;
+
+  @NotNull(
+      groups = StoreTransporterContactValidation.class,
+      message =
+          "{uk.gov.defra.tracesx.notificationschema.representation.partone.storeTransporterContact"
+          + ".not.null}"
+  )
+  private StoreTransporterContactEnum storeTransporterContact;
 }

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/StoreTransporterContactEnum.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/StoreTransporterContactEnum.java
@@ -1,0 +1,6 @@
+package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
+
+public enum StoreTransporterContactEnum {
+  YES,
+  NO
+}

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/groups/StoreTransporterContactValidation.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/groups/StoreTransporterContactValidation.java
@@ -1,0 +1,5 @@
+package uk.gov.defra.tracesx.notificationschema.validation.groups;
+
+public interface StoreTransporterContactValidation {
+
+}

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/StoreTransporterContactEnumTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/StoreTransporterContactEnumTest.java
@@ -1,0 +1,18 @@
+package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+public class StoreTransporterContactEnumTest {
+
+  @Test
+  public void givenYesValue_whenValueOfCalled_shouldReturnEnumValue() {
+    assertThat(StoreTransporterContactEnum.valueOf("YES")).isEqualTo(StoreTransporterContactEnum.YES);
+  }
+
+  @Test
+  public void givenNoValue_whenValueOfCalled_shouldReturnEnumValue() {
+    assertThat(StoreTransporterContactEnum.valueOf("NO")).isEqualTo(StoreTransporterContactEnum.NO);
+  }
+}


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Maciej Trzasalski (Kainos) |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [IMTA-19028 Schema update for transporter...](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/430) |
> | **GitLab MR Number** | [430](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/430) |
> | **Date Originally Opened** | Tue, 22 Oct 2024 |
> | **Approved on GitLab by** | Asad Khan (Kainos), Jonathan Magee, Mayuresh Kadu (Kainos), Odran Muldoon (Kainos), Toyin Ajani (Kainos), niamh mclarnon (Kainos) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: [Jira Ticket](https://eaflood.atlassian.net/browse/IMTA-19028)

### :chart_with_upwards_trend: [SonarQube Report](https://vss-sonarqube.azure.defra.cloud/dashboard?branch=feature%2FIMTA-19028-store-transporter-contacts-schema-change-v1&id=Imports-Notification-Schema)

### :building_construction: [Jenkins Pipeline](https://jenkins-imports.azure.defra.cloud/job/imports-notification-schema/job/feature%2FIMTA-19028-store-transporter-contacts-schema-change-v1/)

### :book: Changes:

- schema change to add new field `partOne.storeTransporterContact`