### PR TITLE
IMTA:18684 code smells in notification schema

### DIFF
--- a/imports-frontend-entities/src/entities/base/type.js
+++ b/imports-frontend-entities/src/entities/base/type.js
@@ -43,7 +43,6 @@ module.exports = class Type {
         }
       },
       set(target, name, value) {
-        void value
         throw new Error('Type is immutable.')
       }
     }))

--- a/notification-schema-java/pom.xml
+++ b/notification-schema-java/pom.xml
@@ -57,8 +57,13 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -70,6 +75,11 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/ComplementParameterSet.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/ComplementParameterSet.java
@@ -145,8 +145,8 @@ public class ComplementParameterSet {
   @JsonIgnore
   public boolean isArticle72() {
     return this.keyDataPair.stream().filter(Objects::nonNull)
-        .anyMatch(keyDataPair ->
-            LOW_RISK_ARTICLE_72_COMMODITY.equals(keyDataPair.getKey())
-            && Boolean.parseBoolean(keyDataPair.getData()));
+        .anyMatch(keyDataPairMatched ->
+            LOW_RISK_ARTICLE_72_COMMODITY.equals(keyDataPairMatched.getKey())
+            && Boolean.parseBoolean(keyDataPairMatched.getData()));
   }
 }

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/Decision.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/Decision.java
@@ -180,6 +180,10 @@ public class Decision {
   @JsonDeserialize(using = IsoDateDeserializer.class)
   private LocalDate temporaryDeadline;
 
+  // SuppressWarning java:S1700 as Sonarqube state that its confusing that the enum has the same
+  // name as the class, I don't believe this is true, we can refactor this name,
+  // but it will cause 10+ changes to the code and not necessarily make it clearer
+  @SuppressWarnings("java:S1700")
   private DecisionEnum decision;
   private FreeCirculationPurposeEnum freeCirculationPurpose;
   private DefinitiveImportPurposeEnum definitiveImportPurpose;

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/VeterinaryInformation.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/VeterinaryInformation.java
@@ -13,11 +13,9 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import uk.gov.defra.tracesx.notificationschema.representation.enumeration.RetrospectiveCloningMergeMethod;
 import uk.gov.defra.tracesx.notificationschema.representation.serialisation.IsoDateDeserializer;
 import uk.gov.defra.tracesx.notificationschema.representation.serialisation.IsoDateSerializer;
 import uk.gov.defra.tracesx.notificationschema.validation.annotations.LatestHealthCertificateRequired;
-import uk.gov.defra.tracesx.notificationschema.validation.annotations.RetrospectiveCloningProperty;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationSingleCvedpFieldValidationHighRiskJourney;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationVeterinaryApprovedEstablishmentValidation;
 

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/AccompanyingDocumentsTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/AccompanyingDocumentsTest.java
@@ -2,13 +2,13 @@ package uk.gov.defra.tracesx.notificationschema.representation;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.ExternalSystem;
 
-public class AccompanyingDocumentsTest {
+ class AccompanyingDocumentsTest {
 
   @Test
-  public void isClonedDocument_ReturnsTrue_whenExternalReferenceIsECERT() {
+  void isClonedDocument_ReturnsTrue_whenExternalReferenceIsECERT() {
     AccompanyingDocument accompanyingDocument = AccompanyingDocument.builder()
         .externalReference(ExternalReference.builder().
             system(ExternalSystem.ECERT)
@@ -18,7 +18,7 @@ public class AccompanyingDocumentsTest {
   }
 
   @Test
-  public void isClonedDocument_ReturnsFalse_whenExternalReferenceIsNotECERT() {
+  void isClonedDocument_ReturnsFalse_whenExternalReferenceIsNotECERT() {
     AccompanyingDocument accompanyingDocument = AccompanyingDocument.builder()
         .externalReference(ExternalReference.builder()
             .system(ExternalSystem.EPHYTO)
@@ -28,7 +28,7 @@ public class AccompanyingDocumentsTest {
   }
 
   @Test
-  public void isClonedDocument_ReturnsFalse_whenNoExternalReference() {
+  void isClonedDocument_ReturnsFalse_whenNoExternalReference() {
     AccompanyingDocument accompanyingDocument = AccompanyingDocument.builder()
         .build();
     assertThat(accompanyingDocument.isClonedDocument()).isFalse();

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/CommoditiesTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/CommoditiesTest.java
@@ -2,19 +2,18 @@ package uk.gov.defra.tracesx.notificationschema.representation;
 
 import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.defra.tracesx.notificationschema.representation.ComplementParameterSet.LOW_RISK_ARTICLE_72_COMMODITY;
 
 import java.util.List;
 import java.util.UUID;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class CommoditiesTest {
+class CommoditiesTest {
 
   @Test
-  public void checkAddCommodityComplementItemWithNullList() {
+  void checkAddCommodityComplementItemWithNullList() {
     Commodities commodities = new Commodities();
 
     commodities.setCommodityComplement(null);
@@ -22,11 +21,11 @@ public class CommoditiesTest {
         .addCommodityComplementItem(new CommodityComplement())
         .addCommodityComplementItem(new CommodityComplement());
 
-    assertEquals(2, commodities.getCommodityComplement().size());
+    assertThat(commodities.getCommodityComplement()).hasSize(2);
   }
 
   @Test
-  public void checkAddComplementParameterSetItemWithNullList() {
+  void checkAddComplementParameterSetItemWithNullList() {
     Commodities commodities = new Commodities();
 
     commodities.setComplementParameterSet(null);
@@ -34,31 +33,31 @@ public class CommoditiesTest {
         .addComplementParameterSetItem(new ComplementParameterSet())
         .addComplementParameterSetItem(new ComplementParameterSet());
 
-    assertEquals(2, commodities.getComplementParameterSet().size());
+    assertThat(commodities.getComplementParameterSet()).hasSize(2);
   }
 
   @Test
-  public void isArticle72Consignment_ReturnsFalse_WhenComplementParameterSetIsNull() {
+  void isArticle72Consignment_ReturnsFalse_WhenComplementParameterSetIsNull() {
     Commodities commodities = Commodities.builder()
         .isLowRiskArticle72Country(true)
         .build();
 
-    assertFalse(commodities.isArticle72Consignment());
+    assertThat(commodities.isArticle72Consignment()).isFalse();
   }
 
   @Test
-  public void isArticle72Consignment_ReturnsFalse_WhenIsLowRiskArticle72CountryIsNull() {
+  void isArticle72Consignment_ReturnsFalse_WhenIsLowRiskArticle72CountryIsNull() {
     Commodities commodities = Commodities.builder()
         .complementParameterSet(List.of(
             buildComplementParameterSet(TRUE),
             buildComplementParameterSet(TRUE)
         )).build();
 
-    assertFalse(commodities.isArticle72Consignment());
+    assertThat(commodities.isArticle72Consignment()).isFalse();
   }
 
   @Test
-  public void isArticle72Consignment_ReturnsFalse_WhenIsLowRiskArticle72CountryIsFalse() {
+  void isArticle72Consignment_ReturnsFalse_WhenIsLowRiskArticle72CountryIsFalse() {
     Commodities commodities = Commodities.builder()
         .isLowRiskArticle72Country(false)
         .complementParameterSet(List.of(
@@ -66,11 +65,11 @@ public class CommoditiesTest {
             buildComplementParameterSet(TRUE)
         )).build();
 
-    assertFalse(commodities.isArticle72Consignment());
+    assertThat(commodities.isArticle72Consignment()).isFalse();
   }
 
   @Test
-  public void isArticle72Consignment_ReturnsFalse_WhenNotAllCommoditiesAreArticle72() {
+  void isArticle72Consignment_ReturnsFalse_WhenNotAllCommoditiesAreArticle72() {
     Commodities commodities = Commodities.builder()
         .isLowRiskArticle72Country(true)
         .complementParameterSet(List.of(
@@ -78,11 +77,11 @@ public class CommoditiesTest {
             buildComplementParameterSet(TRUE)
         )).build();
 
-    assertFalse(commodities.isArticle72Consignment());
+    assertThat(commodities.isArticle72Consignment()).isFalse();
   }
 
   @Test
-  public void isArticle72Consignment_ReturnsTrue_WhenAllCommoditiesAreArticle72() {
+  void isArticle72Consignment_ReturnsTrue_WhenAllCommoditiesAreArticle72() {
     Commodities commodities = Commodities.builder()
         .isLowRiskArticle72Country(true)
         .complementParameterSet(List.of(
@@ -90,7 +89,7 @@ public class CommoditiesTest {
             buildComplementParameterSet(TRUE)
         )).build();
 
-    assertTrue(commodities.isArticle72Consignment());
+    assertThat(commodities.isArticle72Consignment()).isTrue();
   }
 
   private ComplementParameterSet buildComplementParameterSet(Boolean isLowRiskArticle72Commodity) {

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/ComplementParameterSetTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/ComplementParameterSetTest.java
@@ -1,18 +1,17 @@
 package uk.gov.defra.tracesx.notificationschema.representation;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.defra.tracesx.notificationschema.representation.ComplementParameterSet.COMMODITY_GROUP;
 import static uk.gov.defra.tracesx.notificationschema.representation.ComplementParameterSet.LOW_RISK_ARTICLE_72_COMMODITY;
 import static uk.gov.defra.tracesx.notificationschema.representation.ComplementParameterSet.QUANTITY;
 
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class ComplementParameterSetTest {
+class ComplementParameterSetTest {
 
   @Test
-  public void isArticle72_ReturnsFalse_WhenDoesNotContainLowRiskArticle72CommodityKey() {
+  void isArticle72_ReturnsFalse_WhenDoesNotContainLowRiskArticle72CommodityKey() {
     ComplementParameterSet complementParameterSet = ComplementParameterSet.builder()
         .keyDataPair(List.of(
             ComplementParameterSetKeyDataPair.builder().key(QUANTITY).data("1").build(),
@@ -20,11 +19,11 @@ public class ComplementParameterSetTest {
         ))
         .build();
 
-    assertFalse(complementParameterSet.isArticle72());
+    assertThat(complementParameterSet.isArticle72()).isFalse();
   }
 
   @Test
-  public void isArticle72_ReturnsFalse_WhenLowRiskArticle72CommodityIsFalse() {
+  void isArticle72_ReturnsFalse_WhenLowRiskArticle72CommodityIsFalse() {
     ComplementParameterSet complementParameterSet = ComplementParameterSet.builder()
         .keyDataPair(List.of(
             ComplementParameterSetKeyDataPair.builder().key(QUANTITY).data("1").build(),
@@ -33,11 +32,11 @@ public class ComplementParameterSetTest {
         ))
         .build();
 
-    assertFalse(complementParameterSet.isArticle72());
+    assertThat(complementParameterSet.isArticle72()).isFalse();
   }
 
   @Test
-  public void isArticle72_ReturnsTrue_WhenLowRiskArticle72CommodityIsTrue() {
+  void isArticle72_ReturnsTrue_WhenLowRiskArticle72CommodityIsTrue() {
     ComplementParameterSet complementParameterSet = ComplementParameterSet.builder()
         .keyDataPair(List.of(
             ComplementParameterSetKeyDataPair.builder().key(QUANTITY).data("1").build(),
@@ -46,6 +45,6 @@ public class ComplementParameterSetTest {
         ))
         .build();
 
-    assertTrue(complementParameterSet.isArticle72());
+    assertThat(complementParameterSet.isArticle72()).isTrue();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/ControlTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/ControlTest.java
@@ -2,12 +2,12 @@ package uk.gov.defra.tracesx.notificationschema.representation;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class ControlTest {
+class ControlTest {
 
   @Test
-  public void equals() {
+  void equals() {
     EqualsVerifier.forClass(Control.class)
         .usingGetClass()
         .suppress(Warning.NONFINAL_FIELDS)

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/DecisionTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/DecisionTest.java
@@ -1,15 +1,14 @@
 package uk.gov.defra.tracesx.notificationschema.representation;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.NotAcceptableActionReasonEnum;
 
-public class DecisionTest {
+class DecisionTest {
 
   @Test
-  public void notAcceptableActionDestructionReasonIsSetCorrectly() {
+  void notAcceptableActionDestructionReasonIsSetCorrectly() {
     Decision decision = Decision.builder()
         .notAcceptableActionDestructionReason(NotAcceptableActionReasonEnum.CONTAMINATED_PRODUCTS)
         .notAcceptableActionEntryRefusalReason(NotAcceptableActionReasonEnum.PACKAGING_MATERIAL)
@@ -22,19 +21,19 @@ public class DecisionTest {
         .notAcceptableActionUseForOtherPurposesReason(NotAcceptableActionReasonEnum.OTHER)
         .build();
 
-    assertEquals(decision.getNotAcceptableActionDestructionReason(),
-            NotAcceptableActionReasonEnum.CONTAMINATED_PRODUCTS);
-    assertEquals(decision.getNotAcceptableActionEntryRefusalReason(),
-            NotAcceptableActionReasonEnum.PACKAGING_MATERIAL);
-    assertEquals(decision.getNotAcceptableActionQuarantineImposedReason(),
-            NotAcceptableActionReasonEnum.THE_INTERCEPTED_PART_OF_THE_CONSIGNMENT);
-    assertEquals(decision.getNotAcceptableActionSpecialTreatmentReason(),
-            NotAcceptableActionReasonEnum.OTHER);
-    assertEquals(decision.getNotAcceptableActionIndustrialProcessingReason(),
-            NotAcceptableActionReasonEnum.CONTAMINATED_PRODUCTS);
-    assertEquals(decision.getNotAcceptableActionReDispatchReason(),
-            NotAcceptableActionReasonEnum.MEANS_OF_TRANSPORT);
-    assertEquals(decision.getNotAcceptableActionUseForOtherPurposesReason(),
-            NotAcceptableActionReasonEnum.OTHER);
+    assertThat(decision.getNotAcceptableActionDestructionReason()).isEqualTo(
+        NotAcceptableActionReasonEnum.CONTAMINATED_PRODUCTS);
+    assertThat(decision.getNotAcceptableActionEntryRefusalReason()).isEqualTo(
+        NotAcceptableActionReasonEnum.PACKAGING_MATERIAL);
+    assertThat(decision.getNotAcceptableActionQuarantineImposedReason()).isEqualTo(
+        NotAcceptableActionReasonEnum.THE_INTERCEPTED_PART_OF_THE_CONSIGNMENT);
+    assertThat(decision.getNotAcceptableActionSpecialTreatmentReason()).isEqualTo(
+        NotAcceptableActionReasonEnum.OTHER);
+    assertThat(decision.getNotAcceptableActionIndustrialProcessingReason()).isEqualTo(
+        NotAcceptableActionReasonEnum.CONTAMINATED_PRODUCTS);
+    assertThat(decision.getNotAcceptableActionReDispatchReason()).isEqualTo(
+        NotAcceptableActionReasonEnum.MEANS_OF_TRANSPORT);
+    assertThat(decision.getNotAcceptableActionUseForOtherPurposesReason()).isEqualTo(
+        NotAcceptableActionReasonEnum.OTHER);
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/DetailsOnReExportTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/DetailsOnReExportTest.java
@@ -2,12 +2,12 @@ package uk.gov.defra.tracesx.notificationschema.representation;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class DetailsOnReExportTest {
+class DetailsOnReExportTest {
 
   @Test
-  public void equals() {
+  void equals() {
     EqualsVerifier.forClass(DetailsOnReExport.class)
         .suppress(Warning.NONFINAL_FIELDS)
         .verify();

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/FeedbackInformationTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/FeedbackInformationTest.java
@@ -2,12 +2,12 @@ package uk.gov.defra.tracesx.notificationschema.representation;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class FeedbackInformationTest {
+class FeedbackInformationTest {
 
   @Test
-  public void equals() {
+  void equals() {
     EqualsVerifier.forClass(FeedbackInformation.class)
         .usingGetClass()
         .suppress(Warning.NONFINAL_FIELDS)

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/NotificationTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/NotificationTest.java
@@ -3,61 +3,61 @@ package uk.gov.defra.tracesx.notificationschema.representation;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.ExternalSystem;
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.NotificationTypeEnum;
 
-public class NotificationTest {
+class NotificationTest {
 
   private final Notification notification = new Notification();
 
   @Test
-  public void isCveda_ReturnsTrue_whenTypeIsCveda() {
+  void isCveda_ReturnsTrue_whenTypeIsCveda() {
     notification.setType(NotificationTypeEnum.CVEDA);
     assertThat(notification.isCveda()).isTrue();
   }
 
   @Test
-  public void isCvedp_ReturnsTrue_whenTypeIsCvedp() {
+  void isCvedp_ReturnsTrue_whenTypeIsCvedp() {
     notification.setType(NotificationTypeEnum.CVEDP);
     assertThat(notification.isCvedp()).isTrue();
   }
 
   @Test
-  public void isCed_ReturnsTrue_whenTypeIsCed() {
+  void isCed_ReturnsTrue_whenTypeIsCed() {
     notification.setType(NotificationTypeEnum.CED);
     assertThat(notification.isCed()).isTrue();
   }
 
   @Test
-  public void isChedpp_ReturnsTrue_whenTypeIsChedpp() {
+  void isChedpp_ReturnsTrue_whenTypeIsChedpp() {
     notification.setType(NotificationTypeEnum.CHEDPP);
     assertThat(notification.isChedpp()).isTrue();
   }
 
   @Test
-  public void isClonedChedP_ReturnsTrue_whenTypeIsChedpAndCloned() {
+  void isClonedChedP_ReturnsTrue_whenTypeIsChedpAndCloned() {
     notification.setType(NotificationTypeEnum.CVEDP);
     notification.setExternalReferences(List.of(ExternalReference.builder().system(ExternalSystem.ECERT).build()));
     assertThat(notification.isClonedChedP()).isTrue();
   }
 
   @Test
-  public void isClonedChedP_ReturnsFalse_whenTypeIsNotChedp() {
+  void isClonedChedP_ReturnsFalse_whenTypeIsNotChedp() {
     notification.setType(NotificationTypeEnum.CHEDPP);
     notification.setExternalReferences(List.of(ExternalReference.builder().system(ExternalSystem.ECERT).build()));
     assertThat(notification.isClonedChedP()).isFalse();
   }
 
   @Test
-  public void isClonedChedP_ReturnsFalse_whenTypeIsChedpAndExternalReferenceIsEPHYTO() {
+  void isClonedChedP_ReturnsFalse_whenTypeIsChedpAndExternalReferenceIsEPHYTO() {
     notification.setType(NotificationTypeEnum.CVEDP);
     notification.setExternalReferences(List.of(ExternalReference.builder().system(ExternalSystem.EPHYTO).build()));
     assertThat(notification.isClonedChedP()).isFalse();
   }
 
   @Test
-  public void isClonedChedP_ReturnsFalse_whenTypeIsChedpNoExternalReference() {
+  void isClonedChedP_ReturnsFalse_whenTypeIsChedpNoExternalReference() {
     notification.setType(NotificationTypeEnum.CVEDP);
     assertThat(notification.isClonedChedP()).isFalse();
   }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/AnalysisTypeTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/AnalysisTypeTest.java
@@ -1,39 +1,38 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class AnalysisTypeTest {
+class AnalysisTypeTest {
   private final static String INITIAL_ANALYSIS_STRING = "Initial analysis";
   private final static String INVALID_STRING = "Invalid";
 
   @Test
-  public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
+  void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
     String enumResult = AnalysisType.INITIAL.toString();
 
-    assertEquals(enumResult, INITIAL_ANALYSIS_STRING);
+    assertThat(enumResult).isEqualTo(INITIAL_ANALYSIS_STRING);
   }
 
   @Test
-  public void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
+  void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
     String enumResult = AnalysisType.INITIAL.getValue();
 
-    assertEquals(enumResult, INITIAL_ANALYSIS_STRING);
+    assertThat(enumResult).isEqualTo(INITIAL_ANALYSIS_STRING);
   }
 
   @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
+  void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
     AnalysisType enumResult = AnalysisType.fromValue(INITIAL_ANALYSIS_STRING);
 
-    assertEquals(enumResult, AnalysisType.INITIAL);
+    assertThat(enumResult).isEqualTo(AnalysisType.INITIAL);
   }
 
   @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
+  void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
     AnalysisType enumResult = AnalysisType.fromValue(INVALID_STRING);
 
-    assertNull(enumResult);
+    assertThat(enumResult).isNull();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/AnimalCertificationTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/AnimalCertificationTest.java
@@ -1,39 +1,38 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class AnimalCertificationTest {
+ class AnimalCertificationTest {
   private final static String APPROVED_STRING = "Approved";
   private final static String INVALID_STRING = "Invalid";
 
   @Test
-  public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
+  void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
     String enumResult = AnimalCertification.APPROVED.toString();
 
-    assertEquals(enumResult, APPROVED_STRING);
+    assertThat(enumResult).isEqualTo(APPROVED_STRING);
   }
 
   @Test
-  public void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
+  void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
     String enumResult = AnimalCertification.APPROVED.getValue();
 
-    assertEquals(enumResult, APPROVED_STRING);
+    assertThat(enumResult).isEqualTo(APPROVED_STRING);
   }
 
   @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
+  void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
     AnimalCertification enumResult = AnimalCertification.fromValue(APPROVED_STRING);
 
-    assertEquals(enumResult, AnimalCertification.APPROVED);
+    assertThat(enumResult).isEqualTo(AnimalCertification.APPROVED);
   }
 
   @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
+  void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
     AnimalCertification enumResult = AnimalCertification.fromValue(INVALID_STRING);
 
-    assertNull(enumResult);
+    assertThat(enumResult).isNull();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/AnimalsUnitTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/AnimalsUnitTest.java
@@ -1,39 +1,38 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class AnimalsUnitTest {
+ class AnimalsUnitTest {
   private final static String PERCENT_STRING = "percent";
   private final static String INVALID_STRING = "Invalid";
 
   @Test
-  public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
+  void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
     String enumResult = AnimalsUnit.PERCENT.toString();
 
-    assertEquals(enumResult, PERCENT_STRING);
+    assertThat(enumResult).isEqualTo(PERCENT_STRING);
   }
 
   @Test
-  public void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
+  void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
     String enumResult = AnimalsUnit.PERCENT.getValue();
 
-    assertEquals(enumResult, PERCENT_STRING);
+    assertThat(enumResult).isEqualTo(PERCENT_STRING);
   }
 
   @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
+  void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
     AnimalsUnit enumResult = AnimalsUnit.fromValue(PERCENT_STRING);
 
-    assertEquals(enumResult, AnimalsUnit.PERCENT);
+    assertThat(enumResult).isEqualTo(AnimalsUnit.PERCENT);
   }
 
   @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
+  void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
     AnimalsUnit enumResult = AnimalsUnit.fromValue(INVALID_STRING);
 
-    assertNull(enumResult);
+    assertThat(enumResult).isNull();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/AuthorityTypeTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/AuthorityTypeTest.java
@@ -1,39 +1,38 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class AuthorityTypeTest {
+ class AuthorityTypeTest {
   private final static String EXIT_BIP_STRING = "exitbip";
   private final static String INVALID_STRING = "Invalid";
 
   @Test
-  public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
+  void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
     String enumResult = AuthorityType.EXITBIP.toString();
 
-    assertEquals(enumResult, EXIT_BIP_STRING);
+    assertThat(enumResult).isEqualTo(EXIT_BIP_STRING);
   }
 
   @Test
-  public void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
+  void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
     String enumResult = AuthorityType.EXITBIP.getValue();
 
-    assertEquals(enumResult, EXIT_BIP_STRING);
+    assertThat(enumResult).isEqualTo(EXIT_BIP_STRING);
   }
 
   @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
+  void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
     AuthorityType enumResult = AuthorityType.fromValue(EXIT_BIP_STRING);
 
-    assertEquals(enumResult, AuthorityType.EXITBIP);
+    assertThat(enumResult).isEqualTo(AuthorityType.EXITBIP);
   }
 
   @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
+  void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
     AuthorityType enumResult = AuthorityType.fromValue(INVALID_STRING);
 
-    assertNull(enumResult);
+    assertThat(enumResult).isNull();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/CheckStatusTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/CheckStatusTest.java
@@ -1,40 +1,39 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class CheckStatusTest {
+ class CheckStatusTest {
 
   private final static String TO_DO_STRING = "To do";
   private final static String INVALID_STRING = "Invalid";
 
   @Test
-  public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
+  void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
     String enumResult = CheckStatus.TO_DO.toString();
 
-    assertEquals(enumResult, TO_DO_STRING);
+    assertThat(enumResult).isEqualTo(TO_DO_STRING);
   }
 
   @Test
-  public void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
+  void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
     String enumResult = CheckStatus.TO_DO.getValue();
 
-    assertEquals(enumResult, TO_DO_STRING);
+    assertThat(enumResult).isEqualTo(TO_DO_STRING);
   }
 
   @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
+  void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
     CheckStatus enumResult = CheckStatus.fromValue(TO_DO_STRING);
 
-    assertEquals(enumResult, CheckStatus.TO_DO);
+    assertThat(enumResult).isEqualTo(CheckStatus.TO_DO);
   }
 
   @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
+  void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
     CheckStatus enumResult = CheckStatus.fromValue(INVALID_STRING);
 
-    assertNull(enumResult);
+    assertThat(enumResult).isNull();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/CheckTypeTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/CheckTypeTest.java
@@ -1,40 +1,39 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class CheckTypeTest {
+ class CheckTypeTest {
 
   private final static String PHSI_DOCUMENT_STRING = "PHSI_DOCUMENT";
   private final static String INVALID_STRING = "Invalid";
 
   @Test
-  public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
+  void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
     String enumResult = CheckType.PHSI_DOCUMENT.toString();
 
-    assertEquals(enumResult, PHSI_DOCUMENT_STRING);
+    assertThat(enumResult).isEqualTo(PHSI_DOCUMENT_STRING);
   }
 
   @Test
-  public void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
+  void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
     String enumResult = CheckType.PHSI_DOCUMENT.getValue();
 
-    assertEquals(enumResult, PHSI_DOCUMENT_STRING);
+    assertThat(enumResult).isEqualTo(PHSI_DOCUMENT_STRING);
   }
 
   @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
+  void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
     CheckType enumResult = CheckType.fromValue(PHSI_DOCUMENT_STRING);
 
-    assertEquals(enumResult, CheckType.PHSI_DOCUMENT);
+    assertThat(enumResult).isEqualTo(CheckType.PHSI_DOCUMENT);
   }
 
   @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
+  void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
     CheckType enumResult = CheckType.fromValue(INVALID_STRING);
 
-    assertNull(enumResult);
+    assertThat(enumResult).isNull();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ChedppNotAcceptableCommodityOrPackageEnumTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ChedppNotAcceptableCommodityOrPackageEnumTest.java
@@ -1,42 +1,39 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNotNull;
-import static junit.framework.TestCase.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class ChedppNotAcceptableCommodityOrPackageEnumTest {
+class ChedppNotAcceptableCommodityOrPackageEnumTest {
   private final static String COMMODITIES_STRING = "c";
 
   @Test
-  public void chedppNotAcceptableCommodityOrPackageEnumShouldReturnValueWhenValueIsValid() {
+  void chedppNotAcceptableCommodityOrPackageEnumShouldReturnValueWhenValueIsValid() {
     ChedppNotAcceptableCommodityOrPackageEnum enumResult = ChedppNotAcceptableCommodityOrPackageEnum
         .fromValue(COMMODITIES_STRING);
 
-    assertEquals(enumResult, ChedppNotAcceptableCommodityOrPackageEnum.COMMODITIES);
-    assertNotNull(enumResult);
+    assertThat(enumResult).isEqualTo(ChedppNotAcceptableCommodityOrPackageEnum.COMMODITIES);
   }
 
   @Test
-  public void chedppNotAcceptableCommodityOrPackageEnumShouldReturnNullWhenValueIsInvalid() {
+  void chedppNotAcceptableCommodityOrPackageEnumShouldReturnNullWhenValueIsInvalid() {
     ChedppNotAcceptableCommodityOrPackageEnum enumResult = ChedppNotAcceptableCommodityOrPackageEnum
         .fromValue("invalid");
 
-    assertNull(enumResult);
+    assertThat(enumResult).isNull();
   }
 
   @Test
-  public void chedppNotAcceptableCommodityOrPackageEnumShouldReturnStringValue() {
+  void chedppNotAcceptableCommodityOrPackageEnumShouldReturnStringValue() {
     String enumResult = ChedppNotAcceptableCommodityOrPackageEnum.COMMODITIES.toString();
 
-    assertEquals(COMMODITIES_STRING, enumResult);
+    assertThat(enumResult).isEqualTo(COMMODITIES_STRING);
   }
 
   @Test
-  public void chedppNotAcceptableCommodityOrPackageEnumShouldReturnValue() {
+  void chedppNotAcceptableCommodityOrPackageEnumShouldReturnValue() {
     String enumResult = ChedppNotAcceptableCommodityOrPackageEnum.COMMODITIES.getValue();
 
-    assertEquals(enumResult, COMMODITIES_STRING);
+    assertThat(enumResult).isEqualTo(COMMODITIES_STRING);
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ChedppNotAcceptableReasonEnumTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ChedppNotAcceptableReasonEnumTest.java
@@ -1,40 +1,37 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNotNull;
-import static junit.framework.TestCase.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class ChedppNotAcceptableReasonEnumTest {
+class ChedppNotAcceptableReasonEnumTest {
   private final static String DOCPHMDM_STRING = "doc-phmdm";
 
   @Test
-  public void chedppNotAcceptableReasonEnumShouldReturnValueWhenValueIsValid() {
+  void chedppNotAcceptableReasonEnumShouldReturnValueWhenValueIsValid() {
     ChedppNotAcceptableReasonEnum enumResult = ChedppNotAcceptableReasonEnum.fromValue(DOCPHMDM_STRING);
 
-    assertEquals(enumResult, ChedppNotAcceptableReasonEnum.DOCPHMDM);
-    assertNotNull(enumResult);
+    assertThat(enumResult).isEqualTo(ChedppNotAcceptableReasonEnum.DOCPHMDM);
   }
 
   @Test
-  public void chedppNotAcceptableReasonEnumShouldReturnNullWhenValueIsInvalid() {
+  void chedppNotAcceptableReasonEnumShouldReturnNullWhenValueIsInvalid() {
     ChedppNotAcceptableReasonEnum enumResult = ChedppNotAcceptableReasonEnum.fromValue("invalid");
 
-    assertNull(enumResult);
+    assertThat(enumResult).isNull();
   }
 
   @Test
-  public void chedppNotAcceptableReasonEnumShouldReturnStringValue() {
+  void chedppNotAcceptableReasonEnumShouldReturnStringValue() {
     String enumResult = ChedppNotAcceptableReasonEnum.DOCPHMDM.toString();
 
-    assertEquals(DOCPHMDM_STRING, enumResult);
+    assertThat(enumResult).isEqualTo(DOCPHMDM_STRING);
   }
 
   @Test
-  public void chedppNotAcceptableReasonEnumShouldReturnValue() {
+  void chedppNotAcceptableReasonEnumShouldReturnValue() {
     String enumResult = ChedppNotAcceptableReasonEnum.DOCPHMDM.getValue();
 
-    assertEquals(DOCPHMDM_STRING, enumResult);
+    assertThat(enumResult).isEqualTo(DOCPHMDM_STRING);
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/CommodityIntentionTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/CommodityIntentionTest.java
@@ -1,39 +1,37 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
+import org.junit.jupiter.api.Test;
 
-import org.junit.Test;
-
-public class CommodityIntentionTest {
+class CommodityIntentionTest {
   private final static String HUMAN_STRING = "human";
   private final static String INVALID_STRING = "Invalid";
 
   @Test
-  public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
+  void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
     String enumResult = CommodityIntention.HUMAN.toString();
 
-    assertEquals(enumResult, HUMAN_STRING);
+    assertThat(enumResult).isEqualTo(HUMAN_STRING);
   }
 
   @Test
-  public void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
+  void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
     String enumResult = CommodityIntention.HUMAN.getValue();
 
-    assertEquals(enumResult, HUMAN_STRING);
+    assertThat(enumResult).isEqualTo(HUMAN_STRING);
   }
 
   @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
+  void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
     CommodityIntention enumResult = CommodityIntention.fromValue(HUMAN_STRING);
 
-    assertEquals(enumResult, CommodityIntention.HUMAN);
+    assertThat(enumResult).isEqualTo(CommodityIntention.HUMAN);
   }
 
   @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
+  void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
     CommodityIntention enumResult = CommodityIntention.fromValue(INVALID_STRING);
 
-    assertNull(enumResult);
+    assertThat(enumResult).isNull();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/CommodityTemperatureTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/CommodityTemperatureTest.java
@@ -1,39 +1,37 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
+import org.junit.jupiter.api.Test;
 
-import org.junit.Test;
-
-public class CommodityTemperatureTest {
+class CommodityTemperatureTest {
   private final static String AMBIENT_STRING = "Ambient";
   private final static String INVALID_STRING = "Invalid";
 
   @Test
-  public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
+  void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
     String enumResult = CommodityTemperature.AMBIENT.toString();
 
-    assertEquals(enumResult, AMBIENT_STRING);
+    assertThat(enumResult).isEqualTo(AMBIENT_STRING);
   }
 
   @Test
-  public void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
+  void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
     String enumResult = CommodityTemperature.AMBIENT.getValue();
 
-    assertEquals(enumResult, AMBIENT_STRING);
+    assertThat(enumResult).isEqualTo(AMBIENT_STRING);
   }
 
   @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
+  void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
     CommodityTemperature enumResult = CommodityTemperature.fromValue(AMBIENT_STRING);
 
-    assertEquals(enumResult, CommodityTemperature.AMBIENT);
+    assertThat(enumResult).isEqualTo(CommodityTemperature.AMBIENT);
   }
 
   @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
+  void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
     CommodityTemperature enumResult = CommodityTemperature.fromValue(INVALID_STRING);
 
-    assertNull(enumResult);
+    assertThat(enumResult).isNull();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ConclusionTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ConclusionTest.java
@@ -1,39 +1,38 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class ConclusionTest {
+class ConclusionTest {
   private final static String SATISFACTORY_STRING = "Satisfactory";
   private final static String INVALID_STRING = "Invalid";
 
   @Test
-  public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
+  void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
     String enumResult = Conclusion.SATISFACTORY.toString();
 
-    assertEquals(enumResult, SATISFACTORY_STRING);
+    assertThat(enumResult).isEqualTo(SATISFACTORY_STRING);
   }
 
   @Test
-  public void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
+  void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
     String enumResult = Conclusion.SATISFACTORY.getValue();
 
-    assertEquals(enumResult, SATISFACTORY_STRING);
+    assertThat(enumResult).isEqualTo(SATISFACTORY_STRING);
   }
 
   @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
+  void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
     Conclusion enumResult = Conclusion.fromValue(SATISFACTORY_STRING);
 
-    assertEquals(enumResult, Conclusion.SATISFACTORY);
+    assertThat(enumResult).isEqualTo(Conclusion.SATISFACTORY);
   }
 
   @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
+  void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
     Conclusion enumResult = Conclusion.fromValue(INVALID_STRING);
 
-    assertNull(enumResult);
+    assertThat(enumResult).isNull();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ConservationOfSampleTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ConservationOfSampleTest.java
@@ -1,39 +1,38 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class ConservationOfSampleTest {
+class ConservationOfSampleTest {
   private final static String CHILLED_STRING = "Chilled";
   private final static String INVALID_STRING = "Invalid";
 
   @Test
-  public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
+  void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
     String enumResult = ConservationOfSample.CHILLED.toString();
 
-    assertEquals(enumResult, CHILLED_STRING);
+    assertThat(enumResult).isEqualTo(CHILLED_STRING);
   }
 
   @Test
-  public void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
+  void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
     String enumResult = ConservationOfSample.CHILLED.getValue();
 
-    assertEquals(enumResult, CHILLED_STRING);
+    assertThat(enumResult).isEqualTo(CHILLED_STRING);
   }
 
   @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
+  void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
     ConservationOfSample enumResult = ConservationOfSample.fromValue(CHILLED_STRING);
 
-    assertEquals(enumResult, ConservationOfSample.CHILLED);
+    assertThat(enumResult).isEqualTo(ConservationOfSample.CHILLED);
   }
 
   @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
+  void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
     ConservationOfSample enumResult = ConservationOfSample.fromValue(INVALID_STRING);
 
-    assertNull(enumResult);
+    assertThat(enumResult).isNull();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ConsignmentLeaveTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ConsignmentLeaveTest.java
@@ -1,39 +1,39 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
 
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
-public class ConsignmentLeaveTest {
+import org.junit.jupiter.api.Test;
+
+class ConsignmentLeaveTest {
   private final static String YES_STRING = "YES";
   private final static String INVALID_STRING = "Invalid";
 
   @Test
-  public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
+  void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
     String enumResult = ConsignmentLeave.YES.toString();
 
-    assertEquals(enumResult, YES_STRING);
+    assertThat(enumResult).isEqualTo(YES_STRING);
   }
 
   @Test
-  public void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
+  void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
     String enumResult = ConsignmentLeave.YES.getValue();
 
-    assertEquals(enumResult, YES_STRING);
+    assertThat(enumResult).isEqualTo(YES_STRING);
   }
 
   @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
+  void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
     ConsignmentLeave enumResult = ConsignmentLeave.fromValue(YES_STRING);
 
-    assertEquals(enumResult, ConsignmentLeave.YES);
+    assertThat(enumResult).isEqualTo(ConsignmentLeave.YES);
   }
 
   @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
+  void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
     ConsignmentLeave enumResult = ConsignmentLeave.fromValue(INVALID_STRING);
 
-    assertNull(enumResult);
+    assertThat(enumResult).isNull();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ControlStatusTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ControlStatusTest.java
@@ -1,39 +1,38 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class ControlStatusTest {
+class ControlStatusTest {
   private final static String COMPLETED_STRING = "COMPLETED";
   private final static String INVALID_STRING = "Invalid";
 
   @Test
-  public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
+  void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
     String enumResult = ControlStatus.COMPLETED.toString();
 
-    assertEquals(enumResult, COMPLETED_STRING);
+    assertThat(enumResult).isEqualTo(COMPLETED_STRING);
   }
 
   @Test
-  public void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
+  void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
     String enumResult = ControlStatus.COMPLETED.getValue();
 
-    assertEquals(enumResult, COMPLETED_STRING);
+    assertThat(enumResult).isEqualTo(COMPLETED_STRING);
   }
 
   @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
+  void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
     ControlStatus enumResult = ControlStatus.fromValue(COMPLETED_STRING);
 
-    assertEquals(enumResult, ControlStatus.COMPLETED);
+    assertThat(enumResult).isEqualTo(ControlStatus.COMPLETED);
   }
 
   @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
+  void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
     ControlStatus enumResult = ControlStatus.fromValue(INVALID_STRING);
 
-    assertNull(enumResult);
+    assertThat(enumResult).isNull();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/DecisionEnumTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/DecisionEnumTest.java
@@ -1,39 +1,38 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class DecisionEnumTest {
+class DecisionEnumTest {
   private final static String NON_ACCEPTABLE_STRING = "Non Acceptable";
   private final static String INVALID_STRING = "Invalid";
 
   @Test
-  public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
+  void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
     String enumResult = DecisionEnum.NON_ACCEPTABLE.toString();
 
-    assertEquals(enumResult, NON_ACCEPTABLE_STRING);
+    assertThat(enumResult).isEqualTo(NON_ACCEPTABLE_STRING);
   }
 
   @Test
-  public void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
+  void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
     String enumResult = DecisionEnum.NON_ACCEPTABLE.getValue();
 
-    assertEquals(enumResult, NON_ACCEPTABLE_STRING);
+    assertThat(enumResult).isEqualTo(NON_ACCEPTABLE_STRING);
   }
 
   @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
+  void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
     DecisionEnum enumResult = DecisionEnum.fromValue(NON_ACCEPTABLE_STRING);
 
-    assertEquals(enumResult, DecisionEnum.NON_ACCEPTABLE);
+    assertThat(enumResult).isEqualTo(DecisionEnum.NON_ACCEPTABLE);
   }
 
   @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
+  void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
     DecisionEnum enumResult = DecisionEnum.fromValue(INVALID_STRING);
 
-    assertNull(enumResult);
+    assertThat(enumResult).isNull();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/DefinitiveImportPurposeEnumTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/DefinitiveImportPurposeEnumTest.java
@@ -1,39 +1,38 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class DefinitiveImportPurposeEnumTest {
+class DefinitiveImportPurposeEnumTest {
   private final static String SLAUGHTER_STRING = "slaughter";
   private final static String INVALID_STRING = "Invalid";
 
   @Test
-  public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
+  void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
     String enumResult = DefinitiveImportPurposeEnum.SLAUGHTER.toString();
 
-    assertEquals(enumResult, SLAUGHTER_STRING);
+    assertThat(enumResult).isEqualTo(SLAUGHTER_STRING);
   }
 
   @Test
-  public void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
+  void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
     String enumResult = DefinitiveImportPurposeEnum.SLAUGHTER.getValue();
 
-    assertEquals(enumResult, SLAUGHTER_STRING);
+    assertThat(enumResult).isEqualTo(SLAUGHTER_STRING);
   }
 
   @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
+  void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
     DefinitiveImportPurposeEnum enumResult = DefinitiveImportPurposeEnum.fromValue(SLAUGHTER_STRING);
 
-    assertEquals(enumResult, DefinitiveImportPurposeEnum.SLAUGHTER);
+    assertThat(enumResult).isEqualTo(DefinitiveImportPurposeEnum.SLAUGHTER);
   }
 
   @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
+  void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
     DefinitiveImportPurposeEnum enumResult = DefinitiveImportPurposeEnum.fromValue(INVALID_STRING);
 
-    assertNull(enumResult);
+    assertThat(enumResult).isNull();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/DocumentTypeTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/DocumentTypeTest.java
@@ -1,39 +1,38 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class DocumentTypeTest {
+class DocumentTypeTest {
   private final static String AIR_WAYBILL_STRING = "airWaybill";
   private final static String INVALID_STRING = "Invalid";
 
   @Test
-  public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
+  void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
     String enumResult = DocumentType.AIR_WAYBILL.toString();
 
-    assertEquals(enumResult, AIR_WAYBILL_STRING);
+    assertThat(enumResult).isEqualTo(AIR_WAYBILL_STRING);
   }
 
   @Test
-  public void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
+  void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
     String enumResult = DocumentType.AIR_WAYBILL.getValue();
 
-    assertEquals(enumResult, AIR_WAYBILL_STRING);
+    assertThat(enumResult).isEqualTo(AIR_WAYBILL_STRING);
   }
 
   @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
+  void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
     DocumentType enumResult = DocumentType.fromValue(AIR_WAYBILL_STRING);
 
-    assertEquals(enumResult, DocumentType.AIR_WAYBILL);
+    assertThat(enumResult).isEqualTo(DocumentType.AIR_WAYBILL);
   }
 
   @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
+  void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
     DocumentType enumResult = DocumentType.fromValue(INVALID_STRING);
 
-    assertNull(enumResult);
+    assertThat(enumResult).isNull();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/EconomicOperatorStatusTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/EconomicOperatorStatusTest.java
@@ -1,39 +1,38 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class EconomicOperatorStatusTest {
+class EconomicOperatorStatusTest {
   private final static String SUSPENDED_STRING = "suspended";
   private final static String INVALID_STRING = "Invalid";
 
   @Test
-  public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
+  void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
     String enumResult = EconomicOperatorStatus.SUSPENDED.toString();
 
-    assertEquals(enumResult, SUSPENDED_STRING);
+    assertThat(enumResult).isEqualTo(SUSPENDED_STRING);
   }
 
   @Test
-  public void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
+  void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
     String enumResult = EconomicOperatorStatus.SUSPENDED.getValue();
 
-    assertEquals(enumResult, SUSPENDED_STRING);
+    assertThat(enumResult).isEqualTo(SUSPENDED_STRING);
   }
 
   @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
+  void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
     EconomicOperatorStatus enumResult = EconomicOperatorStatus.fromValue(SUSPENDED_STRING);
 
-    assertEquals(enumResult, EconomicOperatorStatus.SUSPENDED);
+    assertThat(enumResult).isEqualTo(EconomicOperatorStatus.SUSPENDED);
   }
 
   @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
+  void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
     EconomicOperatorStatus enumResult = EconomicOperatorStatus.fromValue(INVALID_STRING);
 
-    assertNull(enumResult);
+    assertThat(enumResult).isNull();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/EconomicOperatorTypeTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/EconomicOperatorTypeTest.java
@@ -1,39 +1,38 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class EconomicOperatorTypeTest {
+class EconomicOperatorTypeTest {
   private final static String CHARITY_STRING = "charity";
   private final static String INVALID_STRING = "Invalid";
 
   @Test
-  public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
+  void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
     String enumResult = EconomicOperatorType.CHARITY.toString();
 
-    assertEquals(enumResult, CHARITY_STRING);
+    assertThat(enumResult).isEqualTo(CHARITY_STRING);
   }
 
   @Test
-  public void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
+  void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
     String enumResult = EconomicOperatorType.CHARITY.getValue();
 
-    assertEquals(enumResult, CHARITY_STRING);
+    assertThat(enumResult).isEqualTo(CHARITY_STRING);
   }
 
   @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
+  void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
     EconomicOperatorType enumResult = EconomicOperatorType.fromValue(CHARITY_STRING);
 
-    assertEquals(enumResult, EconomicOperatorType.CHARITY);
+    assertThat(enumResult).isEqualTo(EconomicOperatorType.CHARITY);
   }
 
   @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
+  void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
     EconomicOperatorType enumResult = EconomicOperatorType.fromValue(INVALID_STRING);
 
-    assertNull(enumResult);
+    assertThat(enumResult).isNull();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ExternalSystemTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ExternalSystemTest.java
@@ -1,73 +1,72 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class ExternalSystemTest {
+class ExternalSystemTest {
   private final static String E_CERT = "E-CERT";
   private final static String E_PHYTO = "E-PHYTO";
   private final static String INVALID_STRING = "Invalid";
   private final static String NCTS = "NCTS";
 
   @Test
-  public void toString_ReturnsECertValue_WhenECertEnum() {
+  void toString_ReturnsECertValue_WhenECertEnum() {
     String enumResult = ExternalSystem.ECERT.toString();
-    assertEquals(enumResult, E_CERT);
+    assertThat(enumResult).isEqualTo(E_CERT);
   }
 
   @Test
-  public void toString_ReturnsEPhytoValue_WhenEPhytoEnum() {
+  void toString_ReturnsEPhytoValue_WhenEPhytoEnum() {
     String enumResult = ExternalSystem.EPHYTO.toString();
-    assertEquals(enumResult, E_PHYTO);
+    assertThat(enumResult).isEqualTo(E_PHYTO);
   }
 
   @Test
-  public void toString_ReturnsNCTSValue_WhenNCTS() {
+  void toString_ReturnsNCTSValue_WhenNCTS() {
     String enumResult = ExternalSystem.NCTS.toString();
-    assertEquals(enumResult, NCTS);
+    assertThat(enumResult).isEqualTo(NCTS);
   }
 
   @Test
-  public void getValue_ReturnsECertValue_WhenECertEnum() {
+  void getValue_ReturnsECertValue_WhenECertEnum() {
     String enumResult = ExternalSystem.ECERT.getValue();
-    assertEquals(enumResult, E_CERT);
+    assertThat(enumResult).isEqualTo(E_CERT);
   }
 
   @Test
-  public void getValue_ReturnsEPhytoValue_WhenEPhytoEnum() {
+  void getValue_ReturnsEPhytoValue_WhenEPhytoEnum() {
     String enumResult = ExternalSystem.EPHYTO.getValue();
-    assertEquals(enumResult, E_PHYTO);
+    assertThat(enumResult).isEqualTo(E_PHYTO);
   }
 
   @Test
-  public void getValue_ReturnsNCTSValue_WhenNCTS() {
+  void getValue_ReturnsNCTSValue_WhenNCTS() {
     String enumResult = ExternalSystem.NCTS.getValue();
-    assertEquals(enumResult, NCTS);
+    assertThat(enumResult).isEqualTo(NCTS);
   }
 
   @Test
-  public void fromValue_ReturnsECertEnum_WhenECertString() {
+  void fromValue_ReturnsECertEnum_WhenECertString() {
     ExternalSystem enumResult = ExternalSystem.fromValue(E_CERT);
-    assertEquals(enumResult, ExternalSystem.ECERT);
+    assertThat(enumResult).isEqualTo(ExternalSystem.ECERT);
   }
 
   @Test
-  public void fromValue_ReturnsEPhytoEnum_WhenEPhytoString() {
+  void fromValue_ReturnsEPhytoEnum_WhenEPhytoString() {
     ExternalSystem enumResult = ExternalSystem.fromValue(E_PHYTO);
-    assertEquals(enumResult, ExternalSystem.EPHYTO);
+    assertThat(enumResult).isEqualTo(ExternalSystem.EPHYTO);
   }
 
   @Test
-  public void fromValue_ReturnsNCTSEnum_WhenNCTSString() {
+  void fromValue_ReturnsNCTSEnum_WhenNCTSString() {
     ExternalSystem enumResult = ExternalSystem.fromValue(NCTS);
-    assertEquals(enumResult, ExternalSystem.NCTS);
+    assertThat(enumResult).isEqualTo(ExternalSystem.NCTS);
   }
 
   @Test
-  public void fromValue_ReturnsNull_WhenInvalidString() {
+  void fromValue_ReturnsNull_WhenInvalidString() {
     ExternalSystem enumResult = ExternalSystem.fromValue(INVALID_STRING);
-    assertNull(enumResult);
+    assertThat(enumResult).isNull();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ForImportOrAdmissionEnumTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ForImportOrAdmissionEnumTest.java
@@ -1,39 +1,38 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class ForImportOrAdmissionEnumTest {
+class ForImportOrAdmissionEnumTest {
   private final static String DEFINITIVE_IMPORT_STRING = "Definitive import";
   private final static String INVALID_STRING = "Invalid";
 
   @Test
-  public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
+  void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
     String enumResult = ForImportOrAdmissionEnum.DEFINITIVE_IMPORT.toString();
 
-    assertEquals(enumResult, DEFINITIVE_IMPORT_STRING);
+    assertThat(enumResult).isEqualTo(DEFINITIVE_IMPORT_STRING);
   }
 
   @Test
-  public void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
+  void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
     String enumResult = ForImportOrAdmissionEnum.DEFINITIVE_IMPORT.getValue();
 
-    assertEquals(enumResult, DEFINITIVE_IMPORT_STRING);
+    assertThat(enumResult).isEqualTo(DEFINITIVE_IMPORT_STRING);
   }
 
   @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
+  void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
     ForImportOrAdmissionEnum enumResult = ForImportOrAdmissionEnum.fromValue(DEFINITIVE_IMPORT_STRING);
 
-    assertEquals(enumResult, ForImportOrAdmissionEnum.DEFINITIVE_IMPORT);
+    assertThat(enumResult).isEqualTo(ForImportOrAdmissionEnum.DEFINITIVE_IMPORT);
   }
 
   @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
+  void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
     ForImportOrAdmissionEnum enumResult = ForImportOrAdmissionEnum.fromValue(INVALID_STRING);
 
-    assertNull(enumResult);
+    assertThat(enumResult).isNull();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ForNonConformingEnumTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ForNonConformingEnumTest.java
@@ -1,39 +1,38 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class ForNonConformingEnumTest {
+class ForNonConformingEnumTest {
   private final static String CUSTOMS_WAREHOUSE_STRING = "Customs Warehouse";
   private final static String INVALID_STRING = "Invalid";
 
   @Test
-  public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
+  void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
     String enumResult = ForNonConformingEnum.CUSTOMS_WAREHOUSE.toString();
 
-    assertEquals(enumResult, CUSTOMS_WAREHOUSE_STRING);
+    assertThat(enumResult).isEqualTo(CUSTOMS_WAREHOUSE_STRING);
   }
 
   @Test
-  public void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
+  void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
     String enumResult = ForNonConformingEnum.CUSTOMS_WAREHOUSE.getValue();
 
-    assertEquals(enumResult, CUSTOMS_WAREHOUSE_STRING);
+    assertThat(enumResult).isEqualTo(CUSTOMS_WAREHOUSE_STRING);
   }
 
   @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
+  void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
     ForNonConformingEnum enumResult = ForNonConformingEnum.fromValue(CUSTOMS_WAREHOUSE_STRING);
 
-    assertEquals(enumResult, ForNonConformingEnum.CUSTOMS_WAREHOUSE);
+    assertThat(enumResult).isEqualTo(ForNonConformingEnum.CUSTOMS_WAREHOUSE);
   }
 
   @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
+  void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
     ForNonConformingEnum enumResult = ForNonConformingEnum.fromValue(INVALID_STRING);
 
-    assertNull(enumResult);
+    assertThat(enumResult).isNull();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/FreeCirculationPurposeEnumTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/FreeCirculationPurposeEnumTest.java
@@ -1,39 +1,38 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class FreeCirculationPurposeEnumTest {
+class FreeCirculationPurposeEnumTest {
   private final static String FURTHER_PROCESS_STRING = "Further Process";
   private final static String INVALID_STRING = "Invalid";
 
   @Test
-  public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
+  void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
     String enumResult = FreeCirculationPurposeEnum.FURTHER_PROCESS.toString();
 
-    assertEquals(enumResult, FURTHER_PROCESS_STRING);
+    assertThat(enumResult).isEqualTo(FURTHER_PROCESS_STRING);
   }
 
   @Test
-  public void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
+  void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
     String enumResult = FreeCirculationPurposeEnum.FURTHER_PROCESS.getValue();
 
-    assertEquals(enumResult, FURTHER_PROCESS_STRING);
+    assertThat(enumResult).isEqualTo(FURTHER_PROCESS_STRING);
   }
 
   @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
+  void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
     FreeCirculationPurposeEnum enumResult = FreeCirculationPurposeEnum.fromValue(FURTHER_PROCESS_STRING);
 
-    assertEquals(enumResult, FreeCirculationPurposeEnum.FURTHER_PROCESS);
+    assertThat(enumResult).isEqualTo(FreeCirculationPurposeEnum.FURTHER_PROCESS);
   }
 
   @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
+  void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
     FreeCirculationPurposeEnum enumResult = FreeCirculationPurposeEnum.fromValue(INVALID_STRING);
 
-    assertNull(enumResult);
+    assertThat(enumResult).isNull();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/HmiDecisionTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/HmiDecisionTest.java
@@ -1,39 +1,38 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class HmiDecisionTest {
+class HmiDecisionTest {
   private final static String REQUIRED_STRING = "REQUIRED";
   private final static String INVALID_STRING = "Invalid";
 
   @Test
-  public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
+  void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
     String enumResult = HmiDecision.REQUIRED.toString();
 
-    assertEquals(enumResult, REQUIRED_STRING);
+    assertThat(enumResult).isEqualTo(REQUIRED_STRING);
   }
 
   @Test
-  public void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
+  void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
     String enumResult = HmiDecision.REQUIRED.getValue();
 
-    assertEquals(enumResult, REQUIRED_STRING);
+    assertThat(enumResult).isEqualTo(REQUIRED_STRING);
   }
 
   @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
+  void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
     HmiDecision enumResult = HmiDecision.fromValue(REQUIRED_STRING);
 
-    assertEquals(enumResult, HmiDecision.REQUIRED);
+    assertThat(enumResult).isEqualTo(HmiDecision.REQUIRED);
   }
 
   @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
+  void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
     HmiDecision enumResult = HmiDecision.fromValue(INVALID_STRING);
 
-    assertNull(enumResult);
+    assertThat(enumResult).isNull();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/IUUOptionTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/IUUOptionTest.java
@@ -1,39 +1,38 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class IUUOptionTest {
+class IUUOptionTest {
   private final static String IUUNA_STRING = "IUUNA";
   private final static String INVALID_STRING = "Invalid";
 
   @Test
-  public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
+  void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
     String enumResult = IUUOption.IUUNA.toString();
 
-    assertEquals(enumResult, IUUNA_STRING);
+    assertThat(enumResult).isEqualTo(IUUNA_STRING);
   }
 
   @Test
-  public void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
+  void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
     String enumResult = IUUOption.IUUNA.getValue();
 
-    assertEquals(enumResult, IUUNA_STRING);
+    assertThat(enumResult).isEqualTo(IUUNA_STRING);
   }
 
   @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
+  void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
     IUUOption enumResult = IUUOption.fromValue(IUUNA_STRING);
 
-    assertEquals(enumResult, IUUOption.IUUNA);
+    assertThat(enumResult).isEqualTo(IUUOption.IUUNA);
   }
 
   @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
+  void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
     IUUOption enumResult = IUUOption.fromValue(INVALID_STRING);
 
-    assertNull(enumResult);
+    assertThat(enumResult).isNull();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/IdentificationCheckTypeTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/IdentificationCheckTypeTest.java
@@ -1,47 +1,46 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class IdentificationCheckTypeTest {
+class IdentificationCheckTypeTest {
   private final static String SEAL_CHECK_STRING = "Seal Check";
   private final static String INVALID_STRING = "Invalid";
   private final static String NOT_DONE_STRING = "Not Done";
 
   @Test
-  public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
+  void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
     String enumResult = IdentificationCheckType.SEAL_CHECK.toString();
 
-    assertEquals(enumResult, SEAL_CHECK_STRING);
+    assertThat(enumResult).isEqualTo(SEAL_CHECK_STRING);
   }
 
   @Test
-  public void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
+  void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
     String enumResult = IdentificationCheckType.SEAL_CHECK.getValue();
 
-    assertEquals(enumResult, SEAL_CHECK_STRING);
+    assertThat(enumResult).isEqualTo(SEAL_CHECK_STRING);
   }
 
   @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
+  void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
     IdentificationCheckType enumResult = IdentificationCheckType.fromValue(SEAL_CHECK_STRING);
 
-    assertEquals(enumResult, IdentificationCheckType.SEAL_CHECK);
+    assertThat(enumResult).isEqualTo(IdentificationCheckType.SEAL_CHECK);
   }
 
   @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
+  void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
     IdentificationCheckType enumResult = IdentificationCheckType.fromValue(INVALID_STRING);
 
-    assertNull(enumResult);
+    assertThat(enumResult).isNull();
   }
 
   @Test
-  public void shouldReturnNotDoneIdentityCheckType() {
+  void shouldReturnNotDoneIdentityCheckType() {
     String enumResult = IdentificationCheckType.NOT_DONE.getValue();
 
-    assertEquals(enumResult, NOT_DONE_STRING);
+    assertThat(enumResult).isEqualTo(NOT_DONE_STRING);
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/IdentityCheckNotDoneReasonTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/IdentityCheckNotDoneReasonTest.java
@@ -1,49 +1,48 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class IdentityCheckNotDoneReasonTest {
+class IdentityCheckNotDoneReasonTest {
 
   private final static String REDUCED_CHECKS_REGIME_STRING = "Reduced checks regime";
   private final static String NOT_REQUIRED_STRING = "Not required";
   private final static String INVALID_STRING = "Invalid";
 
   @Test
-  public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
+  void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
     String enumResult = IdentityCheckNotDoneReason.REDUCED_CHECKS_REGIME.toString();
 
-    assertEquals(enumResult, REDUCED_CHECKS_REGIME_STRING);
+    assertThat(enumResult).isEqualTo(REDUCED_CHECKS_REGIME_STRING);
   }
 
   @Test
-  public void givenAValidEnumValue_notRequired_whenToStringCalled_shouldReturnStringValue() {
+  void givenAValidEnumValue_notRequired_whenToStringCalled_shouldReturnStringValue() {
     String enumResult = IdentityCheckNotDoneReason.NOT_REQUIRED.toString();
 
-    assertEquals(enumResult, NOT_REQUIRED_STRING);
+    assertThat(enumResult).isEqualTo(NOT_REQUIRED_STRING);
   }
 
   @Test
-  public void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
+  void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
     String enumResult = IdentityCheckNotDoneReason.NOT_REQUIRED.getValue();
 
-    assertEquals(enumResult, NOT_REQUIRED_STRING);
+    assertThat(enumResult).isEqualTo(NOT_REQUIRED_STRING);
   }
 
   @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
+  void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
     IdentityCheckNotDoneReason enumResult = IdentityCheckNotDoneReason.fromValue(
         NOT_REQUIRED_STRING);
 
-    assertEquals(enumResult, IdentityCheckNotDoneReason.NOT_REQUIRED);
+    assertThat(enumResult).isEqualTo(IdentityCheckNotDoneReason.NOT_REQUIRED);
   }
 
   @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
+  void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
     IdentityCheckNotDoneReason enumResult = IdentityCheckNotDoneReason.fromValue(INVALID_STRING);
 
-    assertNull(enumResult);
+    assertThat(enumResult).isNull();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/IfChanneledOptionEnumTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/IfChanneledOptionEnumTest.java
@@ -1,39 +1,38 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class IfChanneledOptionEnumTest {
+class IfChanneledOptionEnumTest {
   private final static String ARTICLE_8_STRING = "article8";
   private final static String INVALID_STRING = "Invalid";
 
   @Test
-  public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
+  void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
     String enumResult = IfChanneledOptionEnum.ARTICLE8.toString();
 
-    assertEquals(enumResult, ARTICLE_8_STRING);
+    assertThat(enumResult).isEqualTo(ARTICLE_8_STRING);
   }
 
   @Test
-  public void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
+  void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
     String enumResult = IfChanneledOptionEnum.ARTICLE8.getValue();
 
-    assertEquals(enumResult, ARTICLE_8_STRING);
+    assertThat(enumResult).isEqualTo(ARTICLE_8_STRING);
   }
 
   @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
+  void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
     IfChanneledOptionEnum enumResult = IfChanneledOptionEnum.fromValue(ARTICLE_8_STRING);
 
-    assertEquals(enumResult, IfChanneledOptionEnum.ARTICLE8);
+    assertThat(enumResult).isEqualTo(IfChanneledOptionEnum.ARTICLE8);
   }
 
   @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
+  void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
     IfChanneledOptionEnum enumResult = IfChanneledOptionEnum.fromValue(INVALID_STRING);
 
-    assertNull(enumResult);
+    assertThat(enumResult).isNull();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ImpQuantityDataKeysTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ImpQuantityDataKeysTest.java
@@ -1,39 +1,38 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class ImpQuantityDataKeysTest {
+class ImpQuantityDataKeysTest {
   private final static String QUANTITY_STRING = "quantity";
   private final static String INVALID_STRING = "Invalid";
 
   @Test
-  public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
+  void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
     String enumResult = ImpQuantityDataKeys.QUANTITY.toString();
 
-    assertEquals(enumResult, QUANTITY_STRING);
+    assertThat(enumResult).isEqualTo(QUANTITY_STRING);
   }
 
   @Test
-  public void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
+  void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
     String enumResult = ImpQuantityDataKeys.QUANTITY.getValue();
 
-    assertEquals(enumResult, QUANTITY_STRING);
+    assertThat(enumResult).isEqualTo(QUANTITY_STRING);
   }
 
   @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
+  void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
     ImpQuantityDataKeys enumResult = ImpQuantityDataKeys.fromValue(QUANTITY_STRING);
 
-    assertEquals(enumResult, ImpQuantityDataKeys.QUANTITY);
+    assertThat(enumResult).isEqualTo(ImpQuantityDataKeys.QUANTITY);
   }
 
   @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
+  void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
     ImpQuantityDataKeys enumResult = ImpQuantityDataKeys.fromValue(INVALID_STRING);
 
-    assertNull(enumResult);
+    assertThat(enumResult).isNull();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/InspectionRequiredTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/InspectionRequiredTest.java
@@ -2,9 +2,9 @@ package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class InspectionRequiredTest {
+class InspectionRequiredTest {
 
   private final static String REQUIRED = "Required";
   private final static String INCONCLUSIVE = "Inconclusive";
@@ -12,28 +12,28 @@ public class InspectionRequiredTest {
   private final static String INVALID_STRING = "Invalid";
 
   @Test
-  public void givenAValidEnumValue_ReturnStringValue_WhenToStringCalled() {
+  void givenAValidEnumValue_ReturnStringValue_WhenToStringCalled() {
     String enumResult = InspectionRequired.REQUIRED.toString();
 
     assertThat(enumResult).isEqualTo(REQUIRED);
   }
 
   @Test
-  public void givenAValidEnumValue_ReturnValue_WhenGetValueCalled() {
+  void givenAValidEnumValue_ReturnValue_WhenGetValueCalled() {
     String enumResult = InspectionRequired.INCONCLUSIVE.getValue();
 
     assertThat(enumResult).isEqualTo(INCONCLUSIVE);
   }
 
   @Test
-  public void givenAValueValid_ReturnEnumValue_WhenFromValueCalled() {
+  void givenAValueValid_ReturnEnumValue_WhenFromValueCalled() {
     InspectionRequired enumResult = InspectionRequired.fromValue(NOT_REQUIRED);
 
     assertThat(enumResult).isEqualTo(InspectionRequired.NOT_REQUIRED);
   }
 
   @Test
-  public void givenAnInvalidValue_ReturnNull_WhenFromValueCalled() {
+  void givenAnInvalidValue_ReturnNull_WhenFromValueCalled() {
     InspectionRequired enumResult = InspectionRequired.fromValue(INVALID_STRING);
 
     assertThat(enumResult).isNull();

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/InternalMarketPurposeTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/InternalMarketPurposeTest.java
@@ -2,96 +2,96 @@ package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class InternalMarketPurposeTest {
+class InternalMarketPurposeTest {
   private final static String OTHER_STRING = "Other";
   private final static String INVALID_STRING = "Invalid";
 
   @Test
-  public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
+  void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
     assertThat(InternalMarketPurpose.OTHER.toString()).hasToString(OTHER_STRING);
   }
 
   @Test
-  public void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
+  void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
     assertThat(InternalMarketPurpose.OTHER.getValue()).isEqualTo(OTHER_STRING);
   }
 
   @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
+  void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
     assertThat(InternalMarketPurpose.fromValue(OTHER_STRING)).isEqualTo(InternalMarketPurpose.OTHER);
   }
 
   @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
+  void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
     assertThat(InternalMarketPurpose.fromValue(INVALID_STRING)).isNull();
   }
 
   @Test
-  public void givenCommercialSale_whenToStringCalled_shouldReturnStringValue() {
+  void givenCommercialSale_whenToStringCalled_shouldReturnStringValue() {
     assertThat(InternalMarketPurpose.COMMERCIAL_SALE.toString()).hasToString(
             "Commercial Sale");
   }
 
   @Test
-  public void givenCommercialSaleOrChangeOfOwnership_whenToStringCalled_shouldReturnStringValue() {
+  void givenCommercialSaleOrChangeOfOwnership_whenToStringCalled_shouldReturnStringValue() {
     assertThat(InternalMarketPurpose.COMMERCIAL_SALE_OR_CHANGE_OF_OWNERSHIP.toString()).hasToString(
             "Commercial sale or change of ownership");
   }
 
   @Test
-  public void givenRescue_whenToStringCalled_shouldReturnStringValue() {
+  void givenRescue_whenToStringCalled_shouldReturnStringValue() {
     assertThat(InternalMarketPurpose.RESCUE.toString()).hasToString("Rescue");
   }
 
   @Test
-  public void givenBreeding_whenToStringCalled_shouldReturnStringValue() {
+  void givenBreeding_whenToStringCalled_shouldReturnStringValue() {
     assertThat(InternalMarketPurpose.BREEDING.toString()).hasToString("Breeding");
   }
 
   @Test
-  public void givenResearch_whenToStringCalled_shouldReturnStringValue() {
+  void givenResearch_whenToStringCalled_shouldReturnStringValue() {
     assertThat(InternalMarketPurpose.RESEARCH.toString()).hasToString("Research");
   }
 
   @Test
-  public void givenRacing_whenToStringCalled_shouldReturnStringValue() {
+  void givenRacing_whenToStringCalled_shouldReturnStringValue() {
     assertThat(InternalMarketPurpose.RACING.toString()).hasToString("Racing or Competition");
   }
 
   @Test
-  public void givenPremises_whenToStringCalled_shouldReturnStringValue() {
+  void givenPremises_whenToStringCalled_shouldReturnStringValue() {
     assertThat(InternalMarketPurpose.APPROVED_PREMISES.toString()).hasToString("Approved Premises or Body");
   }
 
   @Test
-  public void givenCompanion_whenToStringCalled_shouldReturnStringValue() {
+  void givenCompanion_whenToStringCalled_shouldReturnStringValue() {
     assertThat(InternalMarketPurpose.COMPANION_ANIMAL.toString()).hasToString("Companion Animal not for Resale or Rehoming");
   }
 
   @Test
-  public void givenProduction_whenToStringCalled_shouldReturnStringValue() {
+  void givenProduction_whenToStringCalled_shouldReturnStringValue() {
     assertThat(InternalMarketPurpose.PRODUCTION.toString()).hasToString("Production");
   }
 
   @Test
-  public void givenSlaughter_whenToStringCalled_shouldReturnStringValue() {
+  void givenSlaughter_whenToStringCalled_shouldReturnStringValue() {
     assertThat(InternalMarketPurpose.SLAUGHTER.toString()).hasToString("Slaughter");
   }
 
   @Test
-  public void givenFattening_whenToStringCalled_shouldReturnStringValue() {
+  void givenFattening_whenToStringCalled_shouldReturnStringValue() {
     assertThat(InternalMarketPurpose.FATTENING.toString()).hasToString("Fattening");
   }
 
   @Test
-  public void givenRestocking_whenToStringCalled_shouldReturnStringValue() {
+  void givenRestocking_whenToStringCalled_shouldReturnStringValue() {
     assertThat(InternalMarketPurpose.GAME_RESTOCKING.toString()).hasToString("Game Restocking");
   }
 
   @Test
-  public void givenHorses_whenToStringCalled_shouldReturnStringValue() {
+  void givenHorses_whenToStringCalled_shouldReturnStringValue() {
     assertThat(InternalMarketPurpose.REGISTERED_HORSES.toString()).hasToString("Registered Horses");
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/NotAcceptableActionEnumTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/NotAcceptableActionEnumTest.java
@@ -1,39 +1,38 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class NotAcceptableActionEnumTest {
+class NotAcceptableActionEnumTest {
   private final static String DESTRUCTION_STRING = "destruction";
   private final static String INVALID_STRING = "Invalid";
 
   @Test
-  public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
+  void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
     String enumResult = NotAcceptableActionEnum.DESTRUCTION.toString();
 
-    assertEquals(enumResult, DESTRUCTION_STRING);
+    assertThat(enumResult).isEqualTo(DESTRUCTION_STRING);
   }
 
   @Test
-  public void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
+  void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
     String enumResult = NotAcceptableActionEnum.DESTRUCTION.getValue();
 
-    assertEquals(enumResult, DESTRUCTION_STRING);
+    assertThat(enumResult).isEqualTo(DESTRUCTION_STRING);
   }
 
   @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
+  void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
     NotAcceptableActionEnum enumResult = NotAcceptableActionEnum.fromValue(DESTRUCTION_STRING);
 
-    assertEquals(enumResult, NotAcceptableActionEnum.DESTRUCTION);
+    assertThat(enumResult).isEqualTo(NotAcceptableActionEnum.DESTRUCTION);
   }
 
   @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
+  void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
     NotAcceptableActionEnum enumResult = NotAcceptableActionEnum.fromValue(INVALID_STRING);
 
-    assertNull(enumResult);
+    assertThat(enumResult).isNull();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/NotAcceptableActionReasonEnumTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/NotAcceptableActionReasonEnumTest.java
@@ -1,39 +1,38 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class NotAcceptableActionReasonEnumTest {
+class NotAcceptableActionReasonEnumTest {
   private final static String OTHER_STRING = "Other";
   private final static String INVALID_STRING = "Invalid";
 
   @Test
-  public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
+  void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
     String enumResult = NotAcceptableActionReasonEnum.OTHER.toString();
 
-    assertEquals(enumResult, OTHER_STRING);
+    assertThat(enumResult).isEqualTo(OTHER_STRING);
   }
 
   @Test
-  public void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
+  void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
     String enumResult = NotAcceptableActionReasonEnum.OTHER.getValue();
 
-    assertEquals(enumResult, OTHER_STRING);
+    assertThat(enumResult).isEqualTo(OTHER_STRING);
   }
 
   @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
+  void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
     NotAcceptableActionReasonEnum enumResult = NotAcceptableActionReasonEnum.fromValue(OTHER_STRING);
 
-    assertEquals(enumResult, NotAcceptableActionReasonEnum.OTHER);
+    assertThat(enumResult).isEqualTo(NotAcceptableActionReasonEnum.OTHER);
   }
 
   @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
+  void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
     NotAcceptableActionReasonEnum enumResult = NotAcceptableActionReasonEnum.fromValue(INVALID_STRING);
 
-    assertNull(enumResult);
+    assertThat(enumResult).isNull();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/NotAcceptableReasonsEnumTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/NotAcceptableReasonsEnumTest.java
@@ -1,39 +1,38 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class NotAcceptableReasonsEnumTest {
+class NotAcceptableReasonsEnumTest {
   private final static String ID_HEALTH_MARK_ERROR = "IdHealthMarkError";
   private final static String INVALID_STRING = "Invalid";
 
   @Test
-  public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
+  void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
     String enumResult = NotAcceptableReasonsEnum.IDHEALTHMARKERROR.toString();
 
-    assertEquals(enumResult, ID_HEALTH_MARK_ERROR);
+    assertThat(enumResult).isEqualTo(ID_HEALTH_MARK_ERROR);
   }
 
   @Test
-  public void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
+  void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
     String enumResult = NotAcceptableReasonsEnum.IDHEALTHMARKERROR.getValue();
 
-    assertEquals(enumResult, ID_HEALTH_MARK_ERROR);
+    assertThat(enumResult).isEqualTo(ID_HEALTH_MARK_ERROR);
   }
 
   @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
+  void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
     NotAcceptableReasonsEnum enumResult = NotAcceptableReasonsEnum.fromValue(ID_HEALTH_MARK_ERROR);
 
-    assertEquals(enumResult, NotAcceptableReasonsEnum.IDHEALTHMARKERROR);
+    assertThat(enumResult).isEqualTo(NotAcceptableReasonsEnum.IDHEALTHMARKERROR);
   }
 
   @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
+  void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
     NotAcceptableReasonsEnum enumResult = NotAcceptableReasonsEnum.fromValue(INVALID_STRING);
 
-    assertNull(enumResult);
+    assertThat(enumResult).isNull();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/NotificationTypeEnumTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/NotificationTypeEnumTest.java
@@ -1,39 +1,38 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class NotificationTypeEnumTest {
+class NotificationTypeEnumTest {
   private final static String CED_STRING = "CED";
   private final static String INVALID_STRING = "Invalid";
 
   @Test
-  public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
+  void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
     String enumResult = NotificationTypeEnum.CED.toString();
 
-    assertEquals(enumResult, CED_STRING);
+    assertThat(enumResult).isEqualTo(CED_STRING);
   }
 
   @Test
-  public void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
+  void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
     String enumResult = NotificationTypeEnum.CED.getValue();
 
-    assertEquals(enumResult, CED_STRING);
+    assertThat(enumResult).isEqualTo(CED_STRING);
   }
 
   @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
+  void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
     NotificationTypeEnum enumResult = NotificationTypeEnum.fromValue(CED_STRING);
 
-    assertEquals(enumResult, NotificationTypeEnum.CED);
+    assertThat(enumResult).isEqualTo(NotificationTypeEnum.CED);
   }
 
   @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
+  void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
     NotificationTypeEnum enumResult = NotificationTypeEnum.fromValue(INVALID_STRING);
 
-    assertNull(enumResult);
+    assertThat(enumResult).isNull();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/PackageTypeTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/PackageTypeTest.java
@@ -1,47 +1,46 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class PackageTypeTest {
+class PackageTypeTest {
   private final static String BAG_STRING = "Bag";
   private final static String INVALID_STRING = "Invalid";
   private final static String LEGACY_BULK = "Bulk";
 
   @Test
-  public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
+  void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
     String enumResult = PackageType.BAG.toString();
 
-    assertEquals(enumResult, BAG_STRING);
+    assertThat(enumResult).isEqualTo(BAG_STRING);
   }
 
   @Test
-  public void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
+  void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
     String enumResult = PackageType.BAG.getValue();
 
-    assertEquals(enumResult, BAG_STRING);
+    assertThat(enumResult).isEqualTo(BAG_STRING);
   }
 
   @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
+  void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
     PackageType enumResult = PackageType.fromValue(BAG_STRING);
 
-    assertEquals(enumResult, PackageType.BAG);
+    assertThat(enumResult).isEqualTo(PackageType.BAG);
   }
 
   @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
+  void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
     PackageType enumResult = PackageType.fromValue(INVALID_STRING);
 
-    assertNull(enumResult);
+    assertThat(enumResult).isNull();
   }
 
   @Test
-  public void fromValue_whenCalledWithLegacyBulk_shouldReturnEnumValueOfLegacyBulk() {
+  void fromValue_whenCalledWithLegacyBulk_shouldReturnEnumValueOfLegacyBulk() {
     PackageType enumResult = PackageType.fromValue(LEGACY_BULK);
 
-    assertEquals(enumResult, PackageType.LEGACY_BULK);
+    assertThat(enumResult).isEqualTo(PackageType.LEGACY_BULK);
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/PartyTypeTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/PartyTypeTest.java
@@ -1,39 +1,38 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class PartyTypeTest {
+class PartyTypeTest {
   private final static String COMMERCIAL_TRANSPORTER_STRING = "Commercial transporter";
   private final static String INVALID_STRING = "Invalid";
 
   @Test
-  public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
+  void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
     String enumResult = PartyType.COMMERCIAL_TRANSPORTER.toString();
 
-    assertEquals(enumResult, COMMERCIAL_TRANSPORTER_STRING);
+    assertThat(enumResult).isEqualTo(COMMERCIAL_TRANSPORTER_STRING);
   }
 
   @Test
-  public void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
+  void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
     String enumResult = PartyType.COMMERCIAL_TRANSPORTER.getValue();
 
-    assertEquals(enumResult, COMMERCIAL_TRANSPORTER_STRING);
+    assertThat(enumResult).isEqualTo(COMMERCIAL_TRANSPORTER_STRING);
   }
 
   @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
+  void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
     PartyType enumResult = PartyType.fromValue(COMMERCIAL_TRANSPORTER_STRING);
 
-    assertEquals(enumResult, PartyType.COMMERCIAL_TRANSPORTER);
+    assertThat(enumResult).isEqualTo(PartyType.COMMERCIAL_TRANSPORTER);
   }
 
   @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
+  void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
     PartyType enumResult = PartyType.fromValue(INVALID_STRING);
 
-    assertNull(enumResult);
+    assertThat(enumResult).isNull();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/PhsiClassificationTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/PhsiClassificationTest.java
@@ -1,39 +1,38 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class PhsiClassificationTest {
+class PhsiClassificationTest {
   private final static String MANDATORY_STRING = "Mandatory";
   private final static String INVALID_STRING = "Invalid";
 
   @Test
-  public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
+  void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
     String enumResult = PhsiClassification.MANDATORY.toString();
 
-    assertEquals(enumResult, MANDATORY_STRING);
+    assertThat(enumResult).isEqualTo(MANDATORY_STRING);
   }
 
   @Test
-  public void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
+  void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
     String enumResult = PhsiClassification.MANDATORY.getValue();
 
-    assertEquals(enumResult, MANDATORY_STRING);
+    assertThat(enumResult).isEqualTo(MANDATORY_STRING);
   }
 
   @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
+  void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
     PhsiClassification enumResult = PhsiClassification.fromValue(MANDATORY_STRING);
 
-    assertEquals(enumResult, PhsiClassification.MANDATORY);
+    assertThat(enumResult).isEqualTo(PhsiClassification.MANDATORY);
   }
 
   @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
+  void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
     PhsiDecision enumResult = PhsiDecision.fromValue(INVALID_STRING);
 
-    assertNull(enumResult);
+    assertThat(enumResult).isNull();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/PhsiDecisionTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/PhsiDecisionTest.java
@@ -1,39 +1,38 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class PhsiDecisionTest {
+class PhsiDecisionTest {
   private final static String REQUIRED_STRING = "REQUIRED";
   private final static String INVALID_STRING = "Invalid";
 
   @Test
-  public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
+  void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
     String enumResult = PhsiDecision.REQUIRED.toString();
 
-    assertEquals(enumResult, REQUIRED_STRING);
+    assertThat(enumResult).isEqualTo(REQUIRED_STRING);
   }
 
   @Test
-  public void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
+  void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
     String enumResult = PhsiDecision.REQUIRED.getValue();
 
-    assertEquals(enumResult, REQUIRED_STRING);
+    assertThat(enumResult).isEqualTo(REQUIRED_STRING);
   }
 
   @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
+  void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
     PhsiDecision enumResult = PhsiDecision.fromValue(REQUIRED_STRING);
 
-    assertEquals(enumResult, PhsiDecision.REQUIRED);
+    assertThat(enumResult).isEqualTo(PhsiDecision.REQUIRED);
   }
 
   @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
+  void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
     PhsiDecision enumResult = PhsiDecision.fromValue(INVALID_STRING);
 
-    assertNull(enumResult);
+    assertThat(enumResult).isNull();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/PhysicalCheckNotDoneReasonTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/PhysicalCheckNotDoneReasonTest.java
@@ -1,39 +1,38 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class PhysicalCheckNotDoneReasonTest {
+class PhysicalCheckNotDoneReasonTest {
   private final static String OTHER_STRING = "Other";
   private final static String INVALID_STRING = "Invalid";
 
   @Test
-  public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
+  void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
     String enumResult = PhysicalCheckNotDoneReason.OTHER.toString();
 
-    assertEquals(enumResult, OTHER_STRING);
+    assertThat(enumResult).isEqualTo(OTHER_STRING);
   }
 
   @Test
-  public void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
+  void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
     String enumResult = PhysicalCheckNotDoneReason.OTHER.getValue();
 
-    assertEquals(enumResult, OTHER_STRING);
+    assertThat(enumResult).isEqualTo(OTHER_STRING);
   }
 
   @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
+  void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
     PhysicalCheckNotDoneReason enumResult = PhysicalCheckNotDoneReason.fromValue(OTHER_STRING);
 
-    assertEquals(enumResult, PhysicalCheckNotDoneReason.OTHER);
+    assertThat(enumResult).isEqualTo(PhysicalCheckNotDoneReason.OTHER);
   }
 
   @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
+  void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
     PhysicalCheckNotDoneReason enumResult = PhysicalCheckNotDoneReason.fromValue(INVALID_STRING);
 
-    assertNull(enumResult);
+    assertThat(enumResult).isNull();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ProductTypeTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ProductTypeTest.java
@@ -2,36 +2,36 @@ package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class ProductTypeTest {
+class ProductTypeTest {
 
   private final static String INVALID_STRING = "Invalid";
   private final static String INTENDED_FOR_PLANTING_ALREADY_PLANTED = "Intended for planting: already planted";
 
   @Test
-  public void givenAValidEnumValue_ReturnStringValue_WhenToStringCalled() {
+  void givenAValidEnumValue_ReturnStringValue_WhenToStringCalled() {
     String enumResult = ProductType.INTENDED_FOR_PLANTING_ALREADY_PLANTED.toString();
 
     assertThat(enumResult).isEqualTo(INTENDED_FOR_PLANTING_ALREADY_PLANTED);
   }
 
   @Test
-  public void givenAValidEnumValue_ReturnValue_WhenGetValueCalled() {
+  void givenAValidEnumValue_ReturnValue_WhenGetValueCalled() {
     String enumResult = ProductType.INTENDED_FOR_PLANTING_ALREADY_PLANTED.getValue();
 
     assertThat(enumResult).isEqualTo(INTENDED_FOR_PLANTING_ALREADY_PLANTED);
   }
 
   @Test
-  public void givenAValidValue_ReturnEnumValue_WhenFromValueCalled() {
+  void givenAValidValue_ReturnEnumValue_WhenFromValueCalled() {
     ProductType enumResult = ProductType.fromValue(INTENDED_FOR_PLANTING_ALREADY_PLANTED);
 
     assertThat(enumResult).isEqualTo(ProductType.INTENDED_FOR_PLANTING_ALREADY_PLANTED);
   }
 
   @Test
-  public void givenAnInvalidValue_ReturnNull_WhenFromValueCalled() {
+  void givenAnInvalidValue_ReturnNull_WhenFromValueCalled() {
     ProductType enumResult = ProductType.fromValue(INVALID_STRING);
 
     assertThat(enumResult).isNull();

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ProvideCtcMrnEnumTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ProvideCtcMrnEnumTest.java
@@ -2,21 +2,21 @@ package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class ProvideCtcMrnEnumTest {
+class ProvideCtcMrnEnumTest {
   @Test
-  public void givenYesAddLaterValue_whenValueOfCalled_shouldReturnEnumValue() {
+  void givenYesAddLaterValue_whenValueOfCalled_shouldReturnEnumValue() {
     assertThat(ProvideCtcMrnEnum.valueOf("YES_ADD_LATER")).isEqualTo(ProvideCtcMrnEnum.YES_ADD_LATER);
   }
 
   @Test
-  public void givenYesValue_whenValueOfCalled_shouldReturnEnumValue() {
+  void givenYesValue_whenValueOfCalled_shouldReturnEnumValue() {
     assertThat(ProvideCtcMrnEnum.valueOf("YES")).isEqualTo(ProvideCtcMrnEnum.YES);
   }
 
   @Test
-  public void givenNoValue_whenValueOfCalled_shouldReturnEnumValue() {
+  void givenNoValue_whenValueOfCalled_shouldReturnEnumValue() {
     assertThat(ProvideCtcMrnEnum.valueOf("NO")).isEqualTo(ProvideCtcMrnEnum.NO);
   }
 

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/PurposeGroupEnumTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/PurposeGroupEnumTest.java
@@ -1,39 +1,38 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class PurposeGroupEnumTest {
+class PurposeGroupEnumTest {
   private final static String FOR_IMPORT_STRING = "For Import";
   private final static String INVALID_STRING = "Invalid";
 
   @Test
-  public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
+  void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
     String enumResult = PurposeGroupEnum.IMPORT.toString();
 
-    assertEquals(enumResult, FOR_IMPORT_STRING);
+    assertThat(enumResult).isEqualTo(FOR_IMPORT_STRING);
   }
 
   @Test
-  public void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
+  void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
     String enumResult = PurposeGroupEnum.IMPORT.getValue();
 
-    assertEquals(enumResult, FOR_IMPORT_STRING);
+    assertThat(enumResult).isEqualTo(FOR_IMPORT_STRING);
   }
 
   @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
+  void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
     PurposeGroupEnum enumResult = PurposeGroupEnum.fromValue(FOR_IMPORT_STRING);
 
-    assertEquals(enumResult, PurposeGroupEnum.IMPORT);
+    assertThat(enumResult).isEqualTo(PurposeGroupEnum.IMPORT);
   }
 
   @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
+  void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
     PurposeGroupEnum enumResult = PurposeGroupEnum.fromValue(INVALID_STRING);
 
-    assertNull(enumResult);
+    assertThat(enumResult).isNull();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ResultTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ResultTest.java
@@ -1,39 +1,38 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class ResultTest {
+class ResultTest {
   private final static String DEROGATION_STRING = "Derogation";
   private final static String INVALID_STRING = "Invalid";
 
   @Test
-  public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
+  void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
     String enumResult = Result.DEROGATION.toString();
 
-    assertEquals(enumResult, DEROGATION_STRING);
+    assertThat(enumResult).isEqualTo(DEROGATION_STRING);
   }
 
   @Test
-  public void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
+  void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
     String enumResult = Result.DEROGATION.getValue();
 
-    assertEquals(enumResult, DEROGATION_STRING);
+    assertThat(enumResult).isEqualTo(DEROGATION_STRING);
   }
 
   @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
+  void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
     Result enumResult = Result.fromValue(DEROGATION_STRING);
 
-    assertEquals(enumResult, Result.DEROGATION);
+    assertThat(enumResult).isEqualTo(Result.DEROGATION);
   }
 
   @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
+  void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
     Result enumResult = Result.fromValue(INVALID_STRING);
 
-    assertNull(enumResult);
+    assertThat(enumResult).isNull();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/RiskDecisionTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/RiskDecisionTest.java
@@ -2,36 +2,36 @@ package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class RiskDecisionTest {
+class RiskDecisionTest {
 
   private final static String INVALID_STRING = "Invalid";
   private final static String REQUIRED = "REQUIRED";
 
   @Test
-  public void givenAValidEnumValue_ReturnStringValue_WhenToStringCalled() {
+  void givenAValidEnumValue_ReturnStringValue_WhenToStringCalled() {
     String enumResult = RiskDecision.REQUIRED.toString();
 
     assertThat(enumResult).isEqualTo(REQUIRED);
   }
 
   @Test
-  public void givenAValidEnumValue_ReturnValue_WhenGetValueCalled() {
+  void givenAValidEnumValue_ReturnValue_WhenGetValueCalled() {
     String enumResult = RiskDecision.REQUIRED.getValue();
 
     assertThat(enumResult).isEqualTo(REQUIRED);
   }
 
   @Test
-  public void givenAValidValue_ReturnEnumValue_whenFromValueCalled() {
+  void givenAValidValue_ReturnEnumValue_whenFromValueCalled() {
     RiskDecision enumResult = RiskDecision.fromValue(REQUIRED);
 
     assertThat(enumResult).isEqualTo(RiskDecision.REQUIRED);
   }
 
   @Test
-  public void givenAnInvalidValue_ReturnNull_whenFromValueCalled() {
+  void givenAnInvalidValue_ReturnNull_whenFromValueCalled() {
     RiskDecision enumResult = RiskDecision.fromValue(INVALID_STRING);
 
     assertThat(enumResult).isNull();

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/SpecificWarehouseNonConformingConsignmentEnumTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/SpecificWarehouseNonConformingConsignmentEnumTest.java
@@ -1,39 +1,38 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class SpecificWarehouseNonConformingConsignmentEnumTest {
+class SpecificWarehouseNonConformingConsignmentEnumTest {
   private final static String SHIP_STRING = "Ship";
   private final static String INVALID_STRING = "Invalid";
 
   @Test
-  public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
+  void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
     String enumResult = SpecificWarehouseNonConformingConsignmentEnum.SHIP.toString();
 
-    assertEquals(enumResult, SHIP_STRING);
+    assertThat(enumResult).isEqualTo(SHIP_STRING);
   }
 
   @Test
-  public void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
+  void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
     String enumResult = SpecificWarehouseNonConformingConsignmentEnum.SHIP.getValue();
 
-    assertEquals(enumResult, SHIP_STRING);
+    assertThat(enumResult).isEqualTo(SHIP_STRING);
   }
 
   @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
+  void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
     SpecificWarehouseNonConformingConsignmentEnum enumResult = SpecificWarehouseNonConformingConsignmentEnum.fromValue(SHIP_STRING);
 
-    assertEquals(enumResult, SpecificWarehouseNonConformingConsignmentEnum.SHIP);
+    assertThat(enumResult).isEqualTo(SpecificWarehouseNonConformingConsignmentEnum.SHIP);
   }
 
   @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
+  void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
     SpecificWarehouseNonConformingConsignmentEnum enumResult = SpecificWarehouseNonConformingConsignmentEnum.fromValue(INVALID_STRING);
 
-    assertNull(enumResult);
+    assertThat(enumResult).isNull();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/StatusEnumTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/StatusEnumTest.java
@@ -1,45 +1,44 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class StatusEnumTest {
+class StatusEnumTest {
   private final static String AMEND_STRING = "AMEND";
   private final static String INVALID_STRING = "Invalid";
 
   @Test
-  public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
+  void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
     String enumResult = StatusEnum.AMEND.toString();
 
-    assertEquals(enumResult, AMEND_STRING);
+    assertThat(enumResult).isEqualTo(AMEND_STRING);
   }
 
   @Test
-  public void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
+  void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
     String enumResult = StatusEnum.AMEND.getValue();
 
-    assertEquals(enumResult, AMEND_STRING);
+    assertThat(enumResult).isEqualTo(AMEND_STRING);
   }
 
   @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
+  void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
     StatusEnum enumResult = StatusEnum.fromValue(AMEND_STRING);
 
-    assertEquals(enumResult, StatusEnum.AMEND);
+    assertThat(enumResult).isEqualTo(StatusEnum.AMEND);
   }
 
   @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
+  void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
     StatusEnum enumResult = StatusEnum.fromValue(INVALID_STRING);
 
-    assertNull(enumResult);
+    assertThat(enumResult).isNull();
   }
 
   @Test
-  public void givenValidValuesUnderToProcessStatus_whenFromValueCalled_shouldReturnEnumValue() {
+  void givenValidValuesUnderToProcessStatus_whenFromValueCalled_shouldReturnEnumValue() {
     StatusEnum enumResult = StatusEnum.fromValue("SUBMITTED,IN_PROGRESS,MODIFY");
-    assertEquals(enumResult, StatusEnum.TO_PROCESS);
+    assertThat(enumResult).isEqualTo(StatusEnum.TO_PROCESS);
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/StoreTransporterContactEnumTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/StoreTransporterContactEnumTest.java
@@ -2,17 +2,17 @@ package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class StoreTransporterContactEnumTest {
+class StoreTransporterContactEnumTest {
 
   @Test
-  public void givenYesValue_whenValueOfCalled_shouldReturnEnumValue() {
+  void givenYesValue_whenValueOfCalled_shouldReturnEnumValue() {
     assertThat(StoreTransporterContactEnum.valueOf("YES")).isEqualTo(StoreTransporterContactEnum.YES);
   }
 
   @Test
-  public void givenNoValue_whenValueOfCalled_shouldReturnEnumValue() {
+  void givenNoValue_whenValueOfCalled_shouldReturnEnumValue() {
     assertThat(StoreTransporterContactEnum.valueOf("NO")).isEqualTo(StoreTransporterContactEnum.NO);
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/TestReasonTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/TestReasonTest.java
@@ -1,39 +1,38 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class TestReasonTest {
+class TestReasonTest {
   private final static String RANDOM_STRING = "Random";
   private final static String INVALID_STRING = "Invalid";
 
   @Test
-  public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
+  void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
     String enumResult = TestReason.RANDOM.toString();
 
-    assertEquals(enumResult, RANDOM_STRING);
+    assertThat(enumResult).isEqualTo(RANDOM_STRING);
   }
 
   @Test
-  public void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
+  void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
     String enumResult = TestReason.RANDOM.getValue();
 
-    assertEquals(enumResult, RANDOM_STRING);
+    assertThat(enumResult).isEqualTo(RANDOM_STRING);
   }
 
   @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
+  void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
     TestReason enumResult = TestReason.fromValue(RANDOM_STRING);
 
-    assertEquals(enumResult, TestReason.RANDOM);
+    assertThat(enumResult).isEqualTo(TestReason.RANDOM);
   }
 
   @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
+  void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
     TestReason enumResult = TestReason.fromValue(INVALID_STRING);
 
-    assertNull(enumResult);
+    assertThat(enumResult).isNull();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/TransportMethodTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/TransportMethodTest.java
@@ -1,39 +1,38 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class TransportMethodTest {
+class TransportMethodTest {
   private final static String OTHER_STRING = "Other";
   private final static String INVALID_STRING = "Invalid";
 
   @Test
-  public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
+  void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
     String enumResult = TransportMethod.OTHER.toString();
 
-    assertEquals(enumResult, OTHER_STRING);
+    assertThat(enumResult).isEqualTo(OTHER_STRING);
   }
 
   @Test
-  public void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
+  void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
     String enumResult = TransportMethod.OTHER.getValue();
 
-    assertEquals(enumResult, OTHER_STRING);
+    assertThat(enumResult).isEqualTo(OTHER_STRING);
   }
 
   @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
+  void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
     TransportMethod enumResult = TransportMethod.fromValue(OTHER_STRING);
 
-    assertEquals(enumResult, TransportMethod.OTHER);
+    assertThat(enumResult).isEqualTo(TransportMethod.OTHER);
   }
 
   @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
+  void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
     TransportMethod enumResult = TransportMethod.fromValue(INVALID_STRING);
 
-    assertNull(enumResult);
+    assertThat(enumResult).isNull();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/TransportTypeTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/TransportTypeTest.java
@@ -1,39 +1,38 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class TransportTypeTest {
+class TransportTypeTest {
   private final static String OTHER_STRING = "other";
   private final static String INVALID_STRING = "Invalid";
 
   @Test
-  public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
+  void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
     String enumResult = TransportType.OTHER.toString();
 
-    assertEquals(enumResult, OTHER_STRING);
+    assertThat(enumResult).isEqualTo(OTHER_STRING);
   }
 
   @Test
-  public void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
+  void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
     String enumResult = TransportType.OTHER.getValue();
 
-    assertEquals(enumResult, OTHER_STRING);
+    assertThat(enumResult).isEqualTo(OTHER_STRING);
   }
 
   @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
+  void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
     TransportType enumResult = TransportType.fromValue(OTHER_STRING);
 
-    assertEquals(enumResult, TransportType.OTHER);
+    assertThat(enumResult).isEqualTo(TransportType.OTHER);
   }
 
   @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
+  void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
     TransportType enumResult = TransportType.fromValue(INVALID_STRING);
 
-    assertNull(enumResult);
+    assertThat(enumResult).isNull();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/TypeOfImpTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/TypeOfImpTest.java
@@ -1,39 +1,38 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class TypeOfImpTest {
+class TypeOfImpTest {
   private final static String LIVE_ANIMALS_STRING = "A";
   private final static String INVALID_STRING = "Invalid";
 
   @Test
-  public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
+  void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
     String enumResult = TypeOfImp.LIVE_ANIMALS.toString();
 
-    assertEquals(enumResult, LIVE_ANIMALS_STRING);
+    assertThat(enumResult).isEqualTo(LIVE_ANIMALS_STRING);
   }
 
   @Test
-  public void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
+  void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
     String enumResult = TypeOfImp.LIVE_ANIMALS.getValue();
 
-    assertEquals(enumResult, LIVE_ANIMALS_STRING);
+    assertThat(enumResult).isEqualTo(LIVE_ANIMALS_STRING);
   }
 
   @Test
-  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
+  void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
     TypeOfImp enumResult = TypeOfImp.fromValue(LIVE_ANIMALS_STRING);
 
-    assertEquals(enumResult, TypeOfImp.LIVE_ANIMALS);
+    assertThat(enumResult).isEqualTo(TypeOfImp.LIVE_ANIMALS);
   }
 
   @Test
-  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
+  void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
     TypeOfImp enumResult = TypeOfImp.fromValue(INVALID_STRING);
 
-    assertNull(enumResult);
+    assertThat(enumResult).isNull();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/serialisation/IsoDateDeserializerTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/serialisation/IsoDateDeserializerTest.java
@@ -6,21 +6,21 @@ import static org.mockito.Mockito.when;
 import com.fasterxml.jackson.core.JsonParser;
 import java.io.IOException;
 import java.time.LocalDate;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
-public class IsoDateDeserializerTest {
+@ExtendWith(MockitoExtension.class)
+class IsoDateDeserializerTest {
 
-  private IsoDateDeserializer isoDateDeserializer = new IsoDateDeserializer();
+  private final IsoDateDeserializer isoDateDeserializer = new IsoDateDeserializer();
 
   @Mock
   private JsonParser jsonParser;
 
   @Test
-  public void givenAValidDateString_whenDeserializerCalled_expectLocalDate() throws IOException {
+  void givenAValidDateString_whenDeserializerCalled_expectLocalDate() throws IOException {
     // given
     when(jsonParser.getText()).thenReturn("2020-08-04");
 

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/serialisation/IsoDateSerializerTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/serialisation/IsoDateSerializerTest.java
@@ -6,21 +6,21 @@ import static org.mockito.Mockito.verify;
 import com.fasterxml.jackson.core.JsonGenerator;
 import java.io.IOException;
 import java.time.LocalDate;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
-public class IsoDateSerializerTest {
+@ExtendWith(MockitoExtension.class)
+class IsoDateSerializerTest {
 
-  private IsoDateSerializer isoDateSerializer = new IsoDateSerializer();
+  private final IsoDateSerializer isoDateSerializer = new IsoDateSerializer();
 
   @Mock
   JsonGenerator jsonGenerator;
 
   @Test
-  public void givenAValidLocalDate_whenSerializerCalled_expectMethodCalledWithDateAsString()
+  void givenAValidLocalDate_whenSerializerCalled_expectMethodCalledWithDateAsString()
       throws IOException {
     // given
     LocalDate localDate = LocalDate.of(2020, 8, 4);

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/serialisation/IsoDateTimeDeserializerTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/serialisation/IsoDateTimeDeserializerTest.java
@@ -8,21 +8,21 @@ import java.io.IOException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
-public class IsoDateTimeDeserializerTest {
+@ExtendWith(MockitoExtension.class)
+class IsoDateTimeDeserializerTest {
 
-  private IsoDateTimeDeserializer isoDateTimeDeserializer = new IsoDateTimeDeserializer();
+  private final IsoDateTimeDeserializer isoDateTimeDeserializer = new IsoDateTimeDeserializer();
 
   @Mock
   private JsonParser jsonParser;
 
   @Test
-  public void givenAValidDateTimeString_whenDeserializerCalled_expectLocalDate() throws IOException {
+  void givenAValidDateTimeString_whenDeserializerCalled_expectLocalDate() throws IOException {
     // given
     when(jsonParser.getText()).thenReturn("2020-08-04T15:45:37.029947Z");
 

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/serialisation/IsoDateTimeSerializerTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/serialisation/IsoDateTimeSerializerTest.java
@@ -8,21 +8,21 @@ import java.io.IOException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
-public class IsoDateTimeSerializerTest {
+@ExtendWith(MockitoExtension.class)
+class IsoDateTimeSerializerTest {
 
-  private IsoDateTimeSerializer isoDateTimeSerializer = new IsoDateTimeSerializer();
+  private final IsoDateTimeSerializer isoDateTimeSerializer = new IsoDateTimeSerializer();
 
   @Mock
   JsonGenerator jsonGenerator;
 
   @Test
-  public void givenAValidLocalDateTime_whenSerializerCalled_expectMethodCalledWithDateTimeAsString()
+  void givenAValidLocalDateTime_whenSerializerCalled_expectMethodCalledWithDateTimeAsString()
       throws IOException {
     // given
     LocalDate localDate = LocalDate.of(2020, 8, 4);

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/serialisation/IsoOffsetDateTimeDeserializerTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/serialisation/IsoOffsetDateTimeDeserializerTest.java
@@ -8,21 +8,21 @@ import java.io.IOException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
-public class IsoOffsetDateTimeDeserializerTest {
+@ExtendWith(MockitoExtension.class)
+class IsoOffsetDateTimeDeserializerTest {
 
-  private IsoOffsetDateTimeDeserializer isoOffsetDateTimeDeserializer = new IsoOffsetDateTimeDeserializer();
+  private final IsoOffsetDateTimeDeserializer isoOffsetDateTimeDeserializer = new IsoOffsetDateTimeDeserializer();
 
   @Mock
   private JsonParser jsonParser;
 
   @Test
-  public void givenAValidDateTimeString_whenDeserializerCalled_expectLocalDate() throws IOException {
+  void givenAValidDateTimeString_whenDeserializerCalled_expectLocalDate() throws IOException {
     // given
     when(jsonParser.getText()).thenReturn("2020-08-04T15:45:37.029947Z");
 

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/serialisation/IsoOffsetDateTimeSerializerTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/serialisation/IsoOffsetDateTimeSerializerTest.java
@@ -8,21 +8,21 @@ import java.io.IOException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
-public class IsoOffsetDateTimeSerializerTest {
+@ExtendWith(MockitoExtension.class)
+class IsoOffsetDateTimeSerializerTest {
 
-  private IsoOffsetDateTimeSerializer isoOffsetDateTimeSerializer = new IsoOffsetDateTimeSerializer();
+  private final IsoOffsetDateTimeSerializer isoOffsetDateTimeSerializer = new IsoOffsetDateTimeSerializer();
 
   @Mock
   JsonGenerator jsonGenerator;
 
   @Test
-  public void givenAValidLocalDateTime_whenSerializerCalled_expectMethodCalledWithDateTimeAsString()
+  void givenAValidLocalDateTime_whenSerializerCalled_expectMethodCalledWithDateTimeAsString()
       throws IOException {
     // given
     LocalDate localDate = LocalDate.of(2020, 8, 4);

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/serialisation/IsoTimeDeserializerTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/serialisation/IsoTimeDeserializerTest.java
@@ -6,21 +6,21 @@ import static org.mockito.Mockito.when;
 import com.fasterxml.jackson.core.JsonParser;
 import java.io.IOException;
 import java.time.LocalTime;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
-public class IsoTimeDeserializerTest {
+@ExtendWith(MockitoExtension.class)
+class IsoTimeDeserializerTest {
 
-  private IsoTimeDeserializer isoTimeDeserializer = new IsoTimeDeserializer();
+  private final IsoTimeDeserializer isoTimeDeserializer = new IsoTimeDeserializer();
 
   @Mock
   private JsonParser jsonParser;
 
   @Test
-  public void givenAValidTimeString_whenDeserializerCalled_expectLocalTime() throws IOException {
+  void givenAValidTimeString_whenDeserializerCalled_expectLocalTime() throws IOException {
     // given
     when(jsonParser.getText()).thenReturn("15:45:37.029947Z");
 

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/serialisation/IsoTimeSerializerTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/serialisation/IsoTimeSerializerTest.java
@@ -6,21 +6,21 @@ import static org.mockito.Mockito.verify;
 import com.fasterxml.jackson.core.JsonGenerator;
 import java.io.IOException;
 import java.time.LocalTime;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
-public class IsoTimeSerializerTest {
+@ExtendWith(MockitoExtension.class)
+class IsoTimeSerializerTest {
 
-  private IsoTimeSerializer isoTimeSerializer = new IsoTimeSerializer();
+  private final IsoTimeSerializer isoTimeSerializer = new IsoTimeSerializer();
 
   @Mock
   JsonGenerator jsonGenerator;
 
   @Test
-  public void givenAValidLocalTime_whenSerializerCalled_expectMethodCalledWithTimeAsString()
+  void givenAValidLocalTime_whenSerializerCalled_expectMethodCalledWithTimeAsString()
       throws IOException {
     // given
     LocalTime localTime = LocalTime.of(15, 45, 37, 29947000);

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/EntityPropertyTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/EntityPropertyTest.java
@@ -3,13 +3,13 @@ package uk.gov.defra.tracesx.notificationschema.validation;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.lang.reflect.Field;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.DecisionEnum;
 
-public class EntityPropertyTest {
+class EntityPropertyTest {
 
   @Test
-  public void getAnnotation_ReturnsAnnotation() throws NoSuchFieldException {
+  void getAnnotation_ReturnsAnnotation() throws NoSuchFieldException {
 
     DecisionEnum property = DecisionEnum.ACCEPTABLE_FOR_INTERNAL_MARKET;
     Field field = property.getClass().getField(property.name());

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/ValidationMessageCodeTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/ValidationMessageCodeTest.java
@@ -2,12 +2,12 @@ package uk.gov.defra.tracesx.notificationschema.validation;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class ValidationMessageCodeTest {
+class ValidationMessageCodeTest {
 
   @Test
-  public void toString_PrintsTheCorrectFields() {
+  void toString_PrintsTheCorrectFields() {
     ValidationMessageCode validationMessageCode = new ValidationMessageCode("fieldValue",
         "messageValue");
 
@@ -16,7 +16,7 @@ public class ValidationMessageCodeTest {
   }
 
   @Test
-  public void defaultConstructor_InitialisesWithNullValues() {
+  void defaultConstructor_InitialisesWithNullValues() {
     ValidationMessageCode validationMessageCode = new ValidationMessageCode();
 
     assertThat(validationMessageCode)

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/ValidationMessageTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/ValidationMessageTest.java
@@ -2,21 +2,21 @@ package uk.gov.defra.tracesx.notificationschema.validation;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class ValidationMessageTest {
+class ValidationMessageTest {
 
   private static final String VALUE = "set value";
   private final ValidationMessage testSubject = new ValidationMessage();
 
   @Test
-  public void setField() {
+  void setField() {
     testSubject.setField(VALUE);
     assertThat(testSubject.getField()).isEqualTo(VALUE);
   }
 
   @Test
-  public void setMessage() {
+  void setMessage() {
     testSubject.setMessage(VALUE);
     assertThat(testSubject.getMessage()).isEqualTo(VALUE);
   }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/AccompanyingDocumentsValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/AccompanyingDocumentsValidatorTest.java
@@ -5,8 +5,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collections;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import uk.gov.defra.tracesx.notificationschema.representation.AccompanyingDocument;
 import uk.gov.defra.tracesx.notificationschema.representation.Notification;
 import uk.gov.defra.tracesx.notificationschema.representation.PartOne;
@@ -14,13 +14,13 @@ import uk.gov.defra.tracesx.notificationschema.representation.PartTwo;
 import uk.gov.defra.tracesx.notificationschema.representation.VeterinaryInformation;
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.DocumentType;
 
-public class AccompanyingDocumentsValidatorTest {
+ class AccompanyingDocumentsValidatorTest {
 
   private AccompanyingDocumentsValidator validator;
   private Notification notification;
 
-  @Before
-  public void setup() {
+  @BeforeEach
+  void setup() {
     validator = new AccompanyingDocumentsValidator();
     notification = new Notification();
     VeterinaryInformation veterinaryInformation = new VeterinaryInformation();
@@ -36,63 +36,63 @@ public class AccompanyingDocumentsValidatorTest {
   }
 
   @Test
-  public void isValid_ReturnsTrue_WhenValidPartOneAndPartTwoAccompanyingDocuments() {
+  void isValid_ReturnsTrue_WhenValidPartOneAndPartTwoAccompanyingDocuments() {
     assertThat(validator.isValid(notification, null)).isTrue();
   }
 
   @Test
-  public void isValid_ReturnsTrue_WhenValidPartOneAndPartTwoNullAccompanyingDocuments() {
+  void isValid_ReturnsTrue_WhenValidPartOneAndPartTwoNullAccompanyingDocuments() {
     notification.getPartTwo().setAccompanyingDocuments(null);
     assertThat(validator.isValid(notification, null)).isTrue();
   }
 
   @Test
-  public void isValid_ReturnsTrue_WhenValidPartOneAndPartTwoEmptyAccompanyingDocuments() {
+  void isValid_ReturnsTrue_WhenValidPartOneAndPartTwoEmptyAccompanyingDocuments() {
     notification.getPartTwo().setAccompanyingDocuments(new ArrayList<>());
     assertThat(validator.isValid(notification, null)).isTrue();
   }
 
   @Test
-  public void isValid_ReturnsTrue_WhenPartOneNullVeterinaryInformationAndPartTwoValidAccompanyingDocuments() {
+  void isValid_ReturnsTrue_WhenPartOneNullVeterinaryInformationAndPartTwoValidAccompanyingDocuments() {
     notification.getPartOne().setVeterinaryInformation(null);
     assertThat(validator.isValid(notification, null)).isTrue();
   }
 
   @Test
-  public void isValid_ReturnsTrue_WhenPartOneNullAccompanyingDocumentsAndPartTwoValidAccompanyingDocuments() {
+  void isValid_ReturnsTrue_WhenPartOneNullAccompanyingDocumentsAndPartTwoValidAccompanyingDocuments() {
     notification.getPartOne().getVeterinaryInformation().setAccompanyingDocuments(null);
     assertThat(validator.isValid(notification, null)).isTrue();
   }
 
   @Test
-  public void isValid_ReturnsTrue_WhenPartOneEmptyAccompanyingDocumentsAndPartTwoValidAccompanyingDocuments() {
+  void isValid_ReturnsTrue_WhenPartOneEmptyAccompanyingDocumentsAndPartTwoValidAccompanyingDocuments() {
     notification.getPartOne().getVeterinaryInformation().setAccompanyingDocuments(new ArrayList<>());
     assertThat(validator.isValid(notification, null)).isTrue();
   }
 
   @Test
-  public void isValid_ReturnsFalse_WhenPartOneNullVeterinaryInformationAndPartTwoNullAccompanyingDocuments() {
+  void isValid_ReturnsFalse_WhenPartOneNullVeterinaryInformationAndPartTwoNullAccompanyingDocuments() {
     notification.getPartOne().setVeterinaryInformation(null);
     notification.getPartTwo().setAccompanyingDocuments(null);
     assertThat(validator.isValid(notification, null)).isFalse();
   }
 
   @Test
-  public void isValid_ReturnsFalse_WhenPartOneEmptyAccompanyingDocumentsAndPartTwoNullAccompanyingDocuments() {
+  void isValid_ReturnsFalse_WhenPartOneEmptyAccompanyingDocumentsAndPartTwoNullAccompanyingDocuments() {
     notification.getPartOne().getVeterinaryInformation().setAccompanyingDocuments(new ArrayList<>());
     notification.getPartTwo().setAccompanyingDocuments(null);
     assertThat(validator.isValid(notification, null)).isFalse();
   }
 
   @Test
-  public void isValid_ReturnsFalse_WhenPartOneEmptyAccompanyingDocumentsAndPartTwoEmptyAccompanyingDocuments() {
+  void isValid_ReturnsFalse_WhenPartOneEmptyAccompanyingDocumentsAndPartTwoEmptyAccompanyingDocuments() {
     notification.getPartOne().getVeterinaryInformation().setAccompanyingDocuments(new ArrayList<>());
     notification.getPartTwo().setAccompanyingDocuments(new ArrayList<>());
     assertThat(validator.isValid(notification, null)).isFalse();
   }
 
   @Test
-  public void isValid_ReturnsFalse_WhenPartOneNullAccompanyingDocumentsAndPartTwoEmptyAccompanyingDocuments() {
+  void isValid_ReturnsFalse_WhenPartOneNullAccompanyingDocumentsAndPartTwoEmptyAccompanyingDocuments() {
     notification.getPartOne().getVeterinaryInformation().setAccompanyingDocuments(null);
     notification.getPartTwo().setAccompanyingDocuments(new ArrayList<>());
     assertThat(validator.isValid(notification, null)).isFalse();

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/CedOrCvedpControlledDestinationValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/CedOrCvedpControlledDestinationValidatorTest.java
@@ -1,172 +1,161 @@
 package uk.gov.defra.tracesx.notificationschema.validation.annotations;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.DecisionEnum.ACCEPTABLE_FOR_INTERNAL_MARKET;
 import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.DecisionEnum.ACCEPTABLE_FOR_SPECIFIC_WAREHOUSE;
 import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.DecisionEnum.ACCEPTABLE_FOR_TRANSIT;
 import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.DecisionEnum.ACCEPTABLE_IF_CHANNELED;
 import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.DecisionEnum.NON_ACCEPTABLE;
 import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.NotAcceptableActionEnum.DESTRUCTION;
-import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.NotAcceptableActionEnum.OTHER;
 import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.NotAcceptableActionEnum.REDISPATCHING;
 import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.NotAcceptableActionEnum.REEXPORT;
-import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.NotAcceptableActionEnum.SLAUGHTER;
 import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.SpecificWarehouseNonConformingConsignmentEnum.CUSTOMWAREHOUSE;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.theories.DataPoints;
-import org.junit.experimental.theories.FromDataPoints;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import uk.gov.defra.tracesx.notificationschema.representation.Decision;
 import uk.gov.defra.tracesx.notificationschema.representation.EconomicOperator;
 import uk.gov.defra.tracesx.notificationschema.representation.PartTwo;
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.DefinitiveImportPurposeEnum;
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.NotAcceptableActionEnum;
 
-@RunWith(Theories.class)
-public class CedOrCvedpControlledDestinationValidatorTest {
+ class CedOrCvedpControlledDestinationValidatorTest {
 
   private CedOrCvedpControlledDestinationValidator validator;
 
-  @DataPoints("requiring Controlled Destination")
-  public static final NotAcceptableActionEnum[] notAcceptableActions = new NotAcceptableActionEnum[]{
-      DESTRUCTION,
-      SLAUGHTER,
-      OTHER
-  };
   private PartTwo partTwo;
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     this.validator = new CedOrCvedpControlledDestinationValidator();
     this.partTwo = PartTwo.builder().decision(Decision.builder().build()).build();
   }
 
   @Test
-  public void isValidForNullPartTwo() {
-    assertTrue(validator.isValid(null, null));
+  void isValidForNullPartTwo() {
+    assertThat(validator.isValid(null, null)).isTrue();
   }
 
   @Test
-  public void isValidForNullDecision() {
-    assertTrue(validator.isValid(PartTwo.builder().build(), null));
+  void isValidForNullDecision() {
+    assertThat(validator.isValid(PartTwo.builder().build(), null)).isTrue();
   }
 
   @Test
-  public void isValid_DecisionTransferWithoutControlledDestination_isTrue() {
+  void isValid_DecisionTransferWithoutControlledDestination_isTrue() {
     partTwo.getDecision().setDecision(ACCEPTABLE_FOR_TRANSIT);
 
     boolean result = validator
         .isValid(partTwo, null);
 
-    assertTrue(result);
+    assertThat(result).isTrue();
   }
 
-  @Theory
-  public void isValid_notAcceptableWithFilledControlledDestination_isTrue(
-      @FromDataPoints("requiring Controlled Destination") NotAcceptableActionEnum notAcceptableAction) {
+  @ParameterizedTest
+  @EnumSource(value = NotAcceptableActionEnum.class, names = {"DESTRUCTION", "SLAUGHTER", "OTHER"})
+  void isValid_notAcceptableWithFilledControlledDestination_isTrue(
+      NotAcceptableActionEnum notAcceptableAction) {
     partTwo.setControlledDestination(EconomicOperator.builder().build());
     partTwo.getDecision().setDecision(NON_ACCEPTABLE);
     partTwo.getDecision().setNotAcceptableAction(notAcceptableAction);
 
     boolean result = validator.isValid(partTwo, null);
 
-    assertTrue(result);
+    assertThat(result).isTrue();
   }
 
-  @Theory
-  public void isValid_notAcceptableWithoutFilledControlledDestination_isFalse(
-      @FromDataPoints("requiring Controlled Destination") NotAcceptableActionEnum notAcceptableAction) {
+  @ParameterizedTest
+  @EnumSource(value = NotAcceptableActionEnum.class, names = {"DESTRUCTION", "SLAUGHTER", "OTHER"})
+  void isValid_notAcceptableWithoutFilledControlledDestination_isFalse(
+      NotAcceptableActionEnum notAcceptableAction) {
     partTwo.getDecision().setDecision(NON_ACCEPTABLE);
     partTwo.getDecision().setNotAcceptableAction(notAcceptableAction);
 
     boolean result = validator.isValid(partTwo, null);
 
-    assertFalse(result);
+    assertThat(result).isFalse();
   }
 
   @Test
-  public void isValid_nonAcceptableWithReExportWithoutControlledDestination_isTrue() {
+  void isValid_nonAcceptableWithReExportWithoutControlledDestination_isTrue() {
     partTwo.setControlledDestination(EconomicOperator.builder().build());
     partTwo.getDecision().setDecision(NON_ACCEPTABLE);
     partTwo.getDecision().setNotAcceptableAction(REEXPORT);
 
     boolean result = validator.isValid(partTwo, null);
 
-    assertTrue(result);
+    assertThat(result).isTrue();
   }
 
   @Test
-  public void isValid_nonAcceptableWithoutNotAcceptableActionAndWithoutControlledDestination_isTrue() {
+  void isValid_nonAcceptableWithoutNotAcceptableActionAndWithoutControlledDestination_isTrue() {
     partTwo.getDecision().setDecision(NON_ACCEPTABLE);
 
     boolean result = validator.isValid(partTwo, null);
 
-    assertTrue(result);
+    assertThat(result).isTrue();
   }
 
   @Test
-  public void isValid_nonAcceptableWithDestructionWithoutControlledDestination_isFalse() {
+  void isValid_nonAcceptableWithDestructionWithoutControlledDestination_isFalse() {
     partTwo.getDecision().setDecision(NON_ACCEPTABLE);
     partTwo.getDecision().setNotAcceptableAction(DESTRUCTION);
 
     boolean result = validator.isValid(partTwo, null);
 
-    assertFalse(result);
+    assertThat(result).isFalse();
   }
 
   @Test
-  public void isValid_acceptableForInternalMarketSlaughterWithoutControlledDestination_isTrue() {
+  void isValid_acceptableForInternalMarketSlaughterWithoutControlledDestination_isTrue() {
     partTwo.getDecision().setDecision(ACCEPTABLE_FOR_INTERNAL_MARKET);
     partTwo.getDecision().setDefinitiveImportPurpose(DefinitiveImportPurposeEnum.SLAUGHTER);
 
     boolean result = validator.isValid(partTwo, null);
 
-    assertTrue(result);
+    assertThat(result).isTrue();
   }
 
   @Test
-  public void isValid_channeledWithoutControlledDestination_isFalse() {
+  void isValid_channeledWithoutControlledDestination_isFalse() {
     partTwo.getDecision().setDecision(ACCEPTABLE_IF_CHANNELED);
 
     boolean valid = validator.isValid(partTwo, null);
 
-    assertFalse(valid);
+    assertThat(valid).isFalse();
   }
 
   @Test
-  public void isValid_specificWarehouseAndSpecificWarehouseNonConformingConsignmentWithoutControlledDestination_isFalse() {
+  void isValid_specificWarehouseAndSpecificWarehouseNonConformingConsignmentWithoutControlledDestination_isFalse() {
     partTwo.getDecision().setDecision(ACCEPTABLE_FOR_SPECIFIC_WAREHOUSE);
     partTwo.getDecision().setSpecificWarehouseNonConformingConsignment(CUSTOMWAREHOUSE);
 
     boolean result = validator.isValid(partTwo, null);
 
-    assertFalse(result);
+    assertThat(result).isFalse();
   }
 
   @Test
-  public void isValid_specificWarehouseAndSpecificWarehouseNonConformingConsignmentWithControlledDestination_isTrue() {
+  void isValid_specificWarehouseAndSpecificWarehouseNonConformingConsignmentWithControlledDestination_isTrue() {
     partTwo.getDecision().setDecision(ACCEPTABLE_FOR_SPECIFIC_WAREHOUSE);
     partTwo.getDecision().setSpecificWarehouseNonConformingConsignment(CUSTOMWAREHOUSE);
     partTwo.setControlledDestination(EconomicOperator.builder().build());
 
     boolean result = validator.isValid(partTwo, null);
 
-    assertTrue(result);
+    assertThat(result).isTrue();
   }
 
   @Test
-  public void isValid_nonAcceptableReDispatchingWithoutControlledDestination_isTrue() {
+  void isValid_nonAcceptableReDispatchingWithoutControlledDestination_isTrue() {
     partTwo.getDecision().setDecision(NON_ACCEPTABLE);
     partTwo.getDecision().setNotAcceptableAction(REDISPATCHING);
     partTwo.setControlledDestination(null);
 
     boolean result = validator.isValid(partTwo, null);
 
-    assertTrue(result);
+    assertThat(result).isTrue();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedaDocumentCheckResultValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedaDocumentCheckResultValidatorTest.java
@@ -1,7 +1,6 @@
 package uk.gov.defra.tracesx.notificationschema.validation.annotations;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.Result.DEROGATION;
 import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.Result.NOT_DONE;
 import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.Result.NOT_SATISFACTORY;
@@ -9,163 +8,162 @@ import static uk.gov.defra.tracesx.notificationschema.representation.enumeration
 import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.Result.SATISFACTORY;
 import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.Result.SATISFACTORY_FOLLOWING_OFFICIAL_INTERVENTION;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import uk.gov.defra.tracesx.notificationschema.representation.ConsignmentCheck;
 
-public class ChedaDocumentCheckResultValidatorTest {
+class ChedaDocumentCheckResultValidatorTest {
 
   private ChedaDocumentCheckResultValidator validator;
   private ConsignmentCheck check;
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     validator = new ChedaDocumentCheckResultValidator();
     check = new ConsignmentCheck();
     validator.initialize(null);
   }
 
   @Test
-  public void isValid_returnsFalse_whenDocumentCheckSatisfactoryEuStandardAndNationalRequirementNull() {
-    assertFalse(validator.isValid(check, null));
+  void isValid_returnsFalse_whenDocumentCheckSatisfactoryEuStandardAndNationalRequirementNull() {
+    assertThat(validator.isValid(check, null)).isFalse();
   }
 
   @Test
-  public void isValid_returnsTrue_whenConsignmentCheckIsNull() {
-    Assert.assertTrue(validator.isValid(null, null));
+  void isValid_returnsTrue_whenConsignmentCheckIsNull() {
+    assertThat(validator.isValid(null, null)).isTrue();
   }
 
   @Test
-  public void isValid_returnsTrue_whenDocumentCheckSatisfactoryEuStandardNotSetAndNationalRequirementNotSet() {
+  void isValid_returnsTrue_whenDocumentCheckSatisfactoryEuStandardNotSetAndNationalRequirementNotSet() {
     check.setDocumentCheckResult(SATISFACTORY);
     check.setEuStandard(NOT_SET);
     check.setNationalRequirements(NOT_SET);
 
-    assertTrue(validator.isValid(check, null));
+    assertThat(validator.isValid(check, null)).isTrue();
   }
 
   @Test
-  public void isValid_returnsTrue_whenDocumentCheckNotSatisfactoryEuStandardNotSetAndNationalRequirementNotSet() {
+  void isValid_returnsTrue_whenDocumentCheckNotSatisfactoryEuStandardNotSetAndNationalRequirementNotSet() {
     check.setDocumentCheckResult(NOT_SATISFACTORY);
     check.setEuStandard(NOT_SET);
     check.setNationalRequirements(NOT_SET);
 
-    assertTrue(validator.isValid(check, null));
+    assertThat(validator.isValid(check, null)).isTrue();
   }
 
   @Test
-  public void isValid_returnsFalse_whenDocumentCheckEuStandardAndNationalRequirementNotSatisfactory() {
+  void isValid_returnsFalse_whenDocumentCheckEuStandardAndNationalRequirementNotSatisfactory() {
     check.setDocumentCheckResult(NOT_SATISFACTORY);
     check.setEuStandard(NOT_SATISFACTORY);
     check.setNationalRequirements(NOT_SATISFACTORY);
 
-    assertFalse(validator.isValid(check, null));
+    assertThat(validator.isValid(check, null)).isFalse();
   }
 
   @Test
-  public void isValid_returnsFalse_whenDocumentCheckEuStandardAndNationalRequirementSatisfactory() {
+  void isValid_returnsFalse_whenDocumentCheckEuStandardAndNationalRequirementSatisfactory() {
     check.setDocumentCheckResult(SATISFACTORY);
     check.setEuStandard(SATISFACTORY);
     check.setNationalRequirements(SATISFACTORY);
 
-    assertFalse(validator.isValid(check, null));
+    assertThat(validator.isValid(check, null)).isFalse();
   }
 
   @Test
-  public void isValid_returnsFalse_whenDocumentCheckOfficialInterventionEuStandardNotDoneAndNationalRequirementDerogation() {
+  void isValid_returnsFalse_whenDocumentCheckOfficialInterventionEuStandardNotDoneAndNationalRequirementDerogation() {
     check.setDocumentCheckResult(SATISFACTORY_FOLLOWING_OFFICIAL_INTERVENTION);
     check.setEuStandard(NOT_DONE);
     check.setNationalRequirements(DEROGATION);
 
-    assertFalse(validator.isValid(check, null));
+    assertThat(validator.isValid(check, null)).isFalse();
   }
 
   @Test
-  public void isValid_returnsTrue_whenDocumentCheckNotSetEuStandardSatisfactoryAndNationalRequirementSatisfactory() {
+  void isValid_returnsTrue_whenDocumentCheckNotSetEuStandardSatisfactoryAndNationalRequirementSatisfactory() {
     check.setDocumentCheckResult(NOT_SET);
     check.setEuStandard(SATISFACTORY);
     check.setNationalRequirements(SATISFACTORY);
 
-    assertTrue(validator.isValid(check, null));
+    assertThat(validator.isValid(check, null)).isTrue();
   }
 
   @Test
-  public void isValid_returnsTrue_whenDocumentCheckNotSetEuStandardNotSatisfactoryAndNationalRequirementNotSatisfactory() {
+  void isValid_returnsTrue_whenDocumentCheckNotSetEuStandardNotSatisfactoryAndNationalRequirementNotSatisfactory() {
     check.setDocumentCheckResult(NOT_SET);
     check.setEuStandard(NOT_SATISFACTORY);
     check.setNationalRequirements(NOT_SATISFACTORY);
 
-    assertTrue(validator.isValid(check, null));
+    assertThat(validator.isValid(check, null)).isTrue();
   }
 
   @Test
-  public void isValid_returnsTrue_whenDocumentCheckNotSetEuStandardNotSatisfactoryAndNationalRequirementSatisfactory() {
+  void isValid_returnsTrue_whenDocumentCheckNotSetEuStandardNotSatisfactoryAndNationalRequirementSatisfactory() {
     check.setDocumentCheckResult(NOT_SET);
     check.setEuStandard(NOT_SATISFACTORY);
     check.setNationalRequirements(SATISFACTORY);
 
-    assertTrue(validator.isValid(check, null));
+    assertThat(validator.isValid(check, null)).isTrue();
   }
 
   @Test
-  public void isValid_returnsTrue_whenDocumentCheckNotSetEuStandardSatisfactoryAndNationalRequirementNotSatisfactory() {
+  void isValid_returnsTrue_whenDocumentCheckNotSetEuStandardSatisfactoryAndNationalRequirementNotSatisfactory() {
     check.setDocumentCheckResult(NOT_SET);
     check.setEuStandard(SATISFACTORY);
     check.setNationalRequirements(NOT_SATISFACTORY);
 
-    assertTrue(validator.isValid(check, null));
+    assertThat(validator.isValid(check, null)).isTrue();
   }
 
   @Test
-  public void isValid_returnsFalse_whenDocumentCheckEuStandardAndNationalRequirementNotSet() {
+  void isValid_returnsFalse_whenDocumentCheckEuStandardAndNationalRequirementNotSet() {
     check.setDocumentCheckResult(NOT_SET);
     check.setEuStandard(NOT_SET);
     check.setNationalRequirements(NOT_SET);
 
-    assertFalse(validator.isValid(check, null));
+    assertThat(validator.isValid(check, null)).isFalse();
   }
 
   @Test
-  public void isValid_returnsTrue_whenDocumentCheckEuStandardNotSetNationalRequirementSet() {
+  void isValid_returnsTrue_whenDocumentCheckEuStandardNotSetNationalRequirementSet() {
     check.setDocumentCheckResult(NOT_SET);
     check.setEuStandard(NOT_SET);
     check.setNationalRequirements(SATISFACTORY);
 
-    assertTrue(validator.isValid(check, null));
+    assertThat(validator.isValid(check, null)).isTrue();
   }
 
   @Test
-  public void isValid_returnsTrue_whenDocumentCheckNotSetEuStandardNotSatisfactoryNationalRequirementSatisFactory() {
+  void isValid_returnsTrue_whenDocumentCheckNotSetEuStandardNotSatisfactoryNationalRequirementSatisFactory() {
     check.setDocumentCheckResult(NOT_SET);
     check.setEuStandard(NOT_SATISFACTORY);
     check.setNationalRequirements(SATISFACTORY);
 
-    assertTrue(validator.isValid(check, null));
+    assertThat(validator.isValid(check, null)).isTrue();
   }
 
   @Test
-  public void isValid_returnsTrue_whenDocumentCheckNullEuStandardAndNationalRequirementNotSet() {
+  void isValid_returnsTrue_whenDocumentCheckNullEuStandardAndNationalRequirementNotSet() {
     check.setEuStandard(NOT_SET);
     check.setNationalRequirements(NOT_SET);
 
-    assertFalse(validator.isValid(check, null));
+    assertThat(validator.isValid(check, null)).isFalse();
   }
 
   @Test
-  public void isValid_returnsTrue_whenDocumentCheckEuStandardNullAndNationalRequirementNotSet() {
+  void isValid_returnsTrue_whenDocumentCheckEuStandardNullAndNationalRequirementNotSet() {
     check.setDocumentCheckResult(NOT_SET);
     check.setNationalRequirements(NOT_SET);
 
-    assertTrue(validator.isValid(check, null));
+    assertThat(validator.isValid(check, null)).isTrue();
   }
 
   @Test
-  public void isValid_returnsTrue_whenDocumentCheckSatisfactoryEuStandardAndNationalRequirementNullt() {
+  void isValid_returnsTrue_whenDocumentCheckSatisfactoryEuStandardAndNationalRequirementNull() {
     check.setDocumentCheckResult(SATISFACTORY);
     check.setEuStandard(NOT_SET);
 
-    assertFalse(validator.isValid(check, null));
+    assertThat(validator.isValid(check, null)).isFalse();
   }
 
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedaPurposeExitDateNotNullValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedaPurposeExitDateNotNullValidatorTest.java
@@ -1,24 +1,23 @@
 package uk.gov.defra.tracesx.notificationschema.validation.annotations;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorContext;
 import org.hibernate.validator.constraintvalidation.HibernateConstraintViolationBuilder;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.defra.tracesx.notificationschema.representation.Purpose;
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.ForImportOrAdmissionEnum;
 
 import jakarta.validation.ConstraintValidatorContext;
 
-@RunWith(MockitoJUnitRunner.class)
-public class ChedaPurposeExitDateNotNullValidatorTest {
+@ExtendWith(MockitoExtension.class)
+class ChedaPurposeExitDateNotNullValidatorTest {
 
   private ChedaPurposeExitDateNotNullValidator validator;
   private Purpose purpose;
@@ -32,10 +31,14 @@ public class ChedaPurposeExitDateNotNullValidatorTest {
   @Mock
   ConstraintValidatorContext.ConstraintViolationBuilder.NodeBuilderCustomizableContext nodeBuilderContextMock;
 
-  @Before
-  public void setup() {
+  @BeforeEach
+  void setup() {
     validator = new ChedaPurposeExitDateNotNullValidator();
     purpose = new Purpose();
+
+  }
+
+  void validatorMocking() {
     when(constraintValidatorContextMock
         .unwrap(HibernateConstraintValidatorContext.class))
         .thenReturn(hibernateConstraintValidatorContextMock);
@@ -49,16 +52,17 @@ public class ChedaPurposeExitDateNotNullValidatorTest {
   }
 
   @Test
-  public void validatorShouldReturnFalseIfPurposeIsNull() {
+  void validatorShouldReturnFalseIfPurposeIsNull() {
+    validatorMocking();
     // Given / When
     boolean result = validator.isValid(null, constraintValidatorContextMock);
 
     // Then
-    assertFalse(result);
+    assertThat(result).isFalse();
   }
 
   @Test
-  public void validatorShouldReturnTrueIfForImportOrAdmissionIsNotTemporaryAdmissionHorses() {
+  void validatorShouldReturnTrueIfForImportOrAdmissionIsNotTemporaryAdmissionHorses() {
     // Given
     purpose.setForImportOrAdmission(ForImportOrAdmissionEnum.DEFINITIVE_IMPORT);
 
@@ -66,12 +70,12 @@ public class ChedaPurposeExitDateNotNullValidatorTest {
     boolean result = validator.isValid(purpose, null);
 
     // Then
-    assertTrue(result);
+    assertThat(result).isTrue();
   }
 
 
   @Test
-  public void validatorShouldReturnTrueIfForImportOrAdmissionIsTemporaryAdmissionHorsesWithExitDate() {
+  void validatorShouldReturnTrueIfForImportOrAdmissionIsTemporaryAdmissionHorsesWithExitDate() {
     // Given
     purpose.setForImportOrAdmission(ForImportOrAdmissionEnum.TEMPORARY_ADMISSION_HORSES);
     purpose.setExitDate("exit date");
@@ -80,18 +84,19 @@ public class ChedaPurposeExitDateNotNullValidatorTest {
     boolean result = validator.isValid(purpose, null);
 
     // Then
-    assertTrue(result);
+    assertThat(result).isTrue();
   }
 
   @Test
-  public void validatorShouldReturnFalseIfForImportOrAdmissionIsTemporaryAdmissionHorsesWithNoExitDate() {
+  void validatorShouldReturnFalseIfForImportOrAdmissionIsTemporaryAdmissionHorsesWithNoExitDate() {
     // Given
     purpose.setForImportOrAdmission(ForImportOrAdmissionEnum.TEMPORARY_ADMISSION_HORSES);
+    validatorMocking();
 
     // When
     boolean result = validator.isValid(purpose, constraintValidatorContextMock);
 
     // Then
-    assertFalse(result);
+    assertThat(result).isFalse();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedpIdentityCheckTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedpIdentityCheckTest.java
@@ -1,7 +1,6 @@
 package uk.gov.defra.tracesx.notificationschema.validation.annotations;
 
-import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.assertFalse;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.IdentificationCheckType.FULL_IDENTITY_CHECK;
@@ -9,21 +8,20 @@ import static uk.gov.defra.tracesx.notificationschema.representation.enumeration
 import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.Result.SATISFACTORY;
 
 import jakarta.validation.ConstraintValidatorContext;
-import jakarta.validation.ConstraintValidatorContext.ConstraintViolationBuilder;
 import jakarta.validation.ConstraintValidatorContext.ConstraintViolationBuilder.NodeBuilderCustomizableContext;
 import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorContext;
 import org.hibernate.validator.constraintvalidation.HibernateConstraintViolationBuilder;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.defra.tracesx.notificationschema.representation.ConsignmentCheck;
 import uk.gov.defra.tracesx.notificationschema.representation.Decision;
 import uk.gov.defra.tracesx.notificationschema.representation.PartTwo;
 
-@RunWith(MockitoJUnitRunner.class)
-public class ChedpIdentityCheckTest {
+@ExtendWith(MockitoExtension.class)
+class ChedpIdentityCheckTest {
 
   private ChedpIdentityCheckValidator validator;
   private PartTwo partTwo;
@@ -37,114 +35,125 @@ public class ChedpIdentityCheckTest {
   @Mock
   NodeBuilderCustomizableContext nodeBuilderContextMock;
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     validator = new ChedpIdentityCheckValidator();
     partTwo = new PartTwo();
+  }
+
+  void validatorMocking() {
     when(constraintValidatorContextMock
-            .unwrap(HibernateConstraintValidatorContext.class))
-            .thenReturn(hibernateConstraintValidatorContextMock);
+        .unwrap(HibernateConstraintValidatorContext.class))
+        .thenReturn(hibernateConstraintValidatorContextMock);
 
     when(hibernateConstraintValidatorContextMock
-            .buildConstraintViolationWithTemplate(anyString()))
-            .thenReturn(hibernateConstraintViolationBuilder);
+        .buildConstraintViolationWithTemplate(anyString()))
+        .thenReturn(hibernateConstraintViolationBuilder);
 
     when(hibernateConstraintViolationBuilder.addPropertyNode(anyString()))
-            .thenReturn(nodeBuilderContextMock);
+        .thenReturn(nodeBuilderContextMock);
   }
 
   @Test
-  public void isValid_returnsFalse_whenPartTwoNull() {
-    assertFalse(validator.isValid(null, constraintValidatorContextMock));
+  void isValid_returnsFalse_whenPartTwoNull() {
+    validatorMocking();
+    assertThat(validator.isValid(null, constraintValidatorContextMock)).isFalse();
   }
 
   @Test
-  public void isValid_returnsFalse_whenConsignmentCheckNull() {
-    assertFalse(validator.isValid(partTwo, constraintValidatorContextMock));
+  void isValid_returnsFalse_whenConsignmentCheckNull() {
+    validatorMocking();
+    assertThat(validator.isValid(partTwo, constraintValidatorContextMock)).isFalse();
   }
 
 
   @Test
-  public void isValid_returnsFalse_whenDocumentCheckNullAndIdentityCheckTypeNull() {
+  void isValid_returnsFalse_whenDocumentCheckNullAndIdentityCheckTypeNull() {
+    validatorMocking();
     partTwo.setConsignmentCheck(new ConsignmentCheck());
 
-    assertFalse(validator.isValid(partTwo, constraintValidatorContextMock));
+    assertThat(validator.isValid(partTwo, constraintValidatorContextMock)).isFalse();
   }
 
   @Test
-  public void isValid_returnsFalse_whenDocumentCheckNullAndIdentityCheckResultNull() {
+  void isValid_returnsFalse_whenDocumentCheckNullAndIdentityCheckResultNull() {
+    validatorMocking();
     partTwo.setConsignmentCheck(ConsignmentCheck.builder()
         .identityCheckType(FULL_IDENTITY_CHECK)
         .build());
 
-    assertFalse(validator.isValid(partTwo, constraintValidatorContextMock));
+    assertThat(validator.isValid(partTwo, constraintValidatorContextMock)).isFalse();
   }
 
   @Test
-  public void isValid_returnsTrue_whenDocumentCheckNullAndIdentityCheckNotNull() {
+  void isValid_returnsTrue_whenDocumentCheckNullAndIdentityCheckNotNull() {
     partTwo.setConsignmentCheck(ConsignmentCheck.builder()
-        .identityCheckType(FULL_IDENTITY_CHECK)
-        .identityCheckResult(NOT_SATISFACTORY)
-        .build());
-
-    assertTrue(validator.isValid(partTwo, constraintValidatorContextMock));
-  }
-
-
-  @Test
-  public void isValid_returnsFalse_whenDocumentCheckSatisfactoryAndIdentityCheckTypeNull() {
-    partTwo.setConsignmentCheck(ConsignmentCheck.builder()
-        .documentCheckResult(SATISFACTORY)
-        .build());
-
-    assertFalse(validator.isValid(partTwo, constraintValidatorContextMock));
-  }
-
-  @Test
-  public void isValid_returnsFalse_whenDocumentCheckSatisfactoryAndIdentityCheckResultNull() {
-    partTwo.setConsignmentCheck(ConsignmentCheck.builder()
-        .documentCheckResult(SATISFACTORY)
-        .identityCheckType(FULL_IDENTITY_CHECK)
-        .build());
-
-    assertFalse(validator.isValid(partTwo, constraintValidatorContextMock));
-  }
-
-  @Test
-  public void isValid_returnsTrue_whenDocumentCheckSatisfactoryAndIdentityCheckNotNull() {
-    partTwo.setConsignmentCheck(ConsignmentCheck.builder()
-        .documentCheckResult(SATISFACTORY)
         .identityCheckType(FULL_IDENTITY_CHECK)
         .identityCheckResult(NOT_SATISFACTORY)
         .build());
 
-    assertTrue(validator.isValid(partTwo, constraintValidatorContextMock));
+    assertThat(validator.isValid(partTwo, constraintValidatorContextMock)).isTrue();
   }
 
 
   @Test
-  public void isValid_returnsFalse_whenDocumentCheckNotSatisfactoryAndConsignmentAcceptableAndIdentityCheckTypeNull() {
+  void isValid_returnsFalse_whenDocumentCheckSatisfactoryAndIdentityCheckTypeNull() {
+    validatorMocking();
+    partTwo.setConsignmentCheck(ConsignmentCheck.builder()
+        .documentCheckResult(SATISFACTORY)
+        .build());
+
+    assertThat(validator.isValid(partTwo, constraintValidatorContextMock)).isFalse();
+  }
+
+  @Test
+  void isValid_returnsFalse_whenDocumentCheckSatisfactoryAndIdentityCheckResultNull() {
+    validatorMocking();
+    partTwo.setConsignmentCheck(ConsignmentCheck.builder()
+        .documentCheckResult(SATISFACTORY)
+        .identityCheckType(FULL_IDENTITY_CHECK)
+        .build());
+
+    assertThat(validator.isValid(partTwo, constraintValidatorContextMock)).isFalse();
+  }
+
+  @Test
+  void isValid_returnsTrue_whenDocumentCheckSatisfactoryAndIdentityCheckNotNull() {
+    partTwo.setConsignmentCheck(ConsignmentCheck.builder()
+        .documentCheckResult(SATISFACTORY)
+        .identityCheckType(FULL_IDENTITY_CHECK)
+        .identityCheckResult(NOT_SATISFACTORY)
+        .build());
+
+    assertThat(validator.isValid(partTwo, constraintValidatorContextMock)).isTrue();
+  }
+
+
+  @Test
+  void isValid_returnsFalse_whenDocumentCheckNotSatisfactoryAndConsignmentAcceptableAndIdentityCheckTypeNull() {
+    validatorMocking();
     partTwo.setConsignmentCheck(ConsignmentCheck.builder()
         .documentCheckResult(NOT_SATISFACTORY)
         .build());
     partTwo.setDecision(Decision.builder().consignmentAcceptable(true).build());
 
-    assertFalse(validator.isValid(partTwo, constraintValidatorContextMock));
+    assertThat(validator.isValid(partTwo, constraintValidatorContextMock)).isFalse();
   }
 
   @Test
-  public void isValid_returnsFalse_whenDocumentCheckNotSatisfactoryAndConsignmentAcceptableAndIdentityCheckResultNull() {
+  void isValid_returnsFalse_whenDocumentCheckNotSatisfactoryAndConsignmentAcceptableAndIdentityCheckResultNull() {
+    validatorMocking();
     partTwo.setConsignmentCheck(ConsignmentCheck.builder()
         .documentCheckResult(NOT_SATISFACTORY)
         .identityCheckType(FULL_IDENTITY_CHECK)
         .build());
     partTwo.setDecision(Decision.builder().consignmentAcceptable(true).build());
 
-    assertFalse(validator.isValid(partTwo, constraintValidatorContextMock));
+    assertThat(validator.isValid(partTwo, constraintValidatorContextMock)).isFalse();
   }
 
   @Test
-  public void isValid_returnsTrue_whenDocumentCheckNotSatisfactoryAndConsignmentAcceptableAndIdentityCheckNotNull() {
+  void isValid_returnsTrue_whenDocumentCheckNotSatisfactoryAndConsignmentAcceptableAndIdentityCheckNotNull() {
     partTwo.setConsignmentCheck(ConsignmentCheck.builder()
         .documentCheckResult(NOT_SATISFACTORY)
         .identityCheckType(FULL_IDENTITY_CHECK)
@@ -152,36 +161,36 @@ public class ChedpIdentityCheckTest {
         .build());
     partTwo.setDecision(Decision.builder().consignmentAcceptable(true).build());
 
-    assertTrue(validator.isValid(partTwo, constraintValidatorContextMock));
+    assertThat(validator.isValid(partTwo, constraintValidatorContextMock)).isTrue();
   }
 
 
   @Test
-  public void isValid_returnsTrue_whenDocumentCheckNotSatisfactoryAndDecisionNull() {
+  void isValid_returnsTrue_whenDocumentCheckNotSatisfactoryAndDecisionNull() {
     partTwo.setConsignmentCheck(ConsignmentCheck.builder()
         .documentCheckResult(NOT_SATISFACTORY)
         .build());
 
-    assertTrue(validator.isValid(partTwo, constraintValidatorContextMock));
+    assertThat(validator.isValid(partTwo, constraintValidatorContextMock)).isTrue();
   }
 
   @Test
-  public void isValid_returnsTrue_whenDocumentCheckNotSatisfactoryAndConsignmentAcceptableNull() {
+  void isValid_returnsTrue_whenDocumentCheckNotSatisfactoryAndConsignmentAcceptableNull() {
     partTwo.setConsignmentCheck(ConsignmentCheck.builder()
         .documentCheckResult(NOT_SATISFACTORY)
         .build());
     partTwo.setDecision(Decision.builder().build());
 
-    assertTrue(validator.isValid(partTwo, constraintValidatorContextMock));
+    assertThat(validator.isValid(partTwo, constraintValidatorContextMock)).isTrue();
   }
 
   @Test
-  public void isValid_returnsTrue_whenDocumentCheckNotSatisfactoryAndConsignmentAcceptableFalse() {
+  void isValid_returnsTrue_whenDocumentCheckNotSatisfactoryAndConsignmentAcceptableFalse() {
     partTwo.setConsignmentCheck(ConsignmentCheck.builder()
         .documentCheckResult(NOT_SATISFACTORY)
         .build());
     partTwo.setDecision(Decision.builder().consignmentAcceptable(false).build());
 
-    assertTrue(validator.isValid(partTwo, constraintValidatorContextMock));
+    assertThat(validator.isValid(partTwo, constraintValidatorContextMock)).isTrue();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedpPhysicalCheckTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedpPhysicalCheckTest.java
@@ -1,28 +1,26 @@
 package uk.gov.defra.tracesx.notificationschema.validation.annotations;
 
-import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.assertFalse;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.Result.NOT_SATISFACTORY;
 import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.Result.SATISFACTORY;
 
 import jakarta.validation.ConstraintValidatorContext;
-import jakarta.validation.ConstraintValidatorContext.ConstraintViolationBuilder;
 import jakarta.validation.ConstraintValidatorContext.ConstraintViolationBuilder.NodeBuilderCustomizableContext;
 import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorContext;
 import org.hibernate.validator.constraintvalidation.HibernateConstraintViolationBuilder;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.defra.tracesx.notificationschema.representation.ConsignmentCheck;
 import uk.gov.defra.tracesx.notificationschema.representation.Decision;
 import uk.gov.defra.tracesx.notificationschema.representation.PartTwo;
 
-@RunWith(MockitoJUnitRunner.class)
-public class ChedpPhysicalCheckTest {
+@ExtendWith(MockitoExtension.class)
+class ChedpPhysicalCheckTest {
 
   private ChedpPhysicalCheckValidator validator;
   private PartTwo partTwo;
@@ -36,10 +34,13 @@ public class ChedpPhysicalCheckTest {
   @Mock
   NodeBuilderCustomizableContext nodeBuilderContextMock;
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     validator = new ChedpPhysicalCheckValidator();
     partTwo = new PartTwo();
+  }
+
+  void validatorMocking() {
     when(constraintValidatorContextMock
         .unwrap(HibernateConstraintValidatorContext.class))
         .thenReturn(hibernateConstraintValidatorContextMock);
@@ -52,102 +53,108 @@ public class ChedpPhysicalCheckTest {
         .thenReturn(nodeBuilderContextMock);
   }
 
+
   @Test
-  public void isValid_returnsFalse_whenPartTwoNull() {
-    assertFalse(validator.isValid(null, constraintValidatorContextMock));
+  void isValid_returnsFalse_whenPartTwoNull() {
+    validatorMocking();
+    assertThat(validator.isValid(null, constraintValidatorContextMock)).isFalse();
   }
 
   @Test
-  public void isValid_returnsFalse_whenConsignmentCheckNull() {
-    assertFalse(validator.isValid(partTwo, constraintValidatorContextMock));
+  void isValid_returnsFalse_whenConsignmentCheckNull() {
+    validatorMocking();
+    assertThat(validator.isValid(partTwo, constraintValidatorContextMock)).isFalse();
   }
 
 
   @Test
-  public void isValid_returnsFalse_whenDocumentCheckNullAndPhysicalCheckResultNull() {
+  void isValid_returnsFalse_whenDocumentCheckNullAndPhysicalCheckResultNull() {
+    validatorMocking();
     partTwo.setConsignmentCheck(new ConsignmentCheck());
 
-    assertFalse(validator.isValid(partTwo, constraintValidatorContextMock));
+    assertThat(validator.isValid(partTwo, constraintValidatorContextMock)).isFalse();
   }
 
   @Test
-  public void isValid_returnsTrue_whenDocumentCheckNullAndPhysicalCheckResultNotNull() {
+  void isValid_returnsTrue_whenDocumentCheckNullAndPhysicalCheckResultNotNull() {
     partTwo.setConsignmentCheck(ConsignmentCheck.builder()
         .physicalCheckResult(NOT_SATISFACTORY)
         .build());
 
-    assertTrue(validator.isValid(partTwo, constraintValidatorContextMock));
+    assertThat(validator.isValid(partTwo, constraintValidatorContextMock)).isTrue();
   }
 
 
   @Test
-  public void isValid_returnsFalse_whenDocumentCheckSatisfactoryAndPhysicalCheckResultNull() {
+  void isValid_returnsFalse_whenDocumentCheckSatisfactoryAndPhysicalCheckResultNull() {
+    validatorMocking();
     partTwo.setConsignmentCheck(ConsignmentCheck.builder()
         .documentCheckResult(SATISFACTORY)
         .build());
 
-    assertFalse(validator.isValid(partTwo, constraintValidatorContextMock));
+    assertThat(validator.isValid(partTwo, constraintValidatorContextMock)).isFalse();
   }
 
   @Test
-  public void isValid_returnsTrue_whenDocumentCheckSatisfactoryAndIdentityCheckNotNull() {
+  void isValid_returnsTrue_whenDocumentCheckSatisfactoryAndIdentityCheckNotNull() {
     partTwo.setConsignmentCheck(ConsignmentCheck.builder()
         .documentCheckResult(SATISFACTORY)
         .physicalCheckResult(NOT_SATISFACTORY)
         .build());
 
-    assertTrue(validator.isValid(partTwo, constraintValidatorContextMock));
+    assertThat(validator.isValid(partTwo, constraintValidatorContextMock)).isTrue();
   }
 
 
   @Test
-  public void isValid_returnsFalse_whenDocumentCheckNotSatisfactoryAndConsignmentAcceptableAndPhysicalCheckResultNull() {
+  void isValid_returnsFalse_whenDocumentCheckNotSatisfactoryAndConsignmentAcceptableAndPhysicalCheckResultNull() {
+    validatorMocking();
     partTwo.setConsignmentCheck(ConsignmentCheck.builder()
         .documentCheckResult(NOT_SATISFACTORY)
         .build());
     partTwo.setDecision(Decision.builder().consignmentAcceptable(true).build());
 
-    assertFalse(validator.isValid(partTwo, constraintValidatorContextMock));
+    assertThat(validator.isValid(partTwo, constraintValidatorContextMock)).isFalse();
   }
 
   @Test
-  public void isValid_returnsTrue_whenDocumentCheckNotSatisfactoryAndConsignmentAcceptableAndPhysicalCheckResultNotNull() {
+  void isValid_returnsTrue_whenDocumentCheckNotSatisfactoryAndConsignmentAcceptableAndPhysicalCheckResultNotNull() {
     partTwo.setConsignmentCheck(ConsignmentCheck.builder()
         .documentCheckResult(NOT_SATISFACTORY)
         .physicalCheckResult(NOT_SATISFACTORY)
         .build());
     partTwo.setDecision(Decision.builder().consignmentAcceptable(true).build());
 
-    assertTrue(validator.isValid(partTwo, constraintValidatorContextMock));
+    assertThat(validator.isValid(partTwo, constraintValidatorContextMock)).isTrue();
   }
 
 
   @Test
-  public void isValid_returnsTrue_whenDocumentCheckNotSatisfactoryAndDecisionNull() {
+  void isValid_returnsTrue_whenDocumentCheckNotSatisfactoryAndDecisionNull() {
     partTwo.setConsignmentCheck(ConsignmentCheck.builder()
         .documentCheckResult(NOT_SATISFACTORY)
         .build());
 
-    assertTrue(validator.isValid(partTwo, constraintValidatorContextMock));
+    assertThat(validator.isValid(partTwo, constraintValidatorContextMock)).isTrue();
   }
 
   @Test
-  public void isValid_returnsTrue_whenDocumentCheckNotSatisfactoryAndConsignmentAcceptableNull() {
+  void isValid_returnsTrue_whenDocumentCheckNotSatisfactoryAndConsignmentAcceptableNull() {
     partTwo.setConsignmentCheck(ConsignmentCheck.builder()
         .documentCheckResult(NOT_SATISFACTORY)
         .build());
     partTwo.setDecision(Decision.builder().build());
 
-    assertTrue(validator.isValid(partTwo, constraintValidatorContextMock));
+    assertThat(validator.isValid(partTwo, constraintValidatorContextMock)).isTrue();
   }
 
   @Test
-  public void isValid_returnsTrue_whenDocumentCheckNotSatisfactoryAndConsignmentAcceptableFalse() {
+  void isValid_returnsTrue_whenDocumentCheckNotSatisfactoryAndConsignmentAcceptableFalse() {
     partTwo.setConsignmentCheck(ConsignmentCheck.builder()
         .documentCheckResult(NOT_SATISFACTORY)
         .build());
     partTwo.setDecision(Decision.builder().consignmentAcceptable(false).build());
 
-    assertTrue(validator.isValid(partTwo, constraintValidatorContextMock));
+    assertThat(validator.isValid(partTwo, constraintValidatorContextMock)).isTrue();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedppContactDetailsEmailOrTelephoneRequiredValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedppContactDetailsEmailOrTelephoneRequiredValidatorTest.java
@@ -9,18 +9,17 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import jakarta.validation.ConstraintValidatorContext;
-import jakarta.validation.ConstraintValidatorContext.ConstraintViolationBuilder;
 import jakarta.validation.ConstraintValidatorContext.ConstraintViolationBuilder.NodeBuilderCustomizableContext;
 import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorContext;
 import org.hibernate.validator.constraintvalidation.HibernateConstraintViolationBuilder;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.defra.tracesx.notificationschema.representation.ContactDetails;
 
-@RunWith(MockitoJUnitRunner.class)
-public class ChedppContactDetailsEmailOrTelephoneRequiredValidatorTest {
+@ExtendWith(MockitoExtension.class)
+class ChedppContactDetailsEmailOrTelephoneRequiredValidatorTest {
 
   private final ChedppContactDetailsEmailOrTelephoneRequiredValidator testSubject = new ChedppContactDetailsEmailOrTelephoneRequiredValidator();
   @Mock
@@ -31,25 +30,25 @@ public class ChedppContactDetailsEmailOrTelephoneRequiredValidatorTest {
   private ConstraintValidatorContext context;
 
   @Test
-  public void initialize_InitialiseWithMessage() {
+  void initialize_InitialiseWithMessage() {
     testSubject.initialize(constraintAnnotation);
     verify(constraintAnnotation, times(1)).message();
   }
 
   @Test
-  public void isValid_WhenValidEmail_ThenReturnValid() {
+  void isValid_WhenValidEmail_ThenReturnValid() {
     when(contactDetails.getEmail()).thenReturn("contactus@mail.com");
     assertThat(testSubject.isValid(contactDetails, context)).isTrue();
   }
 
   @Test
-  public void isValid_WhenValidTelephone_ThenReturnValid() {
+  void isValid_WhenValidTelephone_ThenReturnValid() {
     when(contactDetails.getTelephone()).thenReturn("07407414474");
     assertThat(testSubject.isValid(contactDetails, context)).isTrue();
   }
 
   @Test
-  public void isValid_WhenNullDetails_ThenReturnInvalid() {
+  void isValid_WhenNullDetails_ThenReturnInvalid() {
     HibernateConstraintValidatorContext validatorContext = mock(
         HibernateConstraintValidatorContext.class);
     when(context.unwrap(HibernateConstraintValidatorContext.class)).thenReturn(validatorContext);

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedppEstimatedArrivalAtBcpValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedppEstimatedArrivalAtBcpValidatorTest.java
@@ -4,29 +4,29 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.defra.tracesx.notificationschema.representation.Notification;
 import uk.gov.defra.tracesx.notificationschema.representation.PartOne;
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.StatusEnum;
 
-@RunWith(MockitoJUnitRunner.class)
-public class ChedppEstimatedArrivalAtBcpValidatorTest {
+@ExtendWith(MockitoExtension.class)
+class ChedppEstimatedArrivalAtBcpValidatorTest {
 
-  private Notification notification = new Notification();
+  private final Notification notification = new Notification();
   private ChedppEstimatedArrivalAtBcpValidator validator;
 
-  @Before
-  public void setup() {
+  @BeforeEach
+  void setup() {
     notification.setPartOne(new PartOne());
     notification.setStatus(StatusEnum.VALIDATED);
     validator = new ChedppEstimatedArrivalAtBcpValidator();
   }
 
   @Test
-  public void givenNoPartOneWhenValidatorCalledThenValidatorReturnsFalse() {
+  void givenNoPartOneWhenValidatorCalledThenValidatorReturnsFalse() {
     notification.setPartOne(null);
     Boolean result = validator.isValid(notification, null);
 
@@ -35,7 +35,7 @@ public class ChedppEstimatedArrivalAtBcpValidatorTest {
 
 
   @Test
-  public void givenNotificationStatusInProgressWhenValidatorCalledThenValidatorReturnsTrue() {
+  void givenNotificationStatusInProgressWhenValidatorCalledThenValidatorReturnsTrue() {
     notification.getPartOne().setArrivalDate(LocalDate.now().minusDays(1));
     notification.getPartOne().setArrivalTime(LocalTime.now());
     notification.setStatus(StatusEnum.IN_PROGRESS);
@@ -46,7 +46,7 @@ public class ChedppEstimatedArrivalAtBcpValidatorTest {
   }
 
   @Test
-  public void givenNotificationStatusSubmittedWhenValidatorCalledThenValidatorReturnsTrue() {
+  void givenNotificationStatusSubmittedWhenValidatorCalledThenValidatorReturnsTrue() {
     notification.getPartOne().setArrivalDate(LocalDate.now().minusDays(1));
     notification.getPartOne().setArrivalTime(LocalTime.now());
     notification.setStatus(StatusEnum.SUBMITTED);
@@ -57,7 +57,7 @@ public class ChedppEstimatedArrivalAtBcpValidatorTest {
   }
 
   @Test
-  public void givenANullArrivalTimeWhenValidatorCalledThenValidatorReturnsTrue() {
+  void givenANullArrivalTimeWhenValidatorCalledThenValidatorReturnsTrue() {
     notification.getPartOne().setArrivalDate(LocalDate.now());
     notification.getPartOne().setArrivalTime(null);
 
@@ -67,7 +67,7 @@ public class ChedppEstimatedArrivalAtBcpValidatorTest {
   }
 
   @Test
-  public void givenANullArrivalTimeAndArrivalDateWhenValidatorCalledThenValidatorReturnsTrue() {
+  void givenANullArrivalTimeAndArrivalDateWhenValidatorCalledThenValidatorReturnsTrue() {
     notification.getPartOne().setArrivalDate(null);
     notification.getPartOne().setArrivalTime(null);
 
@@ -77,7 +77,7 @@ public class ChedppEstimatedArrivalAtBcpValidatorTest {
   }
 
   @Test
-  public void givenArrivalDateInTheFutureWhenValidatorCalledThenValidatorReturnsTrue() {
+  void givenArrivalDateInTheFutureWhenValidatorCalledThenValidatorReturnsTrue() {
     notification.getPartOne().setArrivalDate(LocalDate.now().plusDays(1));
     notification.getPartOne().setArrivalTime(LocalTime.now());
 
@@ -87,7 +87,7 @@ public class ChedppEstimatedArrivalAtBcpValidatorTest {
   }
 
   @Test
-  public void givenArrivalDateOfTodayAndArrivalTimeInTheFutureWhenValidatorCalledThenValidatorReturnsTrue() {
+  void givenArrivalDateOfTodayAndArrivalTimeInTheFutureWhenValidatorCalledThenValidatorReturnsTrue() {
     notification.getPartOne().setArrivalDate(LocalDate.now());
     notification.getPartOne().setArrivalTime(LocalTime.now().plusHours(1));
 
@@ -97,7 +97,7 @@ public class ChedppEstimatedArrivalAtBcpValidatorTest {
   }
 
   @Test
-  public void givenArrivalDateInThePastWhenValidatorCalledThenValidatorReturnsFalse() {
+  void givenArrivalDateInThePastWhenValidatorCalledThenValidatorReturnsFalse() {
     notification.getPartOne().setArrivalDate(LocalDate.now().minusDays(1));
     notification.getPartOne().setArrivalTime(LocalTime.now());
 
@@ -107,7 +107,7 @@ public class ChedppEstimatedArrivalAtBcpValidatorTest {
   }
 
   @Test
-  public void givenArrivalDateOfTodayAndArrivalTimeInThePastWhenValidatorCalledThenValidatorReturnsFalse() {
+  void givenArrivalDateOfTodayAndArrivalTimeInThePastWhenValidatorCalledThenValidatorReturnsFalse() {
     notification.getPartOne().setArrivalDate(LocalDate.now());
     notification.getPartOne().setArrivalTime(LocalTime.now().minusHours(1));
 

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedppGmsDeclarationValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedppGmsDeclarationValidatorTest.java
@@ -4,16 +4,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.defra.tracesx.notificationschema.representation.Commodities;
 import uk.gov.defra.tracesx.notificationschema.representation.ComplementParameterSet;
 import uk.gov.defra.tracesx.notificationschema.representation.ComplementParameterSetKeyDataPair;
 
-@RunWith(MockitoJUnitRunner.class)
-public class ChedppGmsDeclarationValidatorTest {
+@ExtendWith(MockitoExtension.class)
+class ChedppGmsDeclarationValidatorTest {
 
   private Commodities commodities;
   private ChedppGmsDeclarationValidator validator;
@@ -24,15 +24,15 @@ public class ChedppGmsDeclarationValidatorTest {
   private static final String JOINT = "JOINT";
   private static final String GMS = "GMS";
   private static final String SMS = "SMS";
-  
-  @Before
-  public void setup() {
+
+  @BeforeEach
+  void setup() {
     validator = new ChedppGmsDeclarationValidator();
     commodities = new Commodities();
   }
 
   @Test
-  public void validatorShouldReturnTrueIfCommoditiesIsNull() {
+  void validatorShouldReturnTrueIfCommoditiesIsNull() {
     // When
     boolean result = validator.isValid(null, null);
 
@@ -41,7 +41,7 @@ public class ChedppGmsDeclarationValidatorTest {
   }
 
   @Test
-  public void validatorShouldReturnTrueIfComplementParameterSetIsNull() {
+  void validatorShouldReturnTrueIfComplementParameterSetIsNull() {
     // Given
     Commodities commodities = new Commodities();
     commodities.setComplementParameterSet(null);
@@ -54,7 +54,7 @@ public class ChedppGmsDeclarationValidatorTest {
   }
 
   @Test
-  public void validatorShouldReturnFalseWhenHmiGmsCommodityIsPresentAndTheGmsDeclarationFlagIsNotSet() {
+  void validatorShouldReturnFalseWhenHmiGmsCommodityIsPresentAndTheGmsDeclarationFlagIsNotSet() {
     // Given
     List<ComplementParameterSet> complementParameterSetList = new ArrayList<>();
     complementParameterSetList.add(createComplementParameterSet(HMI, GMS));
@@ -68,7 +68,7 @@ public class ChedppGmsDeclarationValidatorTest {
   }
 
   @Test
-  public void validatorShouldReturnTrueWhenHmiGmsCommodityIsPresentAndTheGmsDeclarationFlagIsTrue() {
+  void validatorShouldReturnTrueWhenHmiGmsCommodityIsPresentAndTheGmsDeclarationFlagIsTrue() {
     // Given
     List<ComplementParameterSet> complementParameterSetList = new ArrayList<>();
     complementParameterSetList.add(createComplementParameterSet(HMI, GMS));
@@ -83,7 +83,7 @@ public class ChedppGmsDeclarationValidatorTest {
   }
 
   @Test
-  public void validatorShouldReturnTrueWhenHmiGmsAndNonHmiGmsCommodityIsPresentAndTheGmsDeclarationFlagIsTrue() {
+  void validatorShouldReturnTrueWhenHmiGmsAndNonHmiGmsCommodityIsPresentAndTheGmsDeclarationFlagIsTrue() {
     // Given
     List<ComplementParameterSet> complementParameterSetList = new ArrayList<>();
     complementParameterSetList.add(ComplementParameterSet.builder().build());
@@ -99,7 +99,7 @@ public class ChedppGmsDeclarationValidatorTest {
   }
 
   @Test
-  public void validatorShouldReturnFalseWhenHmiGmsCommodityIsPresentAndTheGmsDeclarationFlagIsFalse() {
+  void validatorShouldReturnFalseWhenHmiGmsCommodityIsPresentAndTheGmsDeclarationFlagIsFalse() {
     // Given
     List<ComplementParameterSet> complementParameterSetList = new ArrayList<>();
     complementParameterSetList.add(createComplementParameterSet(HMI, GMS));
@@ -114,7 +114,7 @@ public class ChedppGmsDeclarationValidatorTest {
   }
 
   @Test
-  public void validatorShouldReturnFalseWhenHmiGmsAndNonHmiGmsCommodityIsPresentAndTheGmsDeclarationFlagIsFalse() {
+  void validatorShouldReturnFalseWhenHmiGmsAndNonHmiGmsCommodityIsPresentAndTheGmsDeclarationFlagIsFalse() {
     // Given
     List<ComplementParameterSet> complementParameterSetList = new ArrayList<>();
     complementParameterSetList.add(ComplementParameterSet.builder().build());
@@ -130,7 +130,7 @@ public class ChedppGmsDeclarationValidatorTest {
   }
 
   @Test
-  public void validatorShouldReturnTrueWhenNoHmiGmsCommodityIsPresent() {
+  void validatorShouldReturnTrueWhenNoHmiGmsCommodityIsPresent() {
     // Given
     List<ComplementParameterSet> complementParameterSetList = new ArrayList<>();
     complementParameterSetList.add(createComplementParameterSet(HMI, SMS));
@@ -145,7 +145,7 @@ public class ChedppGmsDeclarationValidatorTest {
   }
 
   @Test
-  public void validatorShouldReturnTrueWhenAllKeyDataPairDataFieldsAreNull() {
+  void validatorShouldReturnTrueWhenAllKeyDataPairDataFieldsAreNull() {
     // Given
     List<ComplementParameterSet> complementParameterSetList = new ArrayList<>();
     complementParameterSetList.add(createComplementParameterSet(null, null));

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedppInvalidPodCheckValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedppInvalidPodCheckValidatorTest.java
@@ -2,24 +2,24 @@ package uk.gov.defra.tracesx.notificationschema.validation.annotations;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.defra.tracesx.notificationschema.representation.Commodities;
 import uk.gov.defra.tracesx.notificationschema.representation.EconomicOperator;
 import uk.gov.defra.tracesx.notificationschema.representation.PartOne;
 
-@RunWith(MockitoJUnitRunner.class)
-public class ChedppInvalidPodCheckValidatorTest {
+@ExtendWith(MockitoExtension.class)
+class ChedppInvalidPodCheckValidatorTest {
 
   private ChedppInvalidPodCheckValidator validator;
   private PartOne partOne;
   private Commodities commodities;
   private EconomicOperator pod;
 
-  @Before
-  public void setup() {
+  @BeforeEach
+  void setup() {
     validator = new ChedppInvalidPodCheckValidator();
     partOne = new PartOne();
     commodities = new Commodities();
@@ -27,7 +27,7 @@ public class ChedppInvalidPodCheckValidatorTest {
   }
 
   @Test
-  public void validatorShouldReturnTrueIfPartOneIsNull() {
+  void validatorShouldReturnTrueIfPartOneIsNull() {
     // When
     boolean result = validator.isValid(null, null);
 
@@ -36,7 +36,7 @@ public class ChedppInvalidPodCheckValidatorTest {
   }
 
   @Test
-  public void validatorShouldReturnTrueIfCommoditiesIsNull() {
+  void validatorShouldReturnTrueIfCommoditiesIsNull() {
     // Given
     partOne.setCommodities(null);
 
@@ -48,7 +48,7 @@ public class ChedppInvalidPodCheckValidatorTest {
   }
 
   @Test
-  public void validatorShouldReturnFalseIfPodIsSetForNonPodGroupCountry() {
+  void validatorShouldReturnFalseIfPodIsSetForNonPodGroupCountry() {
     // Given
     commodities.setCountryOfOriginIsPodCountry(Boolean.FALSE);
     partOne.setCommodities(commodities);
@@ -62,7 +62,7 @@ public class ChedppInvalidPodCheckValidatorTest {
   }
 
   @Test
-  public void validatorShouldReturnTrueIfPodIsSetForPodGroupCountry() {
+  void validatorShouldReturnTrueIfPodIsSetForPodGroupCountry() {
     // Given
     commodities.setCountryOfOriginIsPodCountry(Boolean.TRUE);
     partOne.setCommodities(commodities);
@@ -76,7 +76,7 @@ public class ChedppInvalidPodCheckValidatorTest {
   }
 
   @Test
-  public void validatorShouldReturnTrueIfPodIsNull() {
+  void validatorShouldReturnTrueIfPodIsNull() {
     // Given
     partOne.setPod(null);
     commodities.setCountryOfOriginIsPodCountry(Boolean.FALSE);
@@ -90,7 +90,7 @@ public class ChedppInvalidPodCheckValidatorTest {
   }
 
   @Test
-  public void validatorShouldReturnTrueIfPodCountryGroupIsNull() {
+  void validatorShouldReturnTrueIfPodCountryGroupIsNull() {
     // Given
     commodities.setCountryOfOriginIsPodCountry(null);
     partOne.setCommodities(commodities);

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedppIsPositiveDoubleKeyDataPairValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedppIsPositiveDoubleKeyDataPairValidatorTest.java
@@ -3,13 +3,13 @@ package uk.gov.defra.tracesx.notificationschema.validation.annotations;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
-public class ChedppIsPositiveDoubleKeyDataPairValidatorTest {
+@ExtendWith(MockitoExtension.class)
+class ChedppIsPositiveDoubleKeyDataPairValidatorTest {
 
   private static final String FIELD = "field";
   private final ChedppIsPositiveDoubleKeyDataPairValidator testSubject = new ChedppIsPositiveDoubleKeyDataPairValidator();
@@ -17,9 +17,9 @@ public class ChedppIsPositiveDoubleKeyDataPairValidatorTest {
   private ChedppIsPositiveDoubleKeyDataPair keyDataPair;
 
   @Test
-  public void initializeValidator_ReturnsNewInstance() {
+  void initializeValidator_ReturnsNewInstance() {
     when(keyDataPair.field()).thenReturn(FIELD);
-    assertThat(testSubject.initializeValidator(keyDataPair)).isEqualToComparingFieldByField(
-        new IsPositiveDoubleKeyDataPairValidation(FIELD));
+    assertThat(testSubject.initializeValidator(keyDataPair)).usingRecursiveComparison()
+        .isEqualTo(new IsPositiveDoubleKeyDataPairValidation(FIELD));
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedppMinValueKeyDataPairValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedppMinValueKeyDataPairValidatorTest.java
@@ -7,19 +7,19 @@ import static org.mockito.Mockito.when;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.defra.tracesx.notificationschema.representation.Commodities;
 import uk.gov.defra.tracesx.notificationschema.representation.CommodityComplement;
 import uk.gov.defra.tracesx.notificationschema.representation.ComplementParameterSet;
 import uk.gov.defra.tracesx.notificationschema.representation.ComplementParameterSet.ComplementParameterSetBuilder;
 import uk.gov.defra.tracesx.notificationschema.representation.ComplementParameterSetKeyDataPair;
 
-@RunWith(MockitoJUnitRunner.class)
-public class ChedppMinValueKeyDataPairValidatorTest {
+@ExtendWith(MockitoExtension.class)
+class ChedppMinValueKeyDataPairValidatorTest {
 
   private static final String FIELD_NAME = "data-field";
 
@@ -33,12 +33,11 @@ public class ChedppMinValueKeyDataPairValidatorTest {
   private final List<CommodityComplement> commodityComplements = new ArrayList<>();
   private final List<ComplementParameterSet> complementParameterSets = new ArrayList<>();
 
-  @Before
-  public void setup() {
+  @BeforeEach
+  void setup() {
     validator = new ChedppMinValueKeyDataPairValidator();
     when(mockKeyDataPair.field()).thenReturn(FIELD_NAME);
     when(commodities.getCommodityComplement()).thenReturn(commodityComplements);
-    when(commodities.getComplementParameterSet()).thenReturn(complementParameterSets);
     validator.initialize(mockKeyDataPair);
   }
 
@@ -70,23 +69,24 @@ public class ChedppMinValueKeyDataPairValidatorTest {
   }
 
   @Test
-  public void testValidWhenNoCommodityComplement() {
+  void testValidWhenNoCommodityComplement() {
     when(commodities.getCommodityComplement()).thenReturn(null);
     assertThat(validator.isValid(commodities, null)).isTrue();
   }
 
   @Test
-  public void testValidWhenNoComplementParameterSet() {
+  void testValidWhenNoComplementParameterSet() {
     assertThat(validator.isValid(commodities, null)).isTrue();
   }
 
   @Test
-  public void testValidWhenEmptyCommoditiesData() {
+  void testValidWhenEmptyCommoditiesData() {
     assertThat(validator.isValid(commodities, null)).isTrue();
   }
 
   @Test
-  public void testNotValidWhenNoMatchingComplementParameterSet() {
+  void testNotValidWhenNoMatchingComplementParameterSet() {
+    when(commodities.getComplementParameterSet()).thenReturn(complementParameterSets);
     CommodityComplement commodityComplement = createCommodityComplement(1, "1", null);
     ComplementParameterSet complementParameterSet = createComplementParameterSet(
         commodityComplement);
@@ -98,7 +98,8 @@ public class ChedppMinValueKeyDataPairValidatorTest {
   }
 
   @Test
-  public void testValidWhenOnlyInvalidWoodPackagingCommodity() {
+  void testValidWhenOnlyInvalidWoodPackagingCommodity() {
+    when(commodities.getComplementParameterSet()).thenReturn(complementParameterSets);
     CommodityComplement commodityComplement = createCommodityComplement(1, "1", true);
     ComplementParameterSet complementParameterSet = createComplementParameterSet(
         commodityComplement);
@@ -109,7 +110,7 @@ public class ChedppMinValueKeyDataPairValidatorTest {
   }
 
   @Test
-  public void testNotValidWhenNullKeyDataPairInComplementParameterSet() {
+  void testNotValidWhenNullKeyDataPairInComplementParameterSet() {
     CommodityComplement commodityComplement = createCommodityComplement(1, "1", null);
     ComplementParameterSet complementParameterSet = createComplementParameterSet(
         commodityComplement);
@@ -120,7 +121,7 @@ public class ChedppMinValueKeyDataPairValidatorTest {
   }
 
   @Test
-  public void testNullPointerExceptionNotThrownWhenSpeciesIdIsNull() {
+  void testNullPointerExceptionNotThrownWhenSpeciesIdIsNull() {
     CommodityComplement commodityComplement = createCommodityComplement(1, null, null);
     ComplementParameterSet complementParameterSet = createComplementParameterSet(
       commodityComplement,
@@ -133,7 +134,7 @@ public class ChedppMinValueKeyDataPairValidatorTest {
   }
 
   @Test
-  public void testNullPointerExceptionNotThrownWhenComplementIdIsNull() {
+  void testNullPointerExceptionNotThrownWhenComplementIdIsNull() {
     CommodityComplement commodityComplement = createCommodityComplement(null, "1", null);
     ComplementParameterSet complementParameterSet = createComplementParameterSet(
       commodityComplement,
@@ -146,7 +147,7 @@ public class ChedppMinValueKeyDataPairValidatorTest {
   }
 
   @Test
-  public void testValidWhenCommodityIsValidAndWoodPackagingIsInvalid() {
+  void testValidWhenCommodityIsValidAndWoodPackagingIsInvalid() {
     CommodityComplement commodityComplement = createCommodityComplement(1, "1", null);
     ComplementParameterSet complementParameterSet = createComplementParameterSet(
         commodityComplement,
@@ -165,7 +166,7 @@ public class ChedppMinValueKeyDataPairValidatorTest {
   }
 
   @Test
-  public void testValidWhenAllCommoditiesValid() {
+  void testValidWhenAllCommoditiesValid() {
     CommodityComplement commodityComplement = createCommodityComplement(1, "1", null);
     ComplementParameterSet complementParameterSet = createComplementParameterSet(
         commodityComplement,
@@ -194,7 +195,8 @@ public class ChedppMinValueKeyDataPairValidatorTest {
   }
 
   @Test
-  public void testNotValidWhenNotAllCommoditiesValid() {
+  void testNotValidWhenNotAllCommoditiesValid() {
+    when(commodities.getComplementParameterSet()).thenReturn(complementParameterSets);
     CommodityComplement commodityComplement = createCommodityComplement(1, "1", null);
     ComplementParameterSet complementParameterSet = createComplementParameterSet(
         commodityComplement,

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedppNotNullKeyDataPairValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedppNotNullKeyDataPairValidatorTest.java
@@ -1,25 +1,24 @@
 package uk.gov.defra.tracesx.notificationschema.validation.annotations;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.defra.tracesx.notificationschema.representation.Commodities;
 import uk.gov.defra.tracesx.notificationschema.representation.CommodityComplement;
 import uk.gov.defra.tracesx.notificationschema.representation.ComplementParameterSet;
 import uk.gov.defra.tracesx.notificationschema.representation.ComplementParameterSet.ComplementParameterSetBuilder;
 import uk.gov.defra.tracesx.notificationschema.representation.ComplementParameterSetKeyDataPair;
 
-@RunWith(MockitoJUnitRunner.class)
-public class ChedppNotNullKeyDataPairValidatorTest {
+@ExtendWith(MockitoExtension.class)
+class ChedppNotNullKeyDataPairValidatorTest {
 
   private static final String FIELD_NAME = "data-field";
 
@@ -30,15 +29,14 @@ public class ChedppNotNullKeyDataPairValidatorTest {
 
   @Mock
   private Commodities commodities;
-  private List<CommodityComplement> commodityComplements = new ArrayList<>();
-  private List<ComplementParameterSet> complementParameterSets = new ArrayList<>();
+  private final List<CommodityComplement> commodityComplements = new ArrayList<>();
+  private final List<ComplementParameterSet> complementParameterSets = new ArrayList<>();
 
-  @Before
-  public void setup() {
+  @BeforeEach
+  void setup() {
     validator = new ChedppNotNullKeyDataPairValidator();
     when(mockKeyDataPair.field()).thenReturn(FIELD_NAME);
     when(commodities.getCommodityComplement()).thenReturn(commodityComplements);
-    when(commodities.getComplementParameterSet()).thenReturn(complementParameterSets);
     validator.initialize(mockKeyDataPair);
   }
 
@@ -61,23 +59,24 @@ public class ChedppNotNullKeyDataPairValidatorTest {
   }
 
   @Test
-  public void testValidWhenNoCommodityComplement() {
+  void testValidWhenNoCommodityComplement() {
     when(commodities.getCommodityComplement()).thenReturn(null);
-    assertTrue(validator.isValid(commodities, null));
+    assertThat(validator.isValid(commodities, null)).isTrue();
   }
 
   @Test
-  public void testValidWhenNoComplementParameterSet() {
-    assertTrue(validator.isValid(commodities, null));
+  void testValidWhenNoComplementParameterSet() {
+    assertThat(validator.isValid(commodities, null)).isTrue();
   }
 
   @Test
-  public void testValidWhenEmptyCommoditiesData() {
-    assertTrue(validator.isValid(commodities, null));
+  void testValidWhenEmptyCommoditiesData() {
+    assertThat(validator.isValid(commodities, null)).isTrue();
   }
 
   @Test
-  public void testNotValidWhenNoMatchingComplementParameterSet() {
+  void testNotValidWhenNoMatchingComplementParameterSet() {
+    when(commodities.getComplementParameterSet()).thenReturn(complementParameterSets);
     CommodityComplement commodityComplement = createCommodityComplement(1, "1", null);
     ComplementParameterSet complementParameterSet = createComplementParameterSet(
         commodityComplement);
@@ -85,33 +84,34 @@ public class ChedppNotNullKeyDataPairValidatorTest {
     commodityComplements.add(commodityComplement);
     complementParameterSets.add(complementParameterSet);
 
-    assertFalse(validator.isValid(commodities, null));
+    assertThat(validator.isValid(commodities, null)).isFalse();
   }
 
   @Test
-  public void testValidWhenOnlyInvalidWoodPackagingCommodity() {
+  void testValidWhenOnlyInvalidWoodPackagingCommodity() {
     CommodityComplement commodityComplement = createCommodityComplement(1, "1", true);
     ComplementParameterSet complementParameterSet = createComplementParameterSet(
         commodityComplement);
     commodityComplements.add(commodityComplement);
     complementParameterSets.add(complementParameterSet);
 
-    assertTrue(validator.isValid(commodities, null));
+    assertThat(validator.isValid(commodities, null)).isTrue();
   }
 
   @Test
-  public void testNotValidWhenNullKeyDataPairInComplementParameterSet() {
+  void testNotValidWhenNullKeyDataPairInComplementParameterSet() {
+    when(commodities.getComplementParameterSet()).thenReturn(complementParameterSets);
     CommodityComplement commodityComplement = createCommodityComplement(1, "1", null);
     ComplementParameterSet complementParameterSet = createComplementParameterSet(
         commodityComplement);
     commodityComplements.add(commodityComplement);
     complementParameterSets.add(complementParameterSet);
 
-    assertFalse(validator.isValid(commodities, null));
+    assertThat(validator.isValid(commodities, null)).isFalse();
   }
 
   @Test
-  public void testValidWhenCommodityIsValidAndWoodPackagingIsInvalid() {
+  void testValidWhenCommodityIsValidAndWoodPackagingIsInvalid() {
     CommodityComplement commodityComplement = createCommodityComplement(1, "1", null);
     ComplementParameterSet complementParameterSet = createComplementParameterSet(
         commodityComplement,
@@ -126,11 +126,11 @@ public class ChedppNotNullKeyDataPairValidatorTest {
     commodityComplements.add(commodityComplement);
     complementParameterSets.add(complementParameterSet);
 
-    assertTrue(validator.isValid(commodities, null));
+    assertThat(validator.isValid(commodities, null)).isTrue();
   }
 
   @Test
-  public void testValidWhenAllCommoditiesValid() {
+  void testValidWhenAllCommoditiesValid() {
     CommodityComplement commodityComplement = createCommodityComplement(1, "1", null);
     ComplementParameterSet complementParameterSet = createComplementParameterSet(
         commodityComplement,
@@ -155,11 +155,13 @@ public class ChedppNotNullKeyDataPairValidatorTest {
     commodityComplements.add(commodityComplement);
     complementParameterSets.add(complementParameterSet);
 
-    assertTrue(validator.isValid(commodities, null));
+    assertThat(validator.isValid(commodities, null)).isTrue();
   }
 
   @Test
-  public void testNotValidWhenNotAllCommoditiesValid() {
+  void testNotValidWhenNotAllCommoditiesValid() {
+
+    when(commodities.getComplementParameterSet()).thenReturn(complementParameterSets);
     CommodityComplement commodityComplement = createCommodityComplement(1, "1", null);
     ComplementParameterSet complementParameterSet = createComplementParameterSet(
         commodityComplement,
@@ -184,6 +186,6 @@ public class ChedppNotNullKeyDataPairValidatorTest {
     commodityComplements.add(commodityComplement);
     complementParameterSets.add(complementParameterSet);
 
-    assertFalse(validator.isValid(commodities, null));
+    assertThat(validator.isValid(commodities, null)).isFalse();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedppPodRequiredValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedppPodRequiredValidatorTest.java
@@ -5,18 +5,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.defra.tracesx.notificationschema.representation.ComplementParameterSet.LOW_RISK_ARTICLE_72_COMMODITY;
 
 import java.util.List;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.defra.tracesx.notificationschema.representation.Commodities;
 import uk.gov.defra.tracesx.notificationschema.representation.ComplementParameterSet;
 import uk.gov.defra.tracesx.notificationschema.representation.ComplementParameterSetKeyDataPair;
 import uk.gov.defra.tracesx.notificationschema.representation.EconomicOperator;
 import uk.gov.defra.tracesx.notificationschema.representation.PartOne;
 
-@RunWith(MockitoJUnitRunner.class)
-public class ChedppPodRequiredValidatorTest {
+@ExtendWith(MockitoExtension.class)
+class ChedppPodRequiredValidatorTest {
 
   private ChedppPodRequiredValidator validator;
   private PartOne partOne;
@@ -24,15 +24,15 @@ public class ChedppPodRequiredValidatorTest {
 
   private static final String VIA_TEMPORARY_PLACE_OF_DESTINATION = "POD";
 
-  @Before
-  public void setup() {
+  @BeforeEach
+  void setup() {
     validator = new ChedppPodRequiredValidator();
     partOne = new PartOne();
     pod = new EconomicOperator();
   }
 
   @Test
-  public void validatorShouldReturnTrueIfPartOneIsNull() {
+  void validatorShouldReturnTrueIfPartOneIsNull() {
     // When
     boolean result = validator.isValid(null, null);
 
@@ -41,7 +41,7 @@ public class ChedppPodRequiredValidatorTest {
   }
 
   @Test
-  public void validatorShouldReturnTrueIfInspectionPremiseIsNull() {
+  void validatorShouldReturnTrueIfInspectionPremiseIsNull() {
     // Given
     partOne.setPointOfEntryControlPoint(null);
 
@@ -53,7 +53,7 @@ public class ChedppPodRequiredValidatorTest {
   }
 
   @Test
-  public void validatorShouldReturnFalseIfPodIsNullAndInspectionPremiseSetToPod() {
+  void validatorShouldReturnFalseIfPodIsNullAndInspectionPremiseSetToPod() {
     // Given
     partOne.setPointOfEntryControlPoint(VIA_TEMPORARY_PLACE_OF_DESTINATION);
     partOne.setPod(null);
@@ -66,7 +66,7 @@ public class ChedppPodRequiredValidatorTest {
   }
 
   @Test
-  public void validatorShouldReturnTrueIfPodIsSetAndInspectionPremiseSetToPod() {
+  void validatorShouldReturnTrueIfPodIsSetAndInspectionPremiseSetToPod() {
     // Given
     partOne.setPointOfEntryControlPoint(VIA_TEMPORARY_PLACE_OF_DESTINATION);
     partOne.setPod(pod);
@@ -79,7 +79,7 @@ public class ChedppPodRequiredValidatorTest {
   }
 
   @Test
-  public void validatorShouldReturnTrueIfPodIsSetAndInspectionPremiseIsNotSetToPod() {
+  void validatorShouldReturnTrueIfPodIsSetAndInspectionPremiseIsNotSetToPod() {
     // Given
     partOne.setPointOfEntryControlPoint("Some Random Place");
     partOne.setPod(pod);
@@ -92,7 +92,7 @@ public class ChedppPodRequiredValidatorTest {
   }
 
   @Test
-  public void isValid_ReturnsTrue_WhenConsignmentIsArticle72() {
+  void isValid_ReturnsTrue_WhenConsignmentIsArticle72() {
     partOne.setCommodities(Commodities.builder()
         .isLowRiskArticle72Country(true)
         .complementParameterSet(List.of(
@@ -111,7 +111,7 @@ public class ChedppPodRequiredValidatorTest {
   }
 
   @Test
-  public void isValid_ReturnsFalse_WhenConsignmentIsNotArticle72() {
+  void isValid_ReturnsFalse_WhenConsignmentIsNotArticle72() {
     partOne.setPointOfEntryControlPoint(VIA_TEMPORARY_PLACE_OF_DESTINATION);
     partOne.setCommodities(Commodities.builder()
         .isLowRiskArticle72Country(false)

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedppSealsAndContainersValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedppSealsAndContainersValidatorTest.java
@@ -2,44 +2,44 @@ package uk.gov.defra.tracesx.notificationschema.validation.annotations;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import uk.gov.defra.tracesx.notificationschema.representation.NotificationSealsContainers;
 
-public class ChedppSealsAndContainersValidatorTest {
+class ChedppSealsAndContainersValidatorTest {
 
   private ChedppSealsAndContainersValidator validator;
 
-  @Before
-  public void setup() {
+  @BeforeEach
+  void setup() {
     validator = new ChedppSealsAndContainersValidator();
   }
 
   @Test
-  public void isValid_ReturnsTrue_WhenNotificationSealHasContainerNumberAndSealNumber() {
+  void isValid_ReturnsTrue_WhenNotificationSealHasContainerNumberAndSealNumber() {
     NotificationSealsContainers containers = new NotificationSealsContainers("s1", "c1", false, "");
     assertThat(validator.isValid(containers, null)).isTrue();
   }
 
   @Test
-  public void isValid_ReturnsTrue_WhenNotificationSealHasContainerNumber() {
+  void isValid_ReturnsTrue_WhenNotificationSealHasContainerNumber() {
     NotificationSealsContainers containers = new NotificationSealsContainers(null, "c1", false, "");
     assertThat(validator.isValid(containers, null)).isTrue();
   }
 
   @Test
-  public void isValid_ReturnsTrue_WhenNotificationSealHasSealNumber() {
+  void isValid_ReturnsTrue_WhenNotificationSealHasSealNumber() {
     NotificationSealsContainers containers = new NotificationSealsContainers("s1", null, false, "");
     assertThat(validator.isValid(containers, null)).isTrue();
   }
 
   @Test
-  public void isValid_ReturnsTrue_WhenNotificationSealsContainersIsNull() {
+  void isValid_ReturnsTrue_WhenNotificationSealsContainersIsNull() {
     assertThat(validator.isValid(null, null)).isTrue();
   }
 
   @Test
-  public void isValid_ReturnsFalse_WhenNotificationDoesNotHaveAContainerNumberOrSealNumber() {
+  void isValid_ReturnsFalse_WhenNotificationDoesNotHaveAContainerNumberOrSealNumber() {
     NotificationSealsContainers containers = new NotificationSealsContainers(null, null, false, "");
     assertThat(validator.isValid(containers, null)).isFalse();
   }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ContactDetailsEmailOrTelephoneRequiredValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ContactDetailsEmailOrTelephoneRequiredValidatorTest.java
@@ -12,14 +12,14 @@ import jakarta.validation.ConstraintValidatorContext;
 import jakarta.validation.ConstraintValidatorContext.ConstraintViolationBuilder.NodeBuilderCustomizableContext;
 import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorContext;
 import org.hibernate.validator.constraintvalidation.HibernateConstraintViolationBuilder;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.defra.tracesx.notificationschema.representation.ContactDetails;
 
-@RunWith(MockitoJUnitRunner.class)
-public class ContactDetailsEmailOrTelephoneRequiredValidatorTest {
+@ExtendWith(MockitoExtension.class)
+class ContactDetailsEmailOrTelephoneRequiredValidatorTest {
 
   private final ContactDetailsEmailOrTelephoneRequiredValidator testSubject = new ContactDetailsEmailOrTelephoneRequiredValidator();
   @Mock
@@ -30,25 +30,25 @@ public class ContactDetailsEmailOrTelephoneRequiredValidatorTest {
   private ConstraintValidatorContext context;
 
   @Test
-  public void initialize_InitialiseWithMessage() {
+  void initialize_InitialiseWithMessage() {
     testSubject.initialize(constraintAnnotation);
     verify(constraintAnnotation, times(1)).message();
   }
 
   @Test
-  public void isValid_WhenValidEmail_ThenReturnValid() {
+  void isValid_WhenValidEmail_ThenReturnValid() {
     when(contactDetails.getEmail()).thenReturn("contactus@mail.com");
     assertThat(testSubject.isValid(contactDetails, context)).isTrue();
   }
 
   @Test
-  public void isValid_WhenValidTelephone_ThenReturnValid() {
+  void isValid_WhenValidTelephone_ThenReturnValid() {
     when(contactDetails.getTelephone()).thenReturn("07407414474");
     assertThat(testSubject.isValid(contactDetails, context)).isTrue();
   }
 
   @Test
-  public void isValid_WhenNullDetails_ThenReturnInvalid() {
+  void isValid_WhenNullDetails_ThenReturnInvalid() {
     HibernateConstraintValidatorContext validatorContext = mock(
         HibernateConstraintValidatorContext.class);
     when(context.unwrap(HibernateConstraintValidatorContext.class)).thenReturn(validatorContext);

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ControlledDestinationRequirementHelperTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ControlledDestinationRequirementHelperTest.java
@@ -1,7 +1,7 @@
 package uk.gov.defra.tracesx.notificationschema.validation.annotations;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.DecisionEnum.ACCEPTABLE_FOR_INTERNAL_MARKET;
 import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.DecisionEnum.ACCEPTABLE_FOR_SPECIFIC_WAREHOUSE;
 import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.DecisionEnum.ACCEPTABLE_FOR_TEMPORARY_IMPORT;
@@ -16,106 +16,108 @@ import static uk.gov.defra.tracesx.notificationschema.representation.enumeration
 import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.NotificationTypeEnum.CVEDA;
 import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.NotificationTypeEnum.CVEDP;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.theories.DataPoints;
-import org.junit.experimental.theories.FromDataPoints;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import uk.gov.defra.tracesx.notificationschema.representation.Decision;
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.NotAcceptableActionEnum;
 
-@RunWith(Theories.class)
-public class ControlledDestinationRequirementHelperTest {
+class ControlledDestinationRequirementHelperTest {
 
   private Decision decision;
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     decision = Decision.builder().build();
   }
 
   @Test
-  public void isControlledDestinationRequiredForCveda_nonAcceptableOtherAction_isTrue() {
+  void isControlledDestinationRequiredForCveda_nonAcceptableOtherAction_isTrue() {
     decision.setDecision(NON_ACCEPTABLE);
     decision.setNotAcceptableAction(OTHER);
 
     boolean result = ControlledDestinationRequirementHelper
         .isControlledDestinationRequired(decision, CVEDA);
 
-    assertTrue(result);
+    assertThat(result).isTrue();
   }
 
   @Test
-  public void isControlledDestinationRequiredForCveda_nonAcceptableReExportAction_isFalse() {
+  void isControlledDestinationRequiredForCveda_nonAcceptableReExportAction_isFalse() {
     decision.setDecision(NON_ACCEPTABLE);
     decision.setNotAcceptableAction(REEXPORT);
 
     boolean result = ControlledDestinationRequirementHelper
         .isControlledDestinationRequired(decision, CVEDA);
 
-    assertFalse(result);
+    assertThat(result).isFalse();
   }
 
-  @DataPoints("Decisions for CED CVEDP that require controlled destinations")
-  public static final Decision[] decisionThatRequireControlledDestinations = new Decision[]{
-      Decision.builder().decision(ACCEPTABLE_IF_CHANNELED).build(),
-      Decision.builder().decision(ACCEPTABLE_FOR_SPECIFIC_WAREHOUSE).build(),
-      Decision.builder().decision(NON_ACCEPTABLE).notAcceptableAction(DESTRUCTION).build(),
-      Decision.builder().decision(NON_ACCEPTABLE).notAcceptableAction(OTHER).build(),
-      Decision.builder().decision(NON_ACCEPTABLE)
-          .notAcceptableAction(NotAcceptableActionEnum.SLAUGHTER).build()
-  };
+  private static Stream<Arguments> decisionsThatRequireControlledDestinations() {
+    return Stream.of(
+        arguments(Decision.builder().decision(ACCEPTABLE_IF_CHANNELED).build()),
+        arguments(Decision.builder().decision(ACCEPTABLE_FOR_SPECIFIC_WAREHOUSE).build()),
+        arguments(
+            Decision.builder().decision(NON_ACCEPTABLE).notAcceptableAction(DESTRUCTION).build()),
+        arguments(Decision.builder().decision(NON_ACCEPTABLE).notAcceptableAction(OTHER).build()),
+        arguments(Decision.builder().decision(NON_ACCEPTABLE)
+            .notAcceptableAction(NotAcceptableActionEnum.SLAUGHTER).build())
+    );
+  }
 
-  @Theory
-  public void isControlledDestinationRequiredForCedCvedp_decisionsRequiringControlledDestination_isTrue(
-      @FromDataPoints("Decisions for CED CVEDP that require controlled destinations")
-          Decision decision) {
+  @ParameterizedTest
+  @MethodSource("decisionsThatRequireControlledDestinations")
+  void isControlledDestinationRequiredForCedCvedp_decisionsRequiringControlledDestination_isTrue(
+      Decision decision) {
     boolean result = ControlledDestinationRequirementHelper
         .isControlledDestinationRequired(decision, CVEDP);
 
-    assertTrue(result);
+    assertThat(result).isTrue();
   }
 
-  @DataPoints("Decisions for CED CVEDP that not require controlled destinations")
-  public static final Decision[] decisionsThatNotRequireControlledDestination = new Decision[]{
-      Decision.builder().decision(NON_ACCEPTABLE).notAcceptableAction(REEXPORT).build(),
-      Decision.builder().decision(NON_ACCEPTABLE).build(),
-      Decision.builder().decision(ACCEPTABLE_FOR_TEMPORARY_IMPORT).build(),
-      Decision.builder().decision(ACCEPTABLE_FOR_TRANSHIPMENT).build(),
-      Decision.builder().decision(ACCEPTABLE_FOR_INTERNAL_MARKET).build(),
-  };
+  private static Stream<Arguments> decisionsThatNotRequireControlledDestinations() {
+    return Stream.of(
+        arguments(
+            Decision.builder().decision(NON_ACCEPTABLE).notAcceptableAction(REEXPORT).build()),
+        arguments(Decision.builder().decision(NON_ACCEPTABLE).build()),
+        arguments(Decision.builder().decision(ACCEPTABLE_FOR_TEMPORARY_IMPORT).build()),
+        arguments(Decision.builder().decision(ACCEPTABLE_FOR_TRANSHIPMENT).build()),
+        arguments(Decision.builder().decision(ACCEPTABLE_FOR_INTERNAL_MARKET).build())
+    );
+  }
 
-  @Theory
-  public void isControlledDestinationRequiredForCedCvedp_decisionsNotRequiringControlledDestination_isFalse(
-      @FromDataPoints("Decisions for CED CVEDP that not require controlled destinations")
-          Decision decision) {
+  @ParameterizedTest
+  @MethodSource("decisionsThatNotRequireControlledDestinations")
+  void isControlledDestinationRequiredForCedCvedp_decisionsNotRequiringControlledDestination_isFalse(
+      Decision decision) {
     boolean result = ControlledDestinationRequirementHelper
         .isControlledDestinationRequired(decision, CVEDP);
 
-    assertFalse(result);
+    assertThat(result).isFalse();
   }
 
   @Test
-  public void isControlledDestinationRequiredForCveda_internalMarketWithDefinitiveImportPurpose_isTrue() {
+  void isControlledDestinationRequiredForCveda_internalMarketWithDefinitiveImportPurpose_isTrue() {
     decision.setDecision(ACCEPTABLE_FOR_INTERNAL_MARKET);
     decision.setDefinitiveImportPurpose(APPROVEDBODIES);
 
     boolean result = ControlledDestinationRequirementHelper
         .isControlledDestinationRequired(decision, CVEDA);
 
-    assertTrue(result);
+    assertThat(result).isTrue();
   }
 
   @Test
-  public void isControlledDestinationRequiredForCedCvedp_decisionNonAcceptableNotAcceptableReDispatching_isFalse() {
+  void isControlledDestinationRequiredForCedCvedp_decisionNonAcceptableNotAcceptableReDispatching_isFalse() {
     decision.setDecision(NON_ACCEPTABLE);
     decision.setNotAcceptableAction(REDISPATCHING);
 
     boolean result = ControlledDestinationRequirementHelper
         .isControlledDestinationRequired(decision, CVEDP);
 
-    assertFalse(result);
+    assertThat(result).isFalse();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/CvedaControlledDestinationValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/CvedaControlledDestinationValidatorTest.java
@@ -1,165 +1,138 @@
 package uk.gov.defra.tracesx.notificationschema.validation.annotations;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.DecisionEnum.ACCEPTABLE_FOR_INTERNAL_MARKET;
-import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.DecisionEnum.ACCEPTABLE_FOR_SPECIFIC_WAREHOUSE;
-import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.DecisionEnum.ACCEPTABLE_IF_CHANNELED;
 import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.DecisionEnum.NON_ACCEPTABLE;
 import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.DefinitiveImportPurposeEnum.APPROVEDBODIES;
-import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.NotAcceptableActionEnum.DESTRUCTION;
-import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.NotAcceptableActionEnum.EUTHANASIA;
 import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.NotAcceptableActionEnum.REEXPORT;
-import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.NotAcceptableActionEnum.SLAUGHTER;
-import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.NotAcceptableActionEnum.TRANSFORMATION;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.theories.DataPoints;
-import org.junit.experimental.theories.FromDataPoints;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import uk.gov.defra.tracesx.notificationschema.representation.Decision;
 import uk.gov.defra.tracesx.notificationschema.representation.EconomicOperator;
 import uk.gov.defra.tracesx.notificationschema.representation.PartTwo;
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.DecisionEnum;
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.NotAcceptableActionEnum;
 
-@RunWith(Theories.class)
-public class CvedaControlledDestinationValidatorTest {
+class CvedaControlledDestinationValidatorTest {
 
   private CvedaControlledDestinationValidator validator;
   private PartTwo partTwo;
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     this.validator = new CvedaControlledDestinationValidator();
     this.partTwo = PartTwo.builder().decision(Decision.builder().build()).build();
   }
 
   @Test
-  public void isValid_emptyPartTwo_isTrue() {
-    assertTrue(validator.isValid(null, null));
+  void isValid_emptyPartTwo_isTrue() {
+    assertThat(validator.isValid(null, null)).isTrue();
   }
 
   @Test
-  public void isValid_partTwoWithEmptyDecision_isTrue() {
-    assertTrue(validator.isValid(PartTwo.builder().build(), null));
+  void isValid_partTwoWithEmptyDecision_isTrue() {
+    assertThat(validator.isValid(PartTwo.builder().build(), null)).isTrue();
   }
 
-  @DataPoints("Decisions for ControlledDestinations without subOption")
-  public static final DecisionEnum[] decisionsWithoutSubOption = new DecisionEnum[]{
-      ACCEPTABLE_FOR_SPECIFIC_WAREHOUSE,
-      ACCEPTABLE_IF_CHANNELED
-  };
-
-  @DataPoints("Decisions for ControlledDestinations with subOptions")
-  public static final DecisionEnum[] decisionsWithSubOption = new DecisionEnum[]{
-      NON_ACCEPTABLE,
-      ACCEPTABLE_FOR_INTERNAL_MARKET,
-  };
-
-  @DataPoints("requiring Controlled Destinations")
-  public static final NotAcceptableActionEnum[] notAcceptableActionEnumsRequiringControlledDestinations =
-      new NotAcceptableActionEnum[]{
-          SLAUGHTER,
-          EUTHANASIA,
-          TRANSFORMATION,
-          DESTRUCTION
-      };
-
-  @Theory
-  public void isValid_decisionsRequiringControlledDestinationsWithoutControlledDestinations_isFalse(
-      @FromDataPoints("Decisions for ControlledDestinations without subOption") DecisionEnum decisionValue) {
+  @ParameterizedTest
+  @EnumSource(value = DecisionEnum.class, names = {"ACCEPTABLE_FOR_SPECIFIC_WAREHOUSE", "ACCEPTABLE_IF_CHANNELED"})
+  void isValid_decisionsRequiringControlledDestinationsWithoutControlledDestinations_isFalse(
+      DecisionEnum decisionValue) {
     partTwo.getDecision().setDecision(decisionValue);
 
     boolean result = validator.isValid(partTwo, null);
 
-    assertFalse(result);
+    assertThat(result).isFalse();
   }
 
-  @Theory
-  public void isValid_decisionsWithoutSubOptionRequirementAndWithControlledDestination_isTrue(
-      @FromDataPoints("Decisions for ControlledDestinations without subOption") DecisionEnum decisionValue) {
+  @ParameterizedTest
+  @EnumSource(value = DecisionEnum.class, names = {"ACCEPTABLE_FOR_SPECIFIC_WAREHOUSE", "ACCEPTABLE_IF_CHANNELED"})
+  void isValid_decisionsWithoutSubOptionRequirementAndWithControlledDestination_isTrue(
+      DecisionEnum decisionValue) {
     partTwo.getDecision().setDecision(decisionValue);
     partTwo.setControlledDestination(EconomicOperator.builder().build());
 
     boolean result = validator.isValid(partTwo, null);
 
-    assertTrue(result);
+    assertThat(result).isTrue();
   }
 
-  @Theory
-  public void isValid_decisionsRequiringSubOptionsWithoutSubOptionsAndControlledDestinations_isTrue(
-      @FromDataPoints("Decisions for ControlledDestinations with subOptions") DecisionEnum decisionValue) {
+  @ParameterizedTest
+  @EnumSource(value = DecisionEnum.class, names = {"NON_ACCEPTABLE", "ACCEPTABLE_FOR_INTERNAL_MARKET"})
+  void isValid_decisionsRequiringSubOptionsWithoutSubOptionsAndControlledDestinations_isTrue(
+      DecisionEnum decisionValue) {
     partTwo.getDecision().setDecision(decisionValue);
 
     boolean result = validator.isValid(partTwo, null);
 
-    assertTrue(result);
+    assertThat(result).isTrue();
   }
 
-  @Theory
-  public void isValid_nonAcceptedWithNonAcceptableActionsExceptReExportWithoutControlledDestination_isFalse(
-      @FromDataPoints("requiring Controlled Destinations") NotAcceptableActionEnum notAcceptableAction) {
+  @ParameterizedTest
+  @EnumSource(value = NotAcceptableActionEnum.class, names = {"SLAUGHTER", "EUTHANASIA", "TRANSFORMATION", "DESTRUCTION"})
+  void isValid_nonAcceptedWithNonAcceptableActionsExceptReExportWithoutControlledDestination_isFalse(
+      NotAcceptableActionEnum notAcceptableAction) {
     partTwo.getDecision().setDecision(NON_ACCEPTABLE);
     partTwo.getDecision().setNotAcceptableAction(notAcceptableAction);
 
     boolean result = validator.isValid(partTwo, null);
 
-    assertFalse(result);
+    assertThat(result).isFalse();
   }
 
-  @Theory
-  public void isValid_nonAcceptedWithExceptReExportWithControlledDestination_isTrue(
-      @FromDataPoints("requiring Controlled Destinations") NotAcceptableActionEnum notAcceptableAction) {
+  @ParameterizedTest
+  @EnumSource(value = NotAcceptableActionEnum.class, names = {"SLAUGHTER", "EUTHANASIA", "TRANSFORMATION", "DESTRUCTION"})
+  void isValid_nonAcceptedWithExceptReExportWithControlledDestination_isTrue(
+      NotAcceptableActionEnum notAcceptableAction) {
     partTwo.getDecision().setDecision(NON_ACCEPTABLE);
     partTwo.getDecision().setNotAcceptableAction(notAcceptableAction);
     partTwo.setControlledDestination(EconomicOperator.builder().build());
 
     boolean result = validator.isValid(partTwo, null);
 
-    assertTrue(result);
+    assertThat(result).isTrue();
   }
 
   @Test
-  public void isValid_nonAcceptedWithReExportAndWithoutControlledDestination_isTrue() {
+  void isValid_nonAcceptedWithReExportAndWithoutControlledDestination_isTrue() {
     partTwo.getDecision().setDecision(NON_ACCEPTABLE);
     partTwo.getDecision().setNotAcceptableAction(REEXPORT);
 
     boolean result = validator.isValid(partTwo, null);
 
-    assertTrue(result);
+    assertThat(result).isTrue();
   }
 
   @Test
-  public void isValid_internalMarketWithoutDefinitiveImportPurposeAndWithoutControlledDestination_isTrue() {
+  void isValid_internalMarketWithoutDefinitiveImportPurposeAndWithoutControlledDestination_isTrue() {
     partTwo.getDecision().setDecision(ACCEPTABLE_FOR_INTERNAL_MARKET);
 
     boolean result = validator.isValid(partTwo, null);
 
-    assertTrue(result);
+    assertThat(result).isTrue();
   }
 
   @Test
-  public void isValid_internalMarketWithDefinitiveImportPurposeAndWithoutControlledDestination_isFalse() {
+  void isValid_internalMarketWithDefinitiveImportPurposeAndWithoutControlledDestination_isFalse() {
     partTwo.getDecision().setDecision(ACCEPTABLE_FOR_INTERNAL_MARKET);
     partTwo.getDecision().setDefinitiveImportPurpose(APPROVEDBODIES);
 
     boolean result = validator.isValid(partTwo, null);
 
-    assertFalse(result);
+    assertThat(result).isFalse();
   }
 
   @Test
-  public void isValid_internalMarketWithDefinitiveImportPurposeAndWithControlledDestination_isTrue() {
+  void isValid_internalMarketWithDefinitiveImportPurposeAndWithControlledDestination_isTrue() {
     partTwo.getDecision().setDecision(ACCEPTABLE_FOR_INTERNAL_MARKET);
     partTwo.getDecision().setDefinitiveImportPurpose(APPROVEDBODIES);
     partTwo.setControlledDestination(EconomicOperator.builder().build());
 
     boolean result = validator.isValid(partTwo, null);
 
-    assertTrue(result);
+    assertThat(result).isTrue();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/DocumentCheckResultValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/DocumentCheckResultValidatorTest.java
@@ -1,66 +1,64 @@
 package uk.gov.defra.tracesx.notificationschema.validation.annotations;
-
-import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.assertFalse;
+import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.Result.NOT_SATISFACTORY;
 import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.Result.NOT_SET;
 import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.Result.SATISFACTORY;
 import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.Result.SATISFACTORY_FOLLOWING_OFFICIAL_INTERVENTION;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import uk.gov.defra.tracesx.notificationschema.representation.ConsignmentCheck;
 
-public class DocumentCheckResultValidatorTest {
+class DocumentCheckResultValidatorTest {
 
   private DocumentCheckResultValidator validator;
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     validator = new DocumentCheckResultValidator();
   }
 
   @Test
-  public void isValid_returnsTrue_whenConsignmentCheckIsNull() {
-    assertTrue(validator.isValid(null, null));
+  void isValid_returnsTrue_whenConsignmentCheckIsNull() {
+    assertThat(validator.isValid(null, null)).isTrue();
   }
 
   @Test
-  public void isValid_returnsTrue_whenDocumentCheckIsNull() {
+  void isValid_returnsTrue_whenDocumentCheckIsNull() {
     ConsignmentCheck check = new ConsignmentCheck();
 
-    assertTrue(validator.isValid(check, null));
+    assertThat(validator.isValid(check, null)).isTrue();
   }
 
   @Test
-  public void isValid_returnsFalse_whenDocumentCheckResultIsNotSet() {
+  void isValid_returnsFalse_whenDocumentCheckResultIsNotSet() {
     ConsignmentCheck check = new ConsignmentCheck();
     check.setDocumentCheckResult(NOT_SET);
 
-    assertFalse(validator.isValid(check, null));
+    assertThat(validator.isValid(check, null)).isFalse();
   }
 
   @Test
-  public void isValid_returnsFalse_whenDocumentCheckResultIsSatisfactoryFollowingOfficialIntervention() {
+  void isValid_returnsFalse_whenDocumentCheckResultIsSatisfactoryFollowingOfficialIntervention() {
     ConsignmentCheck check = new ConsignmentCheck();
     check.setDocumentCheckResult(SATISFACTORY_FOLLOWING_OFFICIAL_INTERVENTION);
 
-    assertFalse(validator.isValid(check, null));
+    assertThat(validator.isValid(check, null)).isFalse();
   }
 
   @Test
-  public void isValid_returnsTrue_whenDocumentCheckResultIsSatisfactory() {
+  void isValid_returnsTrue_whenDocumentCheckResultIsSatisfactory() {
     ConsignmentCheck check = new ConsignmentCheck();
     check.setDocumentCheckResult(SATISFACTORY);
 
-    assertTrue(validator.isValid(check, null));
+    assertThat(validator.isValid(check, null)).isTrue();
   }
 
   @Test
-  public void isValid_returnsTrue_whenDocumentCheckResultIsNotSatisfactory() {
+  void isValid_returnsTrue_whenDocumentCheckResultIsNotSatisfactory() {
     ConsignmentCheck check = new ConsignmentCheck();
     check.setDocumentCheckResult(NOT_SATISFACTORY);
 
-    assertTrue(validator.isValid(check, null));
+    assertThat(validator.isValid(check, null)).isTrue();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/EuStandardValidatorImplTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/EuStandardValidatorImplTest.java
@@ -1,92 +1,90 @@
 package uk.gov.defra.tracesx.notificationschema.validation.annotations;
 
-import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.assertFalse;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import uk.gov.defra.tracesx.notificationschema.representation.ConsignmentCheck;
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.Result;
 
-public class EuStandardValidatorImplTest {
+class EuStandardValidatorImplTest {
 
   private EuStandardValidatorImpl validator;
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     validator = new EuStandardValidatorImpl();
   }
 
   @Test
-  public void givenEuStandardIsSatisfactory_whenICallIsValid_thenResultIsTrue() {
+  void givenEuStandardIsSatisfactory_whenICallIsValid_thenResultIsTrue() {
     ConsignmentCheck consignmentCheck = new ConsignmentCheck();
     consignmentCheck.setDocumentCheckResult(Result.NOT_SET);
     consignmentCheck.setEuStandard(Result.SATISFACTORY);
 
-    assertTrue(validator.isValid(consignmentCheck, null));
+    assertThat(validator.isValid(consignmentCheck, null)).isTrue();
   }
 
   @Test
-  public void givenEuStandardIsNotSetAndNationalRequirementsSatisfactory_whenICallIsValid_thenResultIsTrue() {
+  void givenEuStandardIsNotSetAndNationalRequirementsSatisfactory_whenICallIsValid_thenResultIsTrue() {
     ConsignmentCheck consignmentCheck = new ConsignmentCheck();
     consignmentCheck.setDocumentCheckResult(Result.NOT_SET);
     consignmentCheck.setEuStandard(Result.NOT_SET);
     consignmentCheck.setNationalRequirements(Result.SATISFACTORY);
 
-    assertFalse(validator.isValid(consignmentCheck, null));
+    assertThat(validator.isValid(consignmentCheck, null)).isFalse();
   }
 
   @Test
-  public void givenEuStandardIsNotSet_whenICallIsValid_thenResultIsFalse() {
+  void givenEuStandardIsNotSet_whenICallIsValid_thenResultIsFalse() {
     ConsignmentCheck consignmentCheck = new ConsignmentCheck();
     consignmentCheck.setEuStandard(Result.NOT_SET);
     consignmentCheck.setDocumentCheckResult(Result.NOT_SET);
     consignmentCheck.setNationalRequirements(Result.SATISFACTORY);
 
-    assertFalse(validator.isValid(consignmentCheck, null));
+    assertThat(validator.isValid(consignmentCheck, null)).isFalse();
   }
 
   @Test
-  public void newNotification_withNotSetChecks_thenResultIsTrue() {
+  void newNotification_withNotSetChecks_thenResultIsTrue() {
     ConsignmentCheck consignmentCheck = new ConsignmentCheck();
     consignmentCheck.setEuStandard(Result.NOT_SET);
     consignmentCheck.setDocumentCheckResult(Result.NOT_SET);
     consignmentCheck.setNationalRequirements(Result.NOT_SET);
 
-    assertTrue(validator.isValid(consignmentCheck, null));
+    assertThat(validator.isValid(consignmentCheck, null)).isTrue();
   }
 
   @Test
-  public void newNotification_thenResultIsTrue() {
+  void newNotification_thenResultIsTrue() {
     ConsignmentCheck consignmentCheck = new ConsignmentCheck();
     consignmentCheck.setDocumentCheckResult(Result.NOT_SET);
 
-    assertTrue(validator.isValid(consignmentCheck, null));
+    assertThat(validator.isValid(consignmentCheck, null)).isTrue();
   }
 
   @Test
-  public void validate_documentCheckNotSetEuStandardAndNationalRequirementChecksSet_thenResultIsTrue() {
+  void validate_documentCheckNotSetEuStandardAndNationalRequirementChecksSet_thenResultIsTrue() {
     ConsignmentCheck consignmentCheck = new ConsignmentCheck();
     consignmentCheck.setEuStandard(Result.NOT_SET);
     consignmentCheck.setDocumentCheckResult(Result.NOT_SET);
     consignmentCheck.setNationalRequirements(Result.NOT_SET);
 
-    assertTrue(validator.isValid(consignmentCheck, null));
+    assertThat(validator.isValid(consignmentCheck, null)).isTrue();
   }
 
   @Test
-  public void validate_documentCheckIstSetEuStandardAndNationalRequirementChecksNotSet_thenResultIsTrue() {
+  void validate_documentCheckIstSetEuStandardAndNationalRequirementChecksNotSet_thenResultIsTrue() {
     ConsignmentCheck consignmentCheck = new ConsignmentCheck();
     consignmentCheck.setEuStandard(Result.NOT_SET);
     consignmentCheck.setDocumentCheckResult(Result.SATISFACTORY);
     consignmentCheck.setNationalRequirements(Result.NOT_SET);
 
-    assertTrue(validator.isValid(consignmentCheck, null));
+    assertThat(validator.isValid(consignmentCheck, null)).isTrue();
   }
 
   @Test
-  public void isValid_returnsTrue_whenConsignmentCheckIsNull() {
-    Assert.assertTrue(validator.isValid(null, null));
+  void isValid_returnsTrue_whenConsignmentCheckIsNull() {
+    assertThat(validator.isValid(null, null)).isTrue();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/FreeCirculationPurposeValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/FreeCirculationPurposeValidatorTest.java
@@ -1,88 +1,62 @@
 package uk.gov.defra.tracesx.notificationschema.validation.annotations;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.DecisionEnum.ACCEPTABLE_FOR_INTERNAL_MARKET;
-import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.DecisionEnum.ACCEPTABLE_FOR_TRANSHIPMENT;
-import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.DecisionEnum.NON_ACCEPTABLE;
-import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.FreeCirculationPurposeEnum.ANIMAL_FEEDING_STUFF;
-import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.FreeCirculationPurposeEnum.FURTHER_PROCESS;
-import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.FreeCirculationPurposeEnum.HUMAN_CONSUMPTION;
-import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.FreeCirculationPurposeEnum.OTHER;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.theories.DataPoints;
-import org.junit.experimental.theories.FromDataPoints;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import uk.gov.defra.tracesx.notificationschema.representation.Decision;
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.DecisionEnum;
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.FreeCirculationPurposeEnum;
 
-@RunWith(Theories.class)
-public class FreeCirculationPurposeValidatorTest {
+class FreeCirculationPurposeValidatorTest {
 
   private FreeCirculationPurposeValidator validator;
 
-  @DataPoints("Other decisions")
-  public static final DecisionEnum[] decisions =
-      new DecisionEnum[]{
-          NON_ACCEPTABLE,
-          ACCEPTABLE_FOR_TRANSHIPMENT
-      };
-
-  @DataPoints("Free circulation purposes")
-  public static final FreeCirculationPurposeEnum[] purpose =
-      new FreeCirculationPurposeEnum[]{
-          ANIMAL_FEEDING_STUFF,
-          HUMAN_CONSUMPTION,
-          FURTHER_PROCESS,
-          OTHER
-      };
-
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     validator = new FreeCirculationPurposeValidator();
   }
 
   @Test
-  public void isValid_acceptableForInternalMarketWithoutDecision_isTrue() {
+  void isValid_acceptableForInternalMarketWithoutDecision_isTrue() {
     Decision decision = new Decision();
 
     boolean result = validator.isValid(decision, null);
 
-    assertTrue(result);
+    assertThat(result).isTrue();
   }
 
   @Test
-  public void isValid_acceptableForInternalMarketWithoutFreeCirculationPurpose_isFalse() {
+  void isValid_acceptableForInternalMarketWithoutFreeCirculationPurpose_isFalse() {
     Decision decision = Decision.builder().decision(ACCEPTABLE_FOR_INTERNAL_MARKET).build();
 
     boolean result = validator.isValid(decision, null);
 
-    assertFalse(result);
+    assertThat(result).isFalse();
   }
 
-  @Theory
-  public void isValid_acceptableForInternalMarketWithFreeCirculationPurpose_isTrue(
-    @FromDataPoints("Free circulation purposes") FreeCirculationPurposeEnum purposeValue) {
+  @ParameterizedTest
+  @EnumSource(value = FreeCirculationPurposeEnum.class, names = {"ANIMAL_FEEDING_STUFF", "HUMAN_CONSUMPTION", "FURTHER_PROCESS", "OTHER"})
+  void isValid_acceptableForInternalMarketWithFreeCirculationPurpose_isTrue(
+    FreeCirculationPurposeEnum purposeValue) {
     Decision decision = Decision.builder().decision(ACCEPTABLE_FOR_INTERNAL_MARKET)
         .freeCirculationPurpose(purposeValue).build();
 
     boolean result = validator.isValid(decision, null);
 
-    assertTrue(result);
+    assertThat(result).isTrue();
   }
 
-  @Theory
-  public void isValid_otherDecisions_isTrue(
-      @FromDataPoints("Other decisions") DecisionEnum decisionValue) {
+  @ParameterizedTest
+  @EnumSource(value = DecisionEnum.class, names = {"NON_ACCEPTABLE", "ACCEPTABLE_FOR_TRANSHIPMENT"})
+  void isValid_otherDecisions_isTrue(DecisionEnum decisionValue) {
     Decision decision = Decision.builder().decision(decisionValue).build();
 
     boolean result = validator.isValid(decision, null);
 
-    assertTrue(result);
+    assertThat(result).isTrue();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/HighRiskEUDocumentCheckResultValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/HighRiskEUDocumentCheckResultValidatorTest.java
@@ -1,66 +1,65 @@
 package uk.gov.defra.tracesx.notificationschema.validation.annotations;
 
-import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.assertFalse;
+import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.Result.NOT_SATISFACTORY;
 import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.Result.NOT_SET;
 import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.Result.SATISFACTORY;
 import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.Result.SATISFACTORY_FOLLOWING_OFFICIAL_INTERVENTION;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import uk.gov.defra.tracesx.notificationschema.representation.ConsignmentCheck;
 
-public class HighRiskEUDocumentCheckResultValidatorTest {
+class HighRiskEUDocumentCheckResultValidatorTest {
 
   private HighRiskEUDocumentCheckResultValidator validator;
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     validator = new HighRiskEUDocumentCheckResultValidator();
   }
 
   @Test
-  public void isValid_returnsTrue_whenConsignmentCheckIsNull() {
-    assertTrue(validator.isValid(null, null));
+  void isValid_returnsTrue_whenConsignmentCheckIsNull() {
+    assertThat(validator.isValid(null, null)).isTrue();
   }
 
   @Test
-  public void isValid_returnsTrue_whenDocumentCheckIsNull() {
+  void isValid_returnsTrue_whenDocumentCheckIsNull() {
     ConsignmentCheck check = new ConsignmentCheck();
 
-    assertTrue(validator.isValid(check, null));
+    assertThat(validator.isValid(check, null)).isTrue();
   }
 
   @Test
-  public void isValid_returnsFalse_whenDocumentCheckIsNotSet() {
+  void isValid_returnsFalse_whenDocumentCheckIsNotSet() {
     ConsignmentCheck check = new ConsignmentCheck();
     check.setDocumentCheckResult(NOT_SET);
 
-    assertFalse(validator.isValid(check, null));
+    assertThat(validator.isValid(check, null)).isFalse();
   }
 
   @Test
-  public void isValid_returnsTrue_whenDocumentCheckResultIsSatisfactoryFollowingOfficialIntervention() {
+  void isValid_returnsTrue_whenDocumentCheckResultIsSatisfactoryFollowingOfficialIntervention() {
     ConsignmentCheck check = new ConsignmentCheck();
     check.setDocumentCheckResult(SATISFACTORY_FOLLOWING_OFFICIAL_INTERVENTION);
 
-    assertTrue(validator.isValid(check, null));
+    assertThat(validator.isValid(check, null)).isTrue();
   }
 
   @Test
-  public void isValid_returnsTrue_whenDocumentCheckResultIsSatisfactory() {
+  void isValid_returnsTrue_whenDocumentCheckResultIsSatisfactory() {
     ConsignmentCheck check = new ConsignmentCheck();
     check.setDocumentCheckResult(SATISFACTORY);
 
-    assertTrue(validator.isValid(check, null));
+    assertThat(validator.isValid(check, null)).isTrue();
   }
 
   @Test
-  public void isValid_returnsTrue_whenDocumentCheckResultIsNotSatisfactory() {
+  void isValid_returnsTrue_whenDocumentCheckResultIsNotSatisfactory() {
     ConsignmentCheck check = new ConsignmentCheck();
     check.setDocumentCheckResult(NOT_SATISFACTORY);
 
-    assertTrue(validator.isValid(check, null));
+    assertThat(validator.isValid(check, null)).isTrue();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/IdentityCheckEuStandardValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/IdentityCheckEuStandardValidatorTest.java
@@ -1,56 +1,55 @@
 package uk.gov.defra.tracesx.notificationschema.validation.annotations;
 
-import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.assertFalse;
+import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.Result.NOT_SATISFACTORY;
 import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.Result.SATISFACTORY;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import uk.gov.defra.tracesx.notificationschema.representation.ConsignmentCheck;
 
-public class IdentityCheckEuStandardValidatorTest {
+class IdentityCheckEuStandardValidatorTest {
 
   private ConsignmentCheck check;
   private IdentityCheckResultValidator validator;
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     validator = new IdentityCheckResultValidator();
     check = new ConsignmentCheck();
   }
 
   @Test
-  public void testThatValidatorReturnsTrueIfNullPassed() {
-    assertTrue(validator.isValid(null, null));
+  void testThatValidatorReturnsTrueIfNullPassed() {
+    assertThat(validator.isValid(null, null)).isTrue();
   }
 
   @Test
-  public void testThatValidatorReturnsTrueIfIdentityCheckDoneIsFalse() {
+  void testThatValidatorReturnsTrueIfIdentityCheckDoneIsFalse() {
     check.setIdentityCheckDone(false);
-    assertTrue(validator.isValid(check, null));
+    assertThat(validator.isValid(check, null)).isTrue();
   }
 
   @Test
-  public void testThatValidatorReturnsTrueIfIdentityCheckDoneIsTrueAndResultIsSatisfactory() {
+  void testThatValidatorReturnsTrueIfIdentityCheckDoneIsTrueAndResultIsSatisfactory() {
     check.setIdentityCheckDone(true);
     check.setIdentityCheckResult(SATISFACTORY);
 
-    assertTrue(validator.isValid(check, null));
+    assertThat(validator.isValid(check, null)).isTrue();
   }
 
   @Test
-  public void testThatValidatorReturnsTrueIfIdentityCheckDoneIsTrueAndResultIsNotSatisfactory() {
+  void testThatValidatorReturnsTrueIfIdentityCheckDoneIsTrueAndResultIsNotSatisfactory() {
     check.setIdentityCheckDone(true);
     check.setIdentityCheckResult(NOT_SATISFACTORY);
 
-    assertTrue(validator.isValid(check, null));
+    assertThat(validator.isValid(check, null)).isTrue();
   }
 
   @Test
-  public void testThatValidatorReturnsFalseIfIdentityCheckDoneIsTrueAndResultIsNull() {
+  void testThatValidatorReturnsFalseIfIdentityCheckDoneIsTrueAndResultIsNull() {
     check.setIdentityCheckDone(true);
 
-    assertFalse(validator.isValid(check, null));
+    assertThat(validator.isValid(check, null)).isFalse();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/IdentityCheckReasonNotDoneValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/IdentityCheckReasonNotDoneValidatorTest.java
@@ -1,62 +1,61 @@
 package uk.gov.defra.tracesx.notificationschema.validation.annotations;
 
 import static java.lang.Boolean.FALSE;
-import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.assertFalse;
+import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.IdentityCheckNotDoneReason.NOT_REQUIRED;
 import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.IdentityCheckNotDoneReason.REDUCED_CHECKS_REGIME;
 import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.Result.NOT_DONE;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import uk.gov.defra.tracesx.notificationschema.representation.ConsignmentCheck;
 
-public class IdentityCheckReasonNotDoneValidatorTest {
+class IdentityCheckReasonNotDoneValidatorTest {
 
   private IdentityCheckReasonNotDoneValidator validator;
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     validator = new IdentityCheckReasonNotDoneValidator();
   }
 
   @Test
-  public void testThatValidatorReturnsTrueIfNullPassed() {
-    assertTrue(validator.isValid(null, null));
+  void testThatValidatorReturnsTrueIfNullPassed() {
+    assertThat(validator.isValid(null, null)).isTrue();
   }
 
   @Test
-  public void testThatValidatorReturnsTrueIfIsIdentityCheckDoneReturnsNull() {
+  void testThatValidatorReturnsTrueIfIsIdentityCheckDoneReturnsNull() {
     ConsignmentCheck check = new ConsignmentCheck();
 
-    assertTrue(validator.isValid(check, null));
+    assertThat(validator.isValid(check, null)).isTrue();
   }
 
   @Test
-  public void testThatValidatorReturnsFalseIfIdentityCheckIsNotDoneAndIdentityCheckNotDoneReasonIsNull() {
+  void testThatValidatorReturnsFalseIfIdentityCheckIsNotDoneAndIdentityCheckNotDoneReasonIsNull() {
     ConsignmentCheck check = new ConsignmentCheck();
     check.setIdentityCheckResult(NOT_DONE);
 
-    assertFalse(validator.isValid(check, null));
+    assertThat(validator.isValid(check, null)).isFalse();
   }
 
   @Test
-  public void testThatValidatorReturnsTrueIfIdentityCheckIsNotDoneAndIdentityCheckNotDoneReasonIsReducedChecksRegime() {
+  void testThatValidatorReturnsTrueIfIdentityCheckIsNotDoneAndIdentityCheckNotDoneReasonIsReducedChecksRegime() {
     ConsignmentCheck check = new ConsignmentCheck();
     check.setIdentityCheckDone(FALSE);
     check.setIdentityCheckResult(NOT_DONE);
     check.setIdentityCheckNotDoneReason(REDUCED_CHECKS_REGIME);
 
-    assertTrue(validator.isValid(check, null));
+    assertThat(validator.isValid(check, null)).isTrue();
   }
 
   @Test
-  public void testThatValidatorReturnsTrueIfIdentityCheckIsNotDoneAndIdentityCheckNotDoneReasonIsNotRequired() {
+  void testThatValidatorReturnsTrueIfIdentityCheckIsNotDoneAndIdentityCheckNotDoneReasonIsNotRequired() {
     ConsignmentCheck check = new ConsignmentCheck();
     check.setIdentityCheckDone(FALSE);
     check.setIdentityCheckResult(NOT_DONE);
     check.setIdentityCheckNotDoneReason(NOT_REQUIRED);
 
-    assertTrue(validator.isValid(check, null));
+    assertThat(validator.isValid(check, null)).isTrue();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/IdentityCheckTypeValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/IdentityCheckTypeValidatorTest.java
@@ -1,60 +1,59 @@
 package uk.gov.defra.tracesx.notificationschema.validation.annotations;
 
-import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.assertFalse;
+import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.IdentificationCheckType.FULL_IDENTITY_CHECK;
 import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.IdentificationCheckType.SEAL_CHECK;
 import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.Result.NOT_SATISFACTORY;
 import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.Result.SATISFACTORY;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import uk.gov.defra.tracesx.notificationschema.representation.ConsignmentCheck;
 
-public class IdentityCheckTypeValidatorTest {
+class IdentityCheckTypeValidatorTest {
 
   private ConsignmentCheck check;
   private IdentityCheckTypeValidator validator;
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     validator = new IdentityCheckTypeValidator();
     check = new ConsignmentCheck();
   }
 
   @Test
-  public void testThatValidatorReturnsTrueIfNullPassed() {
-    assertTrue(validator.isValid(null, null));
+  void testThatValidatorReturnsTrueIfNullPassed() {
+    assertThat(validator.isValid(null, null)).isTrue();
   }
 
   @Test
-  public void testThatValidatorReturnsTrueIfIdentityCheckResultIsNotSatisfactory() {
+  void testThatValidatorReturnsTrueIfIdentityCheckResultIsNotSatisfactory() {
     check.setIdentityCheckResult(NOT_SATISFACTORY);
 
-    assertTrue(validator.isValid(check, null));
+    assertThat(validator.isValid(check, null)).isTrue();
   }
 
   @Test
-  public void testThatValidatorReturnsTrueIfIdentityCheckResultIsSatisfactoryAndTypeIsSealCheck() {
+  void testThatValidatorReturnsTrueIfIdentityCheckResultIsSatisfactoryAndTypeIsSealCheck() {
     check.setIdentityCheckResult(SATISFACTORY);
     check.setIdentityCheckType(SEAL_CHECK);
 
-    assertTrue(validator.isValid(check, null));
+    assertThat(validator.isValid(check, null)).isTrue();
   }
 
   @Test
-  public void
+  void
   testThatValidatorReturnsTrueIfIdentityCheckResultIsSatisfactoryAndTypeIsFullIdentityCheck() {
     check.setIdentityCheckResult(SATISFACTORY);
     check.setIdentityCheckType(FULL_IDENTITY_CHECK);
 
-    assertTrue(validator.isValid(check, null));
+    assertThat(validator.isValid(check, null)).isTrue();
   }
 
   @Test
-  public void testThatValidatorReturnsFalseIfIdentityCheckResultIsSatisfactoryButTypeIsNull() {
+  void testThatValidatorReturnsFalseIfIdentityCheckResultIsSatisfactoryButTypeIsNull() {
     check.setIdentityCheckResult(SATISFACTORY);
 
-    assertFalse(validator.isValid(check, null));
+    assertThat(validator.isValid(check, null)).isFalse();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/IfChanneledOptionValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/IfChanneledOptionValidatorTest.java
@@ -1,73 +1,51 @@
 package uk.gov.defra.tracesx.notificationschema.validation.annotations;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.DecisionEnum.ACCEPTABLE_FOR_INTERNAL_MARKET;
-import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.DecisionEnum.ACCEPTABLE_FOR_SPECIFIC_WAREHOUSE;
-import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.DecisionEnum.ACCEPTABLE_FOR_TEMPORARY_IMPORT;
-import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.DecisionEnum.ACCEPTABLE_FOR_TRANSHIPMENT;
-import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.DecisionEnum.ACCEPTABLE_FOR_TRANSIT;
-import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.DecisionEnum.NON_ACCEPTABLE;
+import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.IfChanneledOptionEnum.ARTICLE8;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.theories.DataPoints;
-import org.junit.experimental.theories.FromDataPoints;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import uk.gov.defra.tracesx.notificationschema.representation.Decision;
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.DecisionEnum;
 
-@RunWith(Theories.class)
-public class IfChanneledOptionValidatorTest {
+class IfChanneledOptionValidatorTest {
 
   private IfChanneledOptionValidator validator;
 
-  @DataPoints("Other decisions")
-  public static final DecisionEnum[] decisions =
-      new DecisionEnum[]{
-          ACCEPTABLE_FOR_SPECIFIC_WAREHOUSE,
-          ACCEPTABLE_FOR_INTERNAL_MARKET,
-          ACCEPTABLE_FOR_TEMPORARY_IMPORT,
-          ACCEPTABLE_FOR_TRANSHIPMENT,
-          ACCEPTABLE_FOR_TRANSIT,
-          NON_ACCEPTABLE
-      };
-
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     validator = new IfChanneledOptionValidator();
   }
 
   @Test
-  public void isValid_acceptableIfChanneledWithoutIfChanneledOption_isFalse() {
+  void isValid_acceptableIfChanneledWithoutIfChanneledOption_isFalse() {
     Decision decision = Decision.builder().decision(DecisionEnum.ACCEPTABLE_IF_CHANNELED).build();
 
     boolean result = validator.isValid(decision, null);
 
-    assertFalse(result);
+    assertThat(result).isFalse();
   }
 
   @Test
-  public void isValid_acceptableIfChanneledWithIfChanneledOption_isTrue() {
+  void isValid_acceptableIfChanneledWithIfChanneledOption_isTrue() {
     Decision decision = Decision.builder().decision(DecisionEnum.ACCEPTABLE_IF_CHANNELED)
         .ifChanneledOption(
             ARTICLE8).build();
 
     boolean result = validator.isValid(decision, null);
 
-    assertTrue(result);
+    assertThat(result).isTrue();
   }
 
-  @Theory
-  public void isValid_otherDecisions_isTrue(
-      @FromDataPoints("Other decisions") DecisionEnum decisionValue) {
+  @ParameterizedTest
+  @EnumSource(value = DecisionEnum.class, names = {"ACCEPTABLE_FOR_SPECIFIC_WAREHOUSE", "ACCEPTABLE_FOR_INTERNAL_MARKET", "ACCEPTABLE_FOR_TEMPORARY_IMPORT", "ACCEPTABLE_FOR_TRANSHIPMENT", "ACCEPTABLE_FOR_TRANSIT", "NON_ACCEPTABLE"})
+  void isValid_otherDecisions_isTrue(DecisionEnum decisionValue) {
     Decision decision = Decision.builder().decision(decisionValue).build();
 
     boolean result = validator.isValid(decision, null);
 
-    assertTrue(result);
+    assertThat(result).isTrue();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ImpPlaceOfDestinationNotNullValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ImpPlaceOfDestinationNotNullValidatorTest.java
@@ -1,30 +1,29 @@
 package uk.gov.defra.tracesx.notificationschema.validation.annotations;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.defra.tracesx.notificationschema.representation.EconomicOperator;
 import uk.gov.defra.tracesx.notificationschema.representation.PartOne;
 
-@RunWith(MockitoJUnitRunner.class)
-public class ImpPlaceOfDestinationNotNullValidatorTest {
+@ExtendWith(MockitoExtension.class)
+class ImpPlaceOfDestinationNotNullValidatorTest {
 
   private ImpPlaceOfDestinationNotNullValidator validator;
 
   private PartOne partOne;
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     validator = new ImpPlaceOfDestinationNotNullValidator();
     partOne = new PartOne();
   }
 
   @Test
-  public void validatorShouldReturnFalseIfPartOneIsNull() {
+  void validatorShouldReturnFalseIfPartOneIsNull() {
     // Given
     partOne = null;
 
@@ -32,11 +31,11 @@ public class ImpPlaceOfDestinationNotNullValidatorTest {
     boolean result = validator.isValid(partOne, null);
 
     // Then
-    assertFalse(result);
+    assertThat(result).isFalse();
   }
 
   @Test
-  public void validatorShouldReturnFalseIfPlaceOfDestinationIsNull() {
+  void validatorShouldReturnFalseIfPlaceOfDestinationIsNull() {
     // Given
     partOne.setPlaceOfDestination(null);
 
@@ -44,11 +43,11 @@ public class ImpPlaceOfDestinationNotNullValidatorTest {
     boolean result = validator.isValid(partOne, null);
 
     // Then
-    assertFalse(result);
+    assertThat(result).isFalse();
   }
 
   @Test
-  public void validatorShouldReturnTruePlaceOfDestinationIsNotNull() {
+  void validatorShouldReturnTruePlaceOfDestinationIsNotNull() {
     // Given
     EconomicOperator placeOfDestination = new EconomicOperator();
     partOne.setPlaceOfDestination(placeOfDestination);
@@ -57,6 +56,6 @@ public class ImpPlaceOfDestinationNotNullValidatorTest {
     boolean result = validator.isValid(partOne, null);
 
     // Then
-    assertTrue(result);
+    assertThat(result).isTrue();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ImpPlaceOfOriginNotNullValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ImpPlaceOfOriginNotNullValidatorTest.java
@@ -1,30 +1,29 @@
 package uk.gov.defra.tracesx.notificationschema.validation.annotations;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.defra.tracesx.notificationschema.representation.EconomicOperator;
 import uk.gov.defra.tracesx.notificationschema.representation.PartOne;
 
-@RunWith(MockitoJUnitRunner.class)
-public class ImpPlaceOfOriginNotNullValidatorTest {
+@ExtendWith(MockitoExtension.class)
+class ImpPlaceOfOriginNotNullValidatorTest {
 
   private ImpPlaceOfOriginNotNullValidator validator;
 
   private PartOne partOne;
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     validator = new ImpPlaceOfOriginNotNullValidator();
     partOne = new PartOne();
   }
 
   @Test
-  public void validatorShouldReturnFalseIfPartOneIsNull() {
+  void validatorShouldReturnFalseIfPartOneIsNull() {
     // Given
     partOne = null;
 
@@ -32,11 +31,11 @@ public class ImpPlaceOfOriginNotNullValidatorTest {
     boolean result = validator.isValid(partOne, null);
 
     // Then
-    assertFalse(result);
+    assertThat(result).isFalse();
   }
 
   @Test
-  public void validatorShouldReturnFalseIfPlaceOfDestinationIsNull() {
+  void validatorShouldReturnFalseIfPlaceOfDestinationIsNull() {
     // Given
     partOne.setConsignor(null);
 
@@ -44,11 +43,11 @@ public class ImpPlaceOfOriginNotNullValidatorTest {
     boolean result = validator.isValid(partOne, null);
 
     // Then
-    assertFalse(result);
+    assertThat(result).isFalse();
   }
 
   @Test
-  public void validatorShouldReturnTruePlaceOfDestinationIsNotNull() {
+  void validatorShouldReturnTruePlaceOfDestinationIsNotNull() {
     // Given
     EconomicOperator placeOfOrigin = new EconomicOperator();
     partOne.setConsignor(placeOfOrigin);
@@ -57,6 +56,6 @@ public class ImpPlaceOfOriginNotNullValidatorTest {
     boolean result = validator.isValid(partOne, null);
 
     // Then
-    assertTrue(result);
+    assertThat(result).isTrue();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ImpPortOfEntryValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ImpPortOfEntryValidatorTest.java
@@ -1,29 +1,28 @@
 package uk.gov.defra.tracesx.notificationschema.validation.annotations;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.defra.tracesx.notificationschema.representation.PartOne;
 
-@RunWith(MockitoJUnitRunner.class)
-public class ImpPortOfEntryValidatorTest {
+@ExtendWith(MockitoExtension.class)
+class ImpPortOfEntryValidatorTest {
 
   private ImpPortOfEntryValidator validator;
 
   private PartOne partOne;
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     validator = new ImpPortOfEntryValidator();
     partOne = new PartOne();
   }
 
   @Test
-  public void validatorShouldReturnFalseIfPartOneIsNull() {
+  void validatorShouldReturnFalseIfPartOneIsNull() {
     // Given
     partOne = null;
 
@@ -31,11 +30,11 @@ public class ImpPortOfEntryValidatorTest {
     boolean result = validator.isValid(partOne, null);
 
     // Then
-    assertFalse(result);
+    assertThat(result).isFalse();
   }
 
   @Test
-  public void validatorShouldReturnFalseIfThePortOfEntryFieldIsNull() {
+  void validatorShouldReturnFalseIfThePortOfEntryFieldIsNull() {
     // Given
     partOne.setPortOfEntry(null);
 
@@ -43,11 +42,11 @@ public class ImpPortOfEntryValidatorTest {
     boolean result = validator.isValid(partOne, null);
 
     // Then
-    assertFalse(result);
+    assertThat(result).isFalse();
   }
 
   @Test
-  public void validatorShouldReturnFalseIfThePortOfEntryFieldIsBlank() {
+  void validatorShouldReturnFalseIfThePortOfEntryFieldIsBlank() {
     // Given
     partOne.setPortOfEntry("");
 
@@ -55,11 +54,11 @@ public class ImpPortOfEntryValidatorTest {
     boolean result = validator.isValid(partOne, null);
 
     // Then
-    assertFalse(result);
+    assertThat(result).isFalse();
   }
 
   @Test
-  public void validatorShouldReturnTrueIfThePortOfEntryFieldHasAValue() {
+  void validatorShouldReturnTrueIfThePortOfEntryFieldHasAValue() {
     // Given
     partOne.setPortOfEntry("Some port of entry");
 
@@ -67,6 +66,6 @@ public class ImpPortOfEntryValidatorTest {
     boolean result = validator.isValid(partOne, null);
 
     // Then
-    assertTrue(result);
+    assertThat(result).isTrue();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ImpPortOfExitDateInFutureValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ImpPortOfExitDateInFutureValidatorTest.java
@@ -3,42 +3,29 @@ package uk.gov.defra.tracesx.notificationschema.validation.annotations;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDate;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.stream.Collectors;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.theories.DataPoints;
-import org.junit.experimental.theories.FromDataPoints;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.EnumSource.Mode;
 import uk.gov.defra.tracesx.notificationschema.representation.Commodities;
 import uk.gov.defra.tracesx.notificationschema.representation.PartOne;
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.AnimalCertification;
 
-@RunWith(Theories.class)
-public class ImpPortOfExitDateInFutureValidatorTest {
+class ImpPortOfExitDateInFutureValidatorTest {
 
   private ImpPortOfExitDateInFutureValidator validator;
 
   private PartOne partOne;
 
-  @DataPoints("Non Transit AnimalCertifications")
-  public static Collection<AnimalCertification> nonTransitAnimalCertifications() {
-    return Arrays.stream(AnimalCertification.values())
-        .filter(animalCertification -> animalCertification != AnimalCertification.TRANSIT)
-        .collect(Collectors.toList());
-  }
-
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     validator = new ImpPortOfExitDateInFutureValidator();
     partOne = new PartOne();
   }
 
   @Test
-  public void validatorShouldReturnTrueIfPartOneIsNull() {
+  void validatorShouldReturnTrueIfPartOneIsNull() {
     partOne = null;
 
     boolean result = validator.isValid(partOne, null);
@@ -47,7 +34,7 @@ public class ImpPortOfExitDateInFutureValidatorTest {
   }
 
   @Test
-  public void validatorShouldReturnTrueIfCommoditiesIsNull() {
+  void validatorShouldReturnTrueIfCommoditiesIsNull() {
     partOne.setCommodities(null);
 
     boolean result = validator.isValid(partOne, null);
@@ -56,7 +43,7 @@ public class ImpPortOfExitDateInFutureValidatorTest {
   }
 
   @Test
-  public void validatorShouldReturnTrueIfAnimalCertificationIsNull() {
+  void validatorShouldReturnTrueIfAnimalCertificationIsNull() {
     partOne.setCommodities(Commodities.builder().build());
 
     boolean result = validator.isValid(partOne, null);
@@ -64,9 +51,10 @@ public class ImpPortOfExitDateInFutureValidatorTest {
     assertThat(result).isTrue();
   }
 
-  @Theory
-  public void validatorShouldReturnTrueIfAnimalCertificationIsNotTransit(
-      @FromDataPoints("Non Transit AnimalCertifications") AnimalCertification animalCertification) {
+  @ParameterizedTest
+  @EnumSource(value = AnimalCertification.class, mode = Mode.EXCLUDE, names = {"TRANSIT"})
+  void validatorShouldReturnTrueIfAnimalCertificationIsNotTransit(
+      AnimalCertification animalCertification) {
     partOne.setCommodities(Commodities.builder().animalsCertifiedAs(animalCertification).build());
 
     boolean result = validator.isValid(partOne, null);
@@ -75,7 +63,7 @@ public class ImpPortOfExitDateInFutureValidatorTest {
   }
 
   @Test
-  public void validatorShouldReturnTrueIfAnimalCertificationIsTransitAndThePortOfExitDateIsNull() {
+  void validatorShouldReturnTrueIfAnimalCertificationIsTransitAndThePortOfExitDateIsNull() {
     partOne.setCommodities(
         Commodities.builder().animalsCertifiedAs(AnimalCertification.TRANSIT).build());
 
@@ -85,7 +73,7 @@ public class ImpPortOfExitDateInFutureValidatorTest {
   }
 
   @Test
-  public void
+  void
       validatorShouldReturnFalseIfAnimalCertificationIsTransitAndThePortOfExitDateIsEarlierThanToday() {
     partOne.setCommodities(
         Commodities.builder().animalsCertifiedAs(AnimalCertification.TRANSIT).build());
@@ -97,7 +85,7 @@ public class ImpPortOfExitDateInFutureValidatorTest {
   }
 
   @Test
-  public void validatorShouldReturnTrueIfAnimalCertificationIsTransitAndThePortOfExitDateIsToday() {
+  void validatorShouldReturnTrueIfAnimalCertificationIsTransitAndThePortOfExitDateIsToday() {
     partOne.setCommodities(
         Commodities.builder().animalsCertifiedAs(AnimalCertification.TRANSIT).build());
     partOne.setPortOfExitDate(LocalDate.now());

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ImpPortOfExitDateNotNullValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ImpPortOfExitDateNotNullValidatorTest.java
@@ -3,42 +3,29 @@ package uk.gov.defra.tracesx.notificationschema.validation.annotations;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDate;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.stream.Collectors;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.theories.DataPoints;
-import org.junit.experimental.theories.FromDataPoints;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.EnumSource.Mode;
 import uk.gov.defra.tracesx.notificationschema.representation.Commodities;
 import uk.gov.defra.tracesx.notificationschema.representation.PartOne;
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.AnimalCertification;
 
-@RunWith(Theories.class)
-public class ImpPortOfExitDateNotNullValidatorTest {
+class ImpPortOfExitDateNotNullValidatorTest {
 
   private ImpPortOfExitDateNotNullValidator validator;
 
   private PartOne partOne;
 
-  @DataPoints("Non Transit AnimalCertifications")
-  public static Collection<AnimalCertification> nonTransitAnimalCertifications() {
-    return Arrays.stream(AnimalCertification.values())
-        .filter(animalCertification -> animalCertification != AnimalCertification.TRANSIT)
-        .collect(Collectors.toList());
-  }
-
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     validator = new ImpPortOfExitDateNotNullValidator();
     partOne = new PartOne();
   }
 
   @Test
-  public void validatorShouldReturnFalseIfPartOneIsNull() {
+  void validatorShouldReturnFalseIfPartOneIsNull() {
     partOne = null;
 
     boolean result = validator.isValid(partOne, null);
@@ -47,7 +34,7 @@ public class ImpPortOfExitDateNotNullValidatorTest {
   }
 
   @Test
-  public void validatorShouldReturnFalseIfCommoditiesIsNull() {
+  void validatorShouldReturnFalseIfCommoditiesIsNull() {
     partOne.setCommodities(null);
 
     boolean result = validator.isValid(partOne, null);
@@ -56,7 +43,7 @@ public class ImpPortOfExitDateNotNullValidatorTest {
   }
 
   @Test
-  public void validatorShouldReturnTrueIfAnimalCertificationIsNull() {
+  void validatorShouldReturnTrueIfAnimalCertificationIsNull() {
     partOne.setCommodities(Commodities.builder().build());
 
     boolean result = validator.isValid(partOne, null);
@@ -64,9 +51,10 @@ public class ImpPortOfExitDateNotNullValidatorTest {
     assertThat(result).isTrue();
   }
 
-  @Theory
-  public void validatorShouldReturnTrueIfAnimalCertificationIsSetAndNotTransit(
-      @FromDataPoints("Non Transit AnimalCertifications") AnimalCertification animalCertification) {
+  @ParameterizedTest
+  @EnumSource(value = AnimalCertification.class, mode = Mode.EXCLUDE, names = {"TRANSIT"})
+  void validatorShouldReturnTrueIfAnimalCertificationIsSetAndNotTransit(
+      AnimalCertification animalCertification) {
     partOne.setCommodities(Commodities.builder().animalsCertifiedAs(animalCertification).build());
 
     boolean result = validator.isValid(partOne, null);
@@ -75,7 +63,7 @@ public class ImpPortOfExitDateNotNullValidatorTest {
   }
 
   @Test
-  public void validatorShouldReturnFalseIfAnimalCertificationIsTransitAndThePortOfExitDateIsNull() {
+  void validatorShouldReturnFalseIfAnimalCertificationIsTransitAndThePortOfExitDateIsNull() {
     partOne.setCommodities(
         Commodities.builder().animalsCertifiedAs(AnimalCertification.TRANSIT).build());
 
@@ -85,7 +73,7 @@ public class ImpPortOfExitDateNotNullValidatorTest {
   }
 
   @Test
-  public void
+  void
       validatorShouldReturnTrueIfAnimalCertificationIsTransitAndThePortOfExitDateIsPopulated() {
     partOne.setCommodities(
         Commodities.builder().animalsCertifiedAs(AnimalCertification.TRANSIT).build());

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ImpPortOfExitValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ImpPortOfExitValidatorTest.java
@@ -2,42 +2,29 @@ package uk.gov.defra.tracesx.notificationschema.validation.annotations;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.stream.Collectors;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.theories.DataPoints;
-import org.junit.experimental.theories.FromDataPoints;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.EnumSource.Mode;
 import uk.gov.defra.tracesx.notificationschema.representation.Commodities;
 import uk.gov.defra.tracesx.notificationschema.representation.PartOne;
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.AnimalCertification;
 
-@RunWith(Theories.class)
-public class ImpPortOfExitValidatorTest {
+class ImpPortOfExitValidatorTest {
 
   private ImpPortOfExitValidator validator;
 
   private PartOne partOne;
 
-  @DataPoints("Non Transit AnimalCertifications")
-  public static Collection<AnimalCertification> nonTransitAnimalCertifications() {
-    return Arrays.stream(AnimalCertification.values())
-        .filter(animalCertification -> animalCertification != AnimalCertification.TRANSIT)
-        .collect(Collectors.toList());
-  }
-
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     validator = new ImpPortOfExitValidator();
     partOne = new PartOne();
   }
 
   @Test
-  public void validatorShouldReturnFalseIfPartOneIsNull() {
+  void validatorShouldReturnFalseIfPartOneIsNull() {
     partOne = null;
 
     boolean result = validator.isValid(partOne, null);
@@ -46,7 +33,7 @@ public class ImpPortOfExitValidatorTest {
   }
 
   @Test
-  public void validatorShouldReturnFalseIfCommoditiesIsNull() {
+  void validatorShouldReturnFalseIfCommoditiesIsNull() {
     partOne.setCommodities(null);
 
     boolean result = validator.isValid(partOne, null);
@@ -55,7 +42,7 @@ public class ImpPortOfExitValidatorTest {
   }
 
   @Test
-  public void validatorShouldReturnTrueIfAnimalCertificationIsNull() {
+  void validatorShouldReturnTrueIfAnimalCertificationIsNull() {
     partOne.setCommodities(Commodities.builder().build());
 
     boolean result = validator.isValid(partOne, null);
@@ -63,9 +50,10 @@ public class ImpPortOfExitValidatorTest {
     assertThat(result).isTrue();
   }
 
-  @Theory
-  public void validatorShouldReturnTrueIfAnimalCertificationIsSetAndNotTransit(
-      @FromDataPoints("Non Transit AnimalCertifications") AnimalCertification animalCertification) {
+  @ParameterizedTest
+  @EnumSource(value = AnimalCertification.class, mode = Mode.EXCLUDE, names = {"TRANSIT"})
+  void validatorShouldReturnTrueIfAnimalCertificationIsSetAndNotTransit(
+      AnimalCertification animalCertification) {
     partOne.setCommodities(Commodities.builder().animalsCertifiedAs(animalCertification).build());
 
     boolean result = validator.isValid(partOne, null);
@@ -74,7 +62,7 @@ public class ImpPortOfExitValidatorTest {
   }
 
   @Test
-  public void validatorShouldReturnFalseIfAnimalCertificationIsTransitAndThePortOfExitIsNull() {
+  void validatorShouldReturnFalseIfAnimalCertificationIsTransitAndThePortOfExitIsNull() {
     partOne.setCommodities(
         Commodities.builder().animalsCertifiedAs(AnimalCertification.TRANSIT).build());
 
@@ -84,7 +72,7 @@ public class ImpPortOfExitValidatorTest {
   }
 
   @Test
-  public void validatorShouldReturnFalseIfAnimalCertificationIsTransitAndThePortOfExitIsBlank() {
+  void validatorShouldReturnFalseIfAnimalCertificationIsTransitAndThePortOfExitIsBlank() {
     partOne.setCommodities(
         Commodities.builder().animalsCertifiedAs(AnimalCertification.TRANSIT).build());
     partOne.setPortOfExit("");
@@ -95,7 +83,7 @@ public class ImpPortOfExitValidatorTest {
   }
 
   @Test
-  public void
+  void
       validatorShouldReturnFalseIfAnimalCertificationIsTransitAndThePortOfExitIsWhitespace() {
     partOne.setCommodities(
         Commodities.builder().animalsCertifiedAs(AnimalCertification.TRANSIT).build());
@@ -107,7 +95,7 @@ public class ImpPortOfExitValidatorTest {
   }
 
   @Test
-  public void validatorShouldReturnTrueIfAnimalCertificationIsTransitAndThePortOfExitIsPopulated() {
+  void validatorShouldReturnTrueIfAnimalCertificationIsTransitAndThePortOfExitIsPopulated() {
     partOne.setCommodities(
         Commodities.builder().animalsCertifiedAs(AnimalCertification.TRANSIT).build());
     partOne.setPortOfExit("Portcullis");

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/InternalMarketValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/InternalMarketValidatorTest.java
@@ -1,42 +1,41 @@
 package uk.gov.defra.tracesx.notificationschema.validation.annotations;
 
-import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.assertFalse;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import uk.gov.defra.tracesx.notificationschema.representation.Decision;
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.DecisionEnum;
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.FreeCirculationPurposeEnum;
 
-public class InternalMarketValidatorTest {
+class InternalMarketValidatorTest {
 
   private InternalMarketValidator validator;
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     validator = new InternalMarketValidator();
   }
 
   @Test
-  public void givenDecisionIsNull_whenICallIsValid_thenResultIsTrue() {
-    assertTrue(validator.isValid(null, null));
+  void givenDecisionIsNull_whenICallIsValid_thenResultIsTrue() {
+    assertThat(validator.isValid(null, null)).isTrue();
   }
 
   @Test
-  public void givenDecisionIsInternalMarketAndFreeCirculationIsNull_whenICallIsValid_thenResultIsFalse() {
+  void givenDecisionIsInternalMarketAndFreeCirculationIsNull_whenICallIsValid_thenResultIsFalse() {
     Decision decision = new Decision();
     decision.setDecision(DecisionEnum.ACCEPTABLE_FOR_INTERNAL_MARKET);
 
-    assertFalse(validator.isValid(decision, null));
+    assertThat(validator.isValid(decision, null)).isFalse();
   }
 
   @Test
-  public void givenDecisionIsInternalMarketAndFreeCirculationIsNotNull_whenICallIsValid_thenResultIsFalse() {
+  void givenDecisionIsInternalMarketAndFreeCirculationIsNotNull_whenICallIsValid_thenResultIsFalse() {
     Decision decision = new Decision();
     decision.setDecision(DecisionEnum.ACCEPTABLE_FOR_INTERNAL_MARKET);
     decision.setFreeCirculationPurpose(FreeCirculationPurposeEnum.FURTHER_PROCESS);
 
-    assertTrue(validator.isValid(decision, null));
+    assertThat(validator.isValid(decision, null)).isTrue();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/IsNonNegativeIntegerKeyDataPairValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/IsNonNegativeIntegerKeyDataPairValidatorTest.java
@@ -1,20 +1,22 @@
 package uk.gov.defra.tracesx.notificationschema.validation.annotations;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.defra.tracesx.notificationschema.representation.ComplementParameterSetKeyDataPair;
 
-@RunWith(MockitoJUnitRunner.class)
-public class IsNonNegativeIntegerKeyDataPairValidatorTest {
+
+@ExtendWith(MockitoExtension.class)
+class IsNonNegativeIntegerKeyDataPairValidatorTest {
 
   @Mock
   private IsNonNegativeIntegerKeyDataPair mockKeyDataPair;
@@ -22,8 +24,8 @@ public class IsNonNegativeIntegerKeyDataPairValidatorTest {
   private IsNonNegativeIntegerKeyDataPairValidator validator;
   private List<ComplementParameterSetKeyDataPair> keyDataPairList;
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     validator = new IsNonNegativeIntegerKeyDataPairValidator();
     when(mockKeyDataPair.field()).thenReturn("number_package");
     keyDataPairList = new ArrayList<>();
@@ -31,57 +33,36 @@ public class IsNonNegativeIntegerKeyDataPairValidatorTest {
   }
 
   @Test
-  public void testKeyDataPairIsInValidIfObjectPassedIsNull() {
-    assertFalse(validator.isValid(null, null));
+  void testKeyDataPairIsInValidIfObjectPassedIsNull() {
+    assertThat(validator.isValid(null, null)).isFalse();
   }
 
   @Test
-  public void testNumberPackageValidationFailsIfNoValueIsProvided() {
+  void testNumberPackageValidationFailsIfNoValueIsProvided() {
     ComplementParameterSetKeyDataPair pair = new ComplementParameterSetKeyDataPair();
     pair.setKey("number_package");
     pair.setData("");
     keyDataPairList.add(pair);
 
-    assertFalse(validator.isValid(keyDataPairList, null));
+    assertThat(validator.isValid(keyDataPairList, null)).isFalse();
   }
 
-  @Test
-  public void testNumberPackageValidationPassesWithValidInteger() {
+  @ParameterizedTest
+  @CsvSource({
+      " ,                           false",  // no value
+      "1,                           true",   // should pass
+      "-1,                          false", //not positive
+      "oiiwr,                       false", //not an int
+      "332840984904824029348904820, false"  //out of range
+  })
+  void NumberPackageValidation(String numberPackage, boolean expectedResult) {
     ComplementParameterSetKeyDataPair pair = new ComplementParameterSetKeyDataPair();
     pair.setKey("number_package");
-    pair.setData("1");
+    pair.setData(numberPackage);
     keyDataPairList.add(pair);
+    boolean result = validator.isValid(keyDataPairList, null);
 
-    assertTrue(validator.isValid(keyDataPairList, null));
+    assertThat(expectedResult).isEqualTo(result);
   }
 
-  @Test
-  public void testNumberPackageValidationFailsWithNegativeInteger() {
-    ComplementParameterSetKeyDataPair pair = new ComplementParameterSetKeyDataPair();
-    pair.setKey("number_package");
-    pair.setData("-1");
-    keyDataPairList.add(pair);
-
-    assertFalse(validator.isValid(keyDataPairList, null));
-  }
-
-  @Test
-  public void testNumberPackageValidationFailsWithNonIntegerType() {
-    ComplementParameterSetKeyDataPair pair = new ComplementParameterSetKeyDataPair();
-    pair.setKey("number_package");
-    pair.setData("oiiwr");
-    keyDataPairList.add(pair);
-
-    assertFalse(validator.isValid(keyDataPairList, null));
-  }
-
-  @Test
-  public void testNumberPackageValidationFailsIfValueIsOutsideOfIntegerRange() {
-    ComplementParameterSetKeyDataPair pair = new ComplementParameterSetKeyDataPair();
-    pair.setKey("number_package");
-    pair.setData("332840984904824029348904820");
-    keyDataPairList.add(pair);
-
-    assertFalse(validator.isValid(keyDataPairList, null));
-  }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/IsPositiveDoubleKeyDataPairValidationTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/IsPositiveDoubleKeyDataPairValidationTest.java
@@ -2,51 +2,29 @@ package uk.gov.defra.tracesx.notificationschema.validation.annotations;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
-public class IsPositiveDoubleKeyDataPairValidationTest {
+class IsPositiveDoubleKeyDataPairValidationTest {
   private IsPositiveDoubleKeyDataPairValidation validator;
-  private String data;
 
-  @Before
-  public void setup() {
+  @BeforeEach
+  void setup() {
     validator = new IsPositiveDoubleKeyDataPairValidation("quantity");
   }
 
-  @Test
-  public void isValid_ReturnsFalse_WhenFieldValueIsNull() {
-    data = null;
-    assertThat(validator.isValid(data)).isFalse();
-  }
-
-  @Test
-  public void isValid_ReturnsFalse_WhenFieldValueIsNonPositiveNumber() {
-    data = "-1";
-    assertThat(validator.isValid(data)).isFalse();
-  }
-
-  @Test
-  public void isValid_ReturnsTrue_WhenFieldValueGreaterThanZero() {
-    data = "1";
-    assertThat(validator.isValid(data)).isTrue();
-  }
-
-  @Test
-  public void isValid_ReturnsFalse_WhenFieldValueIsNotANumber() {
-    data = "??";
-    assertThat(validator.isValid(data)).isFalse();
-  }
-
-  @Test
-  public void isValid_ReturnsFalse_WhenFieldValueIsZero() {
-    data = "0";
-    assertThat(validator.isValid(data)).isFalse();
-  }
-
-  @Test
-  public void isValid_ReturnsTrue_WhenFieldValueIsPositiveDecimal() {
-    data = "1.5";
-    assertThat(validator.isValid(data)).isTrue();
+  @ParameterizedTest
+  @CsvSource({
+      " ,                           false",
+      "1,                           true",
+      "-1,                          false",
+      "??,                          false",
+      "1.5,                         true",
+      "0,                           false"
+  })
+  void shouldValidateData(String quantity, boolean expected) {
+    boolean result = validator.isValid(quantity);
+    assertThat(result).isEqualTo(expected);
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/LaboratoryTestsNotAddedValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/LaboratoryTestsNotAddedValidatorTest.java
@@ -2,66 +2,65 @@ package uk.gov.defra.tracesx.notificationschema.validation.annotations;
 
 import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
-import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.assertFalse;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Collections;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import uk.gov.defra.tracesx.notificationschema.representation.LaboratoryTests;
 import uk.gov.defra.tracesx.notificationschema.representation.PartTwo;
 import uk.gov.defra.tracesx.notificationschema.representation.SingleLaboratoryTest;
 
-public class LaboratoryTestsNotAddedValidatorTest {
+class LaboratoryTestsNotAddedValidatorTest {
 
   private LaboratoryTestsNotAddedValidator validator;
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     validator = new LaboratoryTestsNotAddedValidator();
   }
 
   @Test
-  public void testThatValidatorReturnsTrueIfNullPassed() {
-    assertTrue(validator.isValid(null, null));
+  void testThatValidatorReturnsTrueIfNullPassed() {
+    assertThat(validator.isValid(null, null)).isTrue();
   }
 
   @Test
-  public void testThatValidatorReturnsTrueIfIsLaboratoryTestsNotAddedNull() {
+  void testThatValidatorReturnsTrueIfIsLaboratoryTestsNotAddedNull() {
     PartTwo partTwo = new PartTwo();
 
-    assertTrue(validator.isValid(partTwo, null));
+    assertThat(validator.isValid(partTwo, null)).isTrue();
   }
 
   @Test
-  public void testThatValidatorReturnsTrueWhenLaboratoryTestsRequiredIsFalse() {
+  void testThatValidatorReturnsTrueWhenLaboratoryTestsRequiredIsFalse() {
     PartTwo partTwo = new PartTwo();
     partTwo.setLaboratoryTestsRequired(FALSE);
 
-    assertTrue(validator.isValid(partTwo, null));
+    assertThat(validator.isValid(partTwo, null)).isTrue();
   }
 
   @Test
-  public void
+  void
   testThatValidatorReturnsFalseWhenLaboratoryTestsRequiredIsTrueAndLaboratoryTestsNull() {
     PartTwo partTwo = new PartTwo();
     partTwo.setLaboratoryTestsRequired(TRUE);
 
-    assertFalse(validator.isValid(partTwo, null));
+    assertThat(validator.isValid(partTwo, null)).isFalse();
   }
 
   @Test
-  public void
+  void
   testThatValidatorReturnsFalseWhenLaboratoryTestsRequiredIsTrueAndEmptyLaboratoryTestsList() {
     PartTwo partTwo = new PartTwo();
     partTwo.setLaboratoryTestsRequired(TRUE);
     partTwo.setLaboratoryTests(new LaboratoryTests());
 
-    assertFalse(validator.isValid(partTwo, null));
+    assertThat(validator.isValid(partTwo, null)).isFalse();
   }
 
   @Test
-  public void
+  void
   testThatValidatorReturnsTrueWhenLaboratoryTestsRequiredIsTrueAndLaboratoryTestsListWithOneTest() {
     PartTwo partTwo = new PartTwo();
     partTwo.setLaboratoryTestsRequired(TRUE);
@@ -69,6 +68,6 @@ public class LaboratoryTestsNotAddedValidatorTest {
     laboratoryTests.setSingleLaboratoryTests(Collections.singletonList(new SingleLaboratoryTest()));
     partTwo.setLaboratoryTests(laboratoryTests);
 
-    assertTrue(validator.isValid(partTwo, null));
+    assertThat(validator.isValid(partTwo, null)).isTrue();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/LaboratoryTestsPendingValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/LaboratoryTestsPendingValidatorTest.java
@@ -2,8 +2,7 @@ package uk.gov.defra.tracesx.notificationschema.validation.annotations;
 
 import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
-import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.assertFalse;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.Conclusion.PENDING;
@@ -12,19 +11,19 @@ import java.util.Collections;
 import jakarta.validation.ConstraintValidatorContext;
 import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorContext;
 import org.hibernate.validator.constraintvalidation.HibernateConstraintViolationBuilder;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.defra.tracesx.notificationschema.representation.LaboratoryTestResult;
 import uk.gov.defra.tracesx.notificationschema.representation.LaboratoryTests;
 import uk.gov.defra.tracesx.notificationschema.representation.PartTwo;
 import uk.gov.defra.tracesx.notificationschema.representation.SingleLaboratoryTest;
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.TestReason;
 
-@RunWith(MockitoJUnitRunner.class)
-public class LaboratoryTestsPendingValidatorTest {
+@ExtendWith(MockitoExtension.class)
+class LaboratoryTestsPendingValidatorTest {
 
   private LaboratoryTestsPendingValidator validator;
   private PartTwo partTwo;
@@ -33,87 +32,90 @@ public class LaboratoryTestsPendingValidatorTest {
   @Mock
   ConstraintValidatorContext constraintValidatorContextMock;
   @Mock
-  ConstraintValidatorContext.ConstraintViolationBuilder constraintViolationBuilderMock;
-  @Mock
   HibernateConstraintViolationBuilder hibernateConstraintViolationBuilder;
   @Mock
   ConstraintValidatorContext.ConstraintViolationBuilder.NodeBuilderCustomizableContext nodeBuilderContextMock;
 
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     partTwo = new PartTwo();
     validator = new LaboratoryTestsPendingValidator();
+  }
+
+  void validatorMocking() {
     when(constraintValidatorContextMock
-            .unwrap(HibernateConstraintValidatorContext.class))
-            .thenReturn(hibernateConstraintValidatorContextMock);
+        .unwrap(HibernateConstraintValidatorContext.class))
+        .thenReturn(hibernateConstraintValidatorContextMock);
 
     when(hibernateConstraintValidatorContextMock
-            .buildConstraintViolationWithTemplate(anyString()))
-            .thenReturn(hibernateConstraintViolationBuilder);
+        .buildConstraintViolationWithTemplate(anyString()))
+        .thenReturn(hibernateConstraintViolationBuilder);
 
     when(hibernateConstraintViolationBuilder.addPropertyNode(anyString()))
-            .thenReturn(nodeBuilderContextMock);
+        .thenReturn(nodeBuilderContextMock);
   }
 
   @Test
-  public void testThatValidatorReturnsTrueIfNullPassed() {
-    assertTrue(validator.isValid(null, constraintValidatorContextMock));
+  void testThatValidatorReturnsTrueIfNullPassed() {
+    assertThat(validator.isValid(null, constraintValidatorContextMock)).isTrue();
   }
 
   @Test
-  public void testThatValidatorReturnsTrueIfIsLaboratoryTestsNotAddedNull() {
-    assertTrue(validator.isValid(partTwo, constraintValidatorContextMock));
+  void testThatValidatorReturnsTrueIfIsLaboratoryTestsNotAddedNull() {
+    assertThat(validator.isValid(partTwo, constraintValidatorContextMock)).isTrue();
   }
 
   @Test
-  public void testThatValidatorReturnsTrueWhenLaboratoryTestsRequiredIsFalse() {
+  void testThatValidatorReturnsTrueWhenLaboratoryTestsRequiredIsFalse() {
     partTwo.setLaboratoryTestsRequired(FALSE);
 
-    assertTrue(validator.isValid(partTwo, constraintValidatorContextMock));
+    assertThat(validator.isValid(partTwo, constraintValidatorContextMock)).isTrue();
   }
 
   @Test
-  public void
+  void
   testThatValidatorReturnsFalseWhenLaboratoryTestsRequiredIsTrueAndLaboratoryTestsNull() {
     partTwo.setLaboratoryTestsRequired(TRUE);
 
-    assertTrue(validator.isValid(partTwo, constraintValidatorContextMock));
+    assertThat(validator.isValid(partTwo, constraintValidatorContextMock)).isTrue();
   }
 
   @Test
-  public void
+  void
   testThatValidatorReturnsTrueWhenLaboratoryTestsRequiredIsTrueAndEmptyLaboratoryTestsList() {
     partTwo.setLaboratoryTestsRequired(TRUE);
     partTwo.setLaboratoryTests(new LaboratoryTests());
 
-    assertTrue(validator.isValid(partTwo, constraintValidatorContextMock));
+    assertThat(validator.isValid(partTwo, constraintValidatorContextMock)).isTrue();
   }
 
   @Test
-  public void testThatValidatorReturnsTrueWhenReasonIsRandom() {
+  void testThatValidatorReturnsTrueWhenReasonIsRandom() {
     partTwo.setLaboratoryTestsRequired(TRUE);
     LaboratoryTests laboratoryTests = new LaboratoryTests();
     laboratoryTests.setTestReason(TestReason.RANDOM);
     laboratoryTests.setSingleLaboratoryTests(Collections.singletonList(new SingleLaboratoryTest()));
     partTwo.setLaboratoryTests(laboratoryTests);
 
-    assertTrue(validator.isValid(partTwo, constraintValidatorContextMock));
+    assertThat(validator.isValid(partTwo, constraintValidatorContextMock)).isTrue();
   }
 
   @Test
-  public void shouldFailValidationWhenReasonIsSuspiciousNoTests() {
+  void shouldFailValidationWhenReasonIsSuspiciousNoTests() {
+    validatorMocking();
     partTwo.setLaboratoryTestsRequired(TRUE);
     LaboratoryTests laboratoryTests = new LaboratoryTests();
     laboratoryTests.setTestReason(TestReason.SUSPICIOUS);
     laboratoryTests.setSingleLaboratoryTests(Collections.singletonList(new SingleLaboratoryTest()));
     partTwo.setLaboratoryTests(laboratoryTests);
 
-    assertFalse(validator.isValid(partTwo, constraintValidatorContextMock));
+    assertThat(validator.isValid(partTwo, constraintValidatorContextMock)).isFalse();
   }
 
   @Test
-  public void shouldFailValidationWhenReasonIsSuspiciousAndOnePendingTest() {
+  void shouldFailValidationWhenReasonIsSuspiciousAndOnePendingTest() {
+    validatorMocking();
     partTwo.setLaboratoryTestsRequired(TRUE);
     LaboratoryTests laboratoryTests = new LaboratoryTests();
     laboratoryTests.setTestReason(TestReason.SUSPICIOUS);
@@ -124,22 +126,24 @@ public class LaboratoryTestsPendingValidatorTest {
     laboratoryTests.setSingleLaboratoryTests(Collections.singletonList(singleLaboratoryTest));
     partTwo.setLaboratoryTests(laboratoryTests);
 
-    assertFalse(validator.isValid(partTwo, constraintValidatorContextMock));
+    assertThat(validator.isValid(partTwo, constraintValidatorContextMock)).isFalse();
   }
 
   @Test
-  public void shouldFailValidationWhenReasonIsReEnforcedNoTests() {
+  void shouldFailValidationWhenReasonIsReEnforcedNoTests() {
+    validatorMocking();
     partTwo.setLaboratoryTestsRequired(TRUE);
     LaboratoryTests laboratoryTests = new LaboratoryTests();
     laboratoryTests.setTestReason(TestReason.REENFORCED);
     laboratoryTests.setSingleLaboratoryTests(Collections.singletonList(new SingleLaboratoryTest()));
     partTwo.setLaboratoryTests(laboratoryTests);
 
-    assertFalse(validator.isValid(partTwo, constraintValidatorContextMock));
+    assertThat(validator.isValid(partTwo, constraintValidatorContextMock)).isFalse();
   }
 
   @Test
-  public void shouldFailValidationWhenReasonIsReEnforcedAndOnePendingTest() {
+  void shouldFailValidationWhenReasonIsReEnforcedAndOnePendingTest() {
+    validatorMocking();
     partTwo.setLaboratoryTestsRequired(TRUE);
     LaboratoryTests laboratoryTests = new LaboratoryTests();
     laboratoryTests.setTestReason(TestReason.REENFORCED);
@@ -150,11 +154,11 @@ public class LaboratoryTestsPendingValidatorTest {
     laboratoryTests.setSingleLaboratoryTests(Collections.singletonList(singleLaboratoryTest));
     partTwo.setLaboratoryTests(laboratoryTests);
 
-    assertFalse(validator.isValid(partTwo, constraintValidatorContextMock));
+    assertThat(validator.isValid(partTwo, constraintValidatorContextMock)).isFalse();
   }
 
   @Test
-  public void testThatValidatorReturnsTrueWhenReasonIsRandomAndOnePendingTest() {
+  void testThatValidatorReturnsTrueWhenReasonIsRandomAndOnePendingTest() {
     partTwo.setLaboratoryTestsRequired(TRUE);
     LaboratoryTests laboratoryTests = new LaboratoryTests();
     laboratoryTests.setTestReason(TestReason.RANDOM);
@@ -165,6 +169,6 @@ public class LaboratoryTestsPendingValidatorTest {
     laboratoryTests.setSingleLaboratoryTests(Collections.singletonList(singleLaboratoryTest));
     partTwo.setLaboratoryTests(laboratoryTests);
 
-    assertTrue(validator.isValid(partTwo, constraintValidatorContextMock));
+    assertThat(validator.isValid(partTwo, constraintValidatorContextMock)).isTrue();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/LatestHealthCertificateRequiredValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/LatestHealthCertificateRequiredValidatorTest.java
@@ -4,23 +4,20 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDate;
 import java.util.Collections;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import uk.gov.defra.tracesx.notificationschema.representation.AccompanyingDocument;
-import uk.gov.defra.tracesx.notificationschema.representation.JourneyRiskCategorisation;
-import uk.gov.defra.tracesx.notificationschema.representation.Notification;
-import uk.gov.defra.tracesx.notificationschema.representation.PartOne;
 import uk.gov.defra.tracesx.notificationschema.representation.VeterinaryInformation;
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.DocumentType;
 
-public class LatestHealthCertificateRequiredValidatorTest {
+class LatestHealthCertificateRequiredValidatorTest {
 
   private LatestHealthCertificateRequiredValidator validator;
   private VeterinaryInformation veterinaryInformation;
 
 
-  @Before
-  public void setup() {
+  @BeforeEach
+  void setup() {
     validator = new LatestHealthCertificateRequiredValidator();
     veterinaryInformation = new VeterinaryInformation();
     AccompanyingDocument accompanyingDocument = new AccompanyingDocument();
@@ -31,18 +28,18 @@ public class LatestHealthCertificateRequiredValidatorTest {
   }
 
   @Test
-  public void isValid_ReturnsTrue_WhenContainsLatestHealthCertificate() {
+  void isValid_ReturnsTrue_WhenContainsLatestHealthCertificate() {
     assertThat(validator.isValid(veterinaryInformation, null)).isTrue();
   }
 
   @Test
-  public void isValid_ReturnsFalse_WhenDoesContainsLatestHealthCertificate() {
+  void isValid_ReturnsFalse_WhenDoesContainsLatestHealthCertificate() {
     veterinaryInformation.setAccompanyingDocuments(null);
     assertThat(validator.isValid(veterinaryInformation, null)).isFalse();
   }
 
   @Test
-  public void isValid_ReturnsFalse_WhenContainsAccompanyingDocsButNotLatestHealthCertificate() {
+  void isValid_ReturnsFalse_WhenContainsAccompanyingDocsButNotLatestHealthCertificate() {
     AccompanyingDocument accompanyingDocument = new AccompanyingDocument();
     accompanyingDocument.setDocumentReference("referenceNumber");
     accompanyingDocument.setDocumentIssueDate(LocalDate.now());

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/LatestVeterinaryHealthCertificateRequiredValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/LatestVeterinaryHealthCertificateRequiredValidatorTest.java
@@ -1,7 +1,7 @@
 package uk.gov.defra.tracesx.notificationschema.validation.annotations;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import uk.gov.defra.tracesx.notificationschema.representation.AccompanyingDocument;
 import uk.gov.defra.tracesx.notificationschema.representation.JourneyRiskCategorisation;
 import uk.gov.defra.tracesx.notificationschema.representation.Notification;
@@ -14,7 +14,7 @@ import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class LatestVeterinaryHealthCertificateRequiredValidatorTest {
+class LatestVeterinaryHealthCertificateRequiredValidatorTest {
 
   private LatestVeterinaryHealthCertificateRequiredValidator validator;
   private Notification notification;
@@ -23,8 +23,8 @@ public class LatestVeterinaryHealthCertificateRequiredValidatorTest {
   private static final String RISK_LEVEL_MEDIUM = "Medium";
   private static final String RISK_LEVEL_LOW = "Low";
 
-  @Before
-  public void setup() {
+  @BeforeEach
+  void setup() {
     validator = new LatestVeterinaryHealthCertificateRequiredValidator();
     notification = new Notification();
     JourneyRiskCategorisation journeyRiskCategorisation = new JourneyRiskCategorisation();
@@ -41,32 +41,32 @@ public class LatestVeterinaryHealthCertificateRequiredValidatorTest {
   }
 
   @Test
-  public void isValid_ReturnsTrue_WhenRiskLevelHighAndContainsLatestHealthCertificate() {
+  void isValid_ReturnsTrue_WhenRiskLevelHighAndContainsLatestHealthCertificate() {
     assertThat(validator.isValid(notification, null)).isTrue();
   }
 
   @Test
-  public void isValid_ReturnsTrue_WhenRiskLevelMediumAndContainsLatestHealthCertificate() {
+  void isValid_ReturnsTrue_WhenRiskLevelMediumAndContainsLatestHealthCertificate() {
     notification.getJourneyRiskCategorisation().setRiskLevel(RISK_LEVEL_MEDIUM);
     assertThat(validator.isValid(notification, null)).isTrue();
   }
 
   @Test
-  public void isValid_ReturnsFalse_WhenRiskLevelHighAndDoesNotContainLatestHealthCertificate() {
+  void isValid_ReturnsFalse_WhenRiskLevelHighAndDoesNotContainLatestHealthCertificate() {
     notification.getPartOne().getVeterinaryInformation().getAccompanyingDocuments().get(0).
       setDocumentType(DocumentType.AIR_WAYBILL);
     assertThat(validator.isValid(notification, null)).isFalse();
   }
 
   @Test
-  public void isValid_ReturnsFalse_WhenRiskLevelMediumAndDoesNotContainLatestHealthCertificate() {
+  void isValid_ReturnsFalse_WhenRiskLevelMediumAndDoesNotContainLatestHealthCertificate() {
     notification.getJourneyRiskCategorisation().setRiskLevel(RISK_LEVEL_MEDIUM);
     notification.getPartOne().getVeterinaryInformation().setAccompanyingDocuments(null);
     assertThat(validator.isValid(notification, null)).isFalse();
   }
 
   @Test
-  public void isValid_ReturnsFalse_WhenRiskLevelMediumAndDocTypeIsNotLatestHealthCert() {
+  void isValid_ReturnsFalse_WhenRiskLevelMediumAndDocTypeIsNotLatestHealthCert() {
     notification.getJourneyRiskCategorisation().setRiskLevel(RISK_LEVEL_MEDIUM);
     notification.getPartOne().getVeterinaryInformation().getAccompanyingDocuments().get(0)
       .setDocumentType(DocumentType.AIR_WAYBILL);
@@ -74,7 +74,7 @@ public class LatestVeterinaryHealthCertificateRequiredValidatorTest {
   }
 
   @Test
-  public void isValid_ReturnsTrue_WhenRiskLevelLowAndContainsLatestHealthCertificate() {
+  void isValid_ReturnsTrue_WhenRiskLevelLowAndContainsLatestHealthCertificate() {
     notification.getJourneyRiskCategorisation().setRiskLevel(RISK_LEVEL_LOW);
     notification.getPartOne().getVeterinaryInformation().getAccompanyingDocuments().get(0)
             .setDocumentReference("LatestHealthCertificate");
@@ -82,7 +82,7 @@ public class LatestVeterinaryHealthCertificateRequiredValidatorTest {
   }
 
   @Test
-  public void isValid_ReturnsTrue_WhenRiskLevelLowAndDoesNotContainLatestHealthCertificate() {
+  void isValid_ReturnsTrue_WhenRiskLevelLowAndDoesNotContainLatestHealthCertificate() {
     notification.getJourneyRiskCategorisation().setRiskLevel(RISK_LEVEL_LOW);
     notification.getPartOne().getVeterinaryInformation().getAccompanyingDocuments().get(0).
             setDocumentType(DocumentType.AIR_WAYBILL);
@@ -90,26 +90,26 @@ public class LatestVeterinaryHealthCertificateRequiredValidatorTest {
   }
 
   @Test
-  public void isValid_ReturnsTrue_WhenRiskLevelNotSetAndContainsLatestHealthCertificate() {
+  void isValid_ReturnsTrue_WhenRiskLevelNotSetAndContainsLatestHealthCertificate() {
     notification.getJourneyRiskCategorisation().setRiskLevel(null);
     assertThat(validator.isValid(notification, null)).isTrue();
   }
 
   @Test
-  public void isValid_ReturnsTrue_WhenRiskLevelNotSetAndDoesNotContainLatestHealthCertificate() {
+  void isValid_ReturnsTrue_WhenRiskLevelNotSetAndDoesNotContainLatestHealthCertificate() {
     notification.getJourneyRiskCategorisation().setRiskLevel(null);
     notification.getPartOne().getVeterinaryInformation().setAccompanyingDocuments(null);
     assertThat(validator.isValid(notification, null)).isTrue();
   }
 
   @Test
-  public void isValid_ReturnsTrue_WhenNoJourneyRiskCategorisationObjectExistsAndContainsLatestHealthCertificate() {
+  void isValid_ReturnsTrue_WhenNoJourneyRiskCategorisationObjectExistsAndContainsLatestHealthCertificate() {
     notification.setJourneyRiskCategorisation(null);
     assertThat(validator.isValid(notification, null)).isTrue();
   }
 
   @Test
-  public void isValid_ReturnsFalse_WhenRiskLevelIsHighAndNoVeterinaryInformationExists() {
+  void isValid_ReturnsFalse_WhenRiskLevelIsHighAndNoVeterinaryInformationExists() {
     notification.getPartOne().setVeterinaryInformation(null);
     assertThat(validator.isValid(notification, null)).isFalse();
   }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/MinCommodityGrossWeightValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/MinCommodityGrossWeightValidatorTest.java
@@ -1,56 +1,55 @@
 package uk.gov.defra.tracesx.notificationschema.validation.annotations;
 
-import static junit.framework.TestCase.assertFalse;
-import static junit.framework.TestCase.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.math.BigDecimal;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import uk.gov.defra.tracesx.notificationschema.representation.Commodities;
 
-public class MinCommodityGrossWeightValidatorTest {
+class MinCommodityGrossWeightValidatorTest {
 
   private Commodities commodities;
   private MinCommoditiesGrossWeightValidator validator;
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     commodities = new Commodities();
     validator = new MinCommoditiesGrossWeightValidator();
   }
 
   @Test
-  public void validatorReturnsTrueIfNullPassed() {
-    assertTrue(validator.isValid(null, null));
+  void validatorReturnsTrueIfNullPassed() {
+    assertThat(validator.isValid(null, null)).isTrue();
   }
 
   @Test
-  public void validatorReturnsTrueIfGrossWeightHigherThanNetWeight() {
+  void validatorReturnsTrueIfGrossWeightHigherThanNetWeight() {
     commodities.setTotalNetWeight(new BigDecimal("10"));
     commodities.setTotalGrossWeight(new BigDecimal("15"));
 
-    assertTrue(validator.isValid(commodities, null));
+    assertThat(validator.isValid(commodities, null)).isTrue();
   }
 
   @Test
-  public void validatorReturnsFalseIfGrossWeightLowerThanNetWeight() {
+  void validatorReturnsFalseIfGrossWeightLowerThanNetWeight() {
     commodities.setTotalNetWeight(new BigDecimal("15"));
     commodities.setTotalGrossWeight(new BigDecimal("10"));
 
-    assertFalse(validator.isValid(commodities, null));
+    assertThat(validator.isValid(commodities, null)).isFalse();
   }
 
   @Test
-  public void validatorReturnsTrueIfTotalNetWeightIsNull() {
+  void validatorReturnsTrueIfTotalNetWeightIsNull() {
     commodities.setTotalGrossWeight(new BigDecimal("10"));
 
-    assertTrue(validator.isValid(commodities, null));
+    assertThat(validator.isValid(commodities, null)).isTrue();
   }
 
   @Test
-  public void validatorReturnsTrueIfTotalGrossWeightIsNull() {
+  void validatorReturnsTrueIfTotalGrossWeightIsNull() {
     commodities.setTotalNetWeight(new BigDecimal("10"));
 
-    assertTrue(validator.isValid(commodities, null));
+    assertThat(validator.isValid(commodities, null)).isTrue();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/MinValueKeyDataPairValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/MinValueKeyDataPairValidatorTest.java
@@ -1,20 +1,19 @@
 package uk.gov.defra.tracesx.notificationschema.validation.annotations;
 
-import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.assertFalse;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.defra.tracesx.notificationschema.representation.ComplementParameterSetKeyDataPair;
 
-@RunWith(MockitoJUnitRunner.class)
-public class MinValueKeyDataPairValidatorTest {
+@ExtendWith(MockitoExtension.class)
+class MinValueKeyDataPairValidatorTest {
 
   @Mock
   private MinValueKeyDataPair mockKeyDataPair;
@@ -22,8 +21,8 @@ public class MinValueKeyDataPairValidatorTest {
   private MinValueKeyDataPairValidator validator;
   private List<ComplementParameterSetKeyDataPair> keyDataPairList;
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     validator = new MinValueKeyDataPairValidator();
     when(mockKeyDataPair.field()).thenReturn("number_package");
     keyDataPairList = new ArrayList<>();
@@ -31,12 +30,12 @@ public class MinValueKeyDataPairValidatorTest {
   }
 
   @Test
-  public void testKeyDataPairIsValidIfObjectPassedIsNull() {
-    assertTrue(validator.isValid(null, null));
+  void testKeyDataPairIsValidIfObjectPassedIsNull() {
+    assertThat(validator.isValid(null, null)).isTrue();
   }
 
   @Test
-  public void testNumPackagesIsInvalidIfNoMatchingFieldPresent() {
+  void testNumPackagesIsInvalidIfNoMatchingFieldPresent() {
     ComplementParameterSetKeyDataPair pair = new ComplementParameterSetKeyDataPair();
     pair.setKey("netweight");
     keyDataPairList.add(pair);
@@ -45,41 +44,41 @@ public class MinValueKeyDataPairValidatorTest {
     pair.setKey("type_package");
     keyDataPairList.add(pair);
 
-    assertFalse(validator.isValid(keyDataPairList, null));
+    assertThat(validator.isValid(keyDataPairList, null)).isFalse();
   }
 
   @Test
-  public void testNumPackagesIsInvalidIfDataValueCannotBeParsedToInteger() {
+  void testNumPackagesIsInvalidIfDataValueCannotBeParsedToInteger() {
     ComplementParameterSetKeyDataPair pair = new ComplementParameterSetKeyDataPair();
     pair.setKey("number_package");
     pair.setData("X");
     keyDataPairList.add(pair);
 
-    assertFalse(validator.isValid(keyDataPairList, null));
+    assertThat(validator.isValid(keyDataPairList, null)).isFalse();
   }
 
   @Test
-  public void testNumPackagesIsInvalidIfDataValueIsZero() {
+  void testNumPackagesIsInvalidIfDataValueIsZero() {
     ComplementParameterSetKeyDataPair pair = new ComplementParameterSetKeyDataPair();
     pair.setKey("number_package");
     pair.setData("0");
     keyDataPairList.add(pair);
 
-    assertFalse(validator.isValid(keyDataPairList, null));
+    assertThat(validator.isValid(keyDataPairList, null)).isFalse();
   }
 
   @Test
-  public void testNumPackagesIsValidIfDataValueIsOne() {
+  void testNumPackagesIsValidIfDataValueIsOne() {
     ComplementParameterSetKeyDataPair pair = new ComplementParameterSetKeyDataPair();
     pair.setKey("number_package");
     pair.setData("1");
     keyDataPairList.add(pair);
 
-    assertTrue(validator.isValid(keyDataPairList, null));
+    assertThat(validator.isValid(keyDataPairList, null)).isTrue();
   }
 
   @Test
-  public void testNetWeightIsValidIfDataValueIsDecimal() {
+  void testNetWeightIsValidIfDataValueIsDecimal() {
     when(mockKeyDataPair.field()).thenReturn("netweight");
     validator.initialize(mockKeyDataPair);
 
@@ -88,11 +87,11 @@ public class MinValueKeyDataPairValidatorTest {
     pair.setData("12.34");
     keyDataPairList.add(pair);
 
-    assertTrue(validator.isValid(keyDataPairList, null));
+    assertThat(validator.isValid(keyDataPairList, null)).isTrue();
   }
 
   @Test
-  public void testNetWeightIsValidIfDataValueIsInteger() {
+  void testNetWeightIsValidIfDataValueIsInteger() {
     when(mockKeyDataPair.field()).thenReturn("netweight");
     validator.initialize(mockKeyDataPair);
 
@@ -101,6 +100,6 @@ public class MinValueKeyDataPairValidatorTest {
     pair.setData("1");
     keyDataPairList.add(pair);
 
-    assertTrue(validator.isValid(keyDataPairList, null));
+    assertThat(validator.isValid(keyDataPairList, null)).isTrue();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/NotAcceptableCountryValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/NotAcceptableCountryValidatorTest.java
@@ -1,65 +1,64 @@
 package uk.gov.defra.tracesx.notificationschema.validation.annotations;
 
-import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.assertFalse;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import uk.gov.defra.tracesx.notificationschema.representation.Decision;
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.NotAcceptableReasonsEnum;
 
-public class NotAcceptableCountryValidatorTest {
+class NotAcceptableCountryValidatorTest {
 
   private NotAcceptableCountryValidator validator;
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     validator = new NotAcceptableCountryValidator();
   }
 
   @Test
-  public void testThatValidatorReturnsTrueIfNullPassed() {
-    assertTrue(validator.isValid(null, null));
+  void testThatValidatorReturnsTrueIfNullPassed() {
+    assertThat(validator.isValid(null, null)).isTrue();
   }
 
   @Test
-  public void testThatValidatorReturnsTrueIfConsignmentAcceptableReturnsNull() {
+  void testThatValidatorReturnsTrueIfConsignmentAcceptableReturnsNull() {
     Decision decision = new Decision();
 
-    assertTrue(validator.isValid(decision, null));
+    assertThat(validator.isValid(decision, null)).isTrue();
   }
 
   @Test
-  public void testThatValidatorReturnsTrueIfConsignmentAcceptableIsTrue() {
+  void testThatValidatorReturnsTrueIfConsignmentAcceptableIsTrue() {
     Decision decision = new Decision();
     decision.setConsignmentAcceptable(Boolean.TRUE);
 
-    assertTrue(validator.isValid(decision, null));
+    assertThat(validator.isValid(decision, null)).isTrue();
   }
 
   @Test
-  public void
+  void
   testThatValidatorReturnsTrueIfConsignmentAcceptableIsFalseAndNotAcceptableReasonsIsNull() {
     Decision decision = new Decision();
     decision.setConsignmentAcceptable(Boolean.FALSE);
 
-    assertTrue(validator.isValid(decision, null));
+    assertThat(validator.isValid(decision, null)).isTrue();
   }
 
   @Test
-  public void
+  void
   testThatValidatorReturnsTrueIfConsignmentAcceptableIsFalseAndNotAcceptableReasonsIsEmpty() {
     Decision decision = new Decision();
     decision.setConsignmentAcceptable(Boolean.FALSE);
     decision.setNotAcceptableReasons(new ArrayList<>());
 
-    assertTrue(validator.isValid(decision, null));
+    assertThat(validator.isValid(decision, null)).isTrue();
   }
 
   @Test
-  public void
+  void
   testThatValidatorReturnsFalseIfConsignmentAcceptableIsFalseAndNotAcceptableReasonsContainsCountryAndCountryIsNotSelected() {
     Decision decision = new Decision();
     decision.setConsignmentAcceptable(Boolean.FALSE);
@@ -67,6 +66,6 @@ public class NotAcceptableCountryValidatorTest {
     reasons.add(NotAcceptableReasonsEnum.NONAPPROVEDCOUNTRY);
     decision.setNotAcceptableReasons(reasons);
 
-    assertFalse(validator.isValid(decision, null));
+    assertThat(validator.isValid(decision, null)).isFalse();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/NotAcceptableEstablishmentValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/NotAcceptableEstablishmentValidatorTest.java
@@ -1,39 +1,38 @@
 package uk.gov.defra.tracesx.notificationschema.validation.annotations;
 
-import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.assertFalse;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import uk.gov.defra.tracesx.notificationschema.representation.Decision;
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.NotAcceptableReasonsEnum;
 
-public class NotAcceptableEstablishmentValidatorTest {
+class NotAcceptableEstablishmentValidatorTest {
 
   private NotAcceptableEstablishmentValidator validator;
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     validator = new NotAcceptableEstablishmentValidator();
   }
 
   @Test
-  public void givenDecisionIsNull_whenICallIsValid_thenResultIsTrue() {
-    assertTrue(validator.isValid(null, null));
+  void givenDecisionIsNull_whenICallIsValid_thenResultIsTrue() {
+    assertThat(validator.isValid(null, null)).isTrue();
   }
 
   @Test
-  public void givenConsignmentIsAcceptable_whenICallIsValid_thenResultIsTrue() {
+  void givenConsignmentIsAcceptable_whenICallIsValid_thenResultIsTrue() {
     Decision decision = new Decision();
     decision.setConsignmentAcceptable(true);
 
-    assertTrue(validator.isValid(decision, null));
+    assertThat(validator.isValid(decision, null)).isTrue();
   }
 
   @Test
-  public void givenNoNonApprovedEstablishmentName_whenICallIsValid_thenResultIsFalse() {
+  void givenNoNonApprovedEstablishmentName_whenICallIsValid_thenResultIsFalse() {
     Decision decision = new Decision();
 
     List<NotAcceptableReasonsEnum> notAcceptableReasons = new ArrayList<>();
@@ -42,11 +41,11 @@ public class NotAcceptableEstablishmentValidatorTest {
     decision.setConsignmentAcceptable(false);
     decision.setNotAcceptableReasons(notAcceptableReasons);
 
-    assertFalse(validator.isValid(decision, null));
+    assertThat(validator.isValid(decision, null)).isFalse();
   }
 
   @Test
-  public void givenANonApprovedEstablishmentName_whenICallIsValid_thenResultIsFalse() {
+  void givenANonApprovedEstablishmentName_whenICallIsValid_thenResultIsFalse() {
     Decision decision = new Decision();
 
     List<NotAcceptableReasonsEnum> notAcceptableReasons = new ArrayList<>();
@@ -56,11 +55,11 @@ public class NotAcceptableEstablishmentValidatorTest {
     decision.setNotAcceptableReasons(notAcceptableReasons);
     decision.setNotAcceptableEstablishment("Establishment name");
 
-    assertTrue(validator.isValid(decision, null));
+    assertThat(validator.isValid(decision, null)).isTrue();
   }
 
   @Test
-  public void givenNonApprovedEstablishmentIsNotANotAcceptableReason_whenICallIsValid_thenResultIsTrue() {
+  void givenNonApprovedEstablishmentIsNotANotAcceptableReason_whenICallIsValid_thenResultIsTrue() {
     Decision decision = new Decision();
 
     List<NotAcceptableReasonsEnum> notAcceptableReasons = new ArrayList<>();
@@ -68,6 +67,6 @@ public class NotAcceptableEstablishmentValidatorTest {
     decision.setConsignmentAcceptable(false);
     decision.setNotAcceptableReasons(notAcceptableReasons);
 
-    assertTrue(validator.isValid(decision, null));
+    assertThat(validator.isValid(decision, null)).isTrue();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/NotAcceptableOtherReasonValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/NotAcceptableOtherReasonValidatorTest.java
@@ -1,51 +1,50 @@
 package uk.gov.defra.tracesx.notificationschema.validation.annotations;
 
-import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.assertFalse;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import uk.gov.defra.tracesx.notificationschema.representation.Decision;
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.NotAcceptableReasonsEnum;
 
-public class NotAcceptableOtherReasonValidatorTest {
+class NotAcceptableOtherReasonValidatorTest {
 
   private NotAcceptableOtherReasonValidator validator;
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     validator = new NotAcceptableOtherReasonValidator();
   }
 
   @Test
-  public void givenDecisionIsNull_whenICallIsValid_thenResultIsTrue() {
-    assertTrue(validator.isValid(null, null));
+  void givenDecisionIsNull_whenICallIsValid_thenResultIsTrue() {
+    assertThat(validator.isValid(null, null)).isTrue();
   }
 
   @Test
-  public void givenConsignmentIsAcceptable_whenICallIsValid_thenResultIsTrue() {
+  void givenConsignmentIsAcceptable_whenICallIsValid_thenResultIsTrue() {
     Decision decision = new Decision();
     decision.setConsignmentAcceptable(true);
 
-    assertTrue(validator.isValid(decision, null));
+    assertThat(validator.isValid(decision, null)).isTrue();
   }
 
   @Test
-  public void givenNoNotAcceptableOtherReason_whenICallIsValid_thenResultIsFalse() {
+  void givenNoNotAcceptableOtherReason_whenICallIsValid_thenResultIsFalse() {
     Decision decision = new Decision();
     List<NotAcceptableReasonsEnum> notAcceptableReasons = Collections
         .singletonList(NotAcceptableReasonsEnum.OTHER);
     decision.setNotAcceptableReasons(notAcceptableReasons);
     decision.setConsignmentAcceptable(false);
 
-    assertFalse(validator.isValid(decision, null));
+    assertThat(validator.isValid(decision, null)).isFalse();
   }
 
   @Test
-  public void givenANotAcceptableOtherReason_whenICallIsValid_thenResultIsTrue() {
+  void givenANotAcceptableOtherReason_whenICallIsValid_thenResultIsTrue() {
     Decision decision = new Decision();
 
     List<NotAcceptableReasonsEnum> notAcceptableReasons = new ArrayList<>();
@@ -55,6 +54,6 @@ public class NotAcceptableOtherReasonValidatorTest {
     decision.setNotAcceptableReasons(notAcceptableReasons);
     decision.setNotAcceptableOtherReason("Other reason");
 
-    assertTrue(validator.isValid(decision, null));
+    assertThat(validator.isValid(decision, null)).isTrue();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/NotAcceptableReasonValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/NotAcceptableReasonValidatorTest.java
@@ -1,65 +1,64 @@
 package uk.gov.defra.tracesx.notificationschema.validation.annotations;
 
-import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.assertFalse;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import uk.gov.defra.tracesx.notificationschema.representation.Decision;
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.NotAcceptableReasonsEnum;
 
-public class NotAcceptableReasonValidatorTest {
+class NotAcceptableReasonValidatorTest {
 
   private NotAcceptableReasonValidator validator;
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     validator = new NotAcceptableReasonValidator();
   }
 
   @Test
-  public void testThatValidatorReturnsTrueIfNullPassed() {
-    assertTrue(validator.isValid(null, null));
+  void testThatValidatorReturnsTrueIfNullPassed() {
+    assertThat(validator.isValid(null, null)).isTrue();
   }
 
   @Test
-  public void testThatValidatorReturnsTrueIfConsignmentAcceptableReturnsNull() {
+  void testThatValidatorReturnsTrueIfConsignmentAcceptableReturnsNull() {
     Decision decision = new Decision();
 
-    assertTrue(validator.isValid(decision, null));
+    assertThat(validator.isValid(decision, null)).isTrue();
   }
 
   @Test
-  public void testThatValidatorReturnsTrueIfConsignmentAcceptableIsTrue() {
+  void testThatValidatorReturnsTrueIfConsignmentAcceptableIsTrue() {
     Decision decision = new Decision();
     decision.setConsignmentAcceptable(Boolean.TRUE);
 
-    assertTrue(validator.isValid(decision, null));
+    assertThat(validator.isValid(decision, null)).isTrue();
   }
 
   @Test
-  public void
+  void
   testThatValidatorReturnsFalseIfConsignmentAcceptableIsFalseAndNotAcceptableReasonsIsNull() {
     Decision decision = new Decision();
     decision.setConsignmentAcceptable(Boolean.FALSE);
 
-    assertFalse(validator.isValid(decision, null));
+    assertThat(validator.isValid(decision, null)).isFalse();
   }
 
   @Test
-  public void
+  void
   testThatValidatorReturnsFalseIfConsignmentAcceptableIsFalseAndNotAcceptableReasonsIsEmpty() {
     Decision decision = new Decision();
     decision.setConsignmentAcceptable(Boolean.FALSE);
     decision.setNotAcceptableReasons(new ArrayList<>());
 
-    assertFalse(validator.isValid(decision, null));
+    assertThat(validator.isValid(decision, null)).isFalse();
   }
 
   @Test
-  public void
+  void
   testThatValidatorReturnsTrueIfConsignmentAcceptableIsFalseAndNotAcceptableReasonsIsNotEmpty() {
     Decision decision = new Decision();
     decision.setConsignmentAcceptable(Boolean.FALSE);
@@ -67,6 +66,6 @@ public class NotAcceptableReasonValidatorTest {
     reasons.add(NotAcceptableReasonsEnum.ABSENCEADDITIONALGUARANTEES);
     decision.setNotAcceptableReasons(reasons);
 
-    assertTrue(validator.isValid(decision, null));
+    assertThat(validator.isValid(decision, null)).isTrue();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/NotNullCustomsReferenceNumberValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/NotNullCustomsReferenceNumberValidatorTest.java
@@ -1,44 +1,43 @@
 package uk.gov.defra.tracesx.notificationschema.validation.annotations;
 
-import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.assertFalse;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import uk.gov.defra.tracesx.notificationschema.representation.PartOne;
 
-public class NotNullCustomsReferenceNumberValidatorTest {
+class NotNullCustomsReferenceNumberValidatorTest {
 
   private PartOne partOne;
   private NotNullCustomsReferenceNumberValidator validator;
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     partOne = new PartOne();
     validator = new NotNullCustomsReferenceNumberValidator();
   }
 
   @Test
-  public void validatorReturnsFalse_ifNoPartOne() {
-    assertFalse(validator.isValid(null, null));
+  void validatorReturnsFalse_ifNoPartOne() {
+    assertThat(validator.isValid(null, null)).isFalse();
   }
 
   @Test
-  public void validatorReturnsFalse_ifNoCustomsReferenceNumber() {
-    assertFalse(validator.isValid(partOne, null));
+  void validatorReturnsFalse_ifNoCustomsReferenceNumber() {
+    assertThat(validator.isValid(partOne, null)).isFalse();
   }
 
   @Test
-  public void validatorReturnsTrue_ifCustomsReferenceNumber() {
+  void validatorReturnsTrue_ifCustomsReferenceNumber() {
     partOne.setCustomsReferenceNumber("ABCD1234");
 
-    assertTrue(validator.isValid(partOne, null));
+    assertThat(validator.isValid(partOne, null)).isTrue();
   }
 
   @Test
-  public void validatorReturnsFalse_ifEmptyCustomsReferenceNumber() {
+  void validatorReturnsFalse_ifEmptyCustomsReferenceNumber() {
     partOne.setCustomsReferenceNumber("");
 
-    assertFalse(validator.isValid(partOne, null));
+    assertThat(validator.isValid(partOne, null)).isFalse();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/NotNullKeyDataPairValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/NotNullKeyDataPairValidatorTest.java
@@ -1,20 +1,19 @@
 package uk.gov.defra.tracesx.notificationschema.validation.annotations;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.defra.tracesx.notificationschema.representation.ComplementParameterSetKeyDataPair;
 
-@RunWith(MockitoJUnitRunner.class)
-public class NotNullKeyDataPairValidatorTest {
+@ExtendWith(MockitoExtension.class)
+class NotNullKeyDataPairValidatorTest {
 
   @Mock
   private NotNullKeyDataPair mockKeyDataPair;
@@ -22,8 +21,8 @@ public class NotNullKeyDataPairValidatorTest {
   private NotNullKeyDataPairValidator validator;
   private List<ComplementParameterSetKeyDataPair> keyDataPairList;
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     validator = new NotNullKeyDataPairValidator();
     when(mockKeyDataPair.field()).thenReturn("type_package");
     keyDataPairList = new ArrayList<>();
@@ -31,12 +30,12 @@ public class NotNullKeyDataPairValidatorTest {
   }
 
   @Test
-  public void testKeyDataPairIsInValidIfObjectPassedIsNull() {
-    assertFalse(validator.isValid(null, null));
+  void testKeyDataPairIsInValidIfObjectPassedIsNull() {
+    assertThat(validator.isValid(null, null)).isFalse();
   }
 
   @Test
-  public void testTypePackageIsInvalidIfNoMatchingFieldPresent() {
+  void testTypePackageIsInvalidIfNoMatchingFieldPresent() {
     ComplementParameterSetKeyDataPair pair = new ComplementParameterSetKeyDataPair();
     pair.setKey("netweight");
     keyDataPairList.add(pair);
@@ -45,26 +44,26 @@ public class NotNullKeyDataPairValidatorTest {
     pair.setKey("number_package");
     keyDataPairList.add(pair);
 
-    assertFalse(validator.isValid(keyDataPairList, null));
+    assertThat(validator.isValid(keyDataPairList, null)).isFalse();
   }
 
   @Test
-  public void testTypePackageIsInValidIfDataValueIsEmpty() {
+  void testTypePackageIsInValidIfDataValueIsEmpty() {
     ComplementParameterSetKeyDataPair pair = new ComplementParameterSetKeyDataPair();
     pair.setKey("type_package");
     pair.setData("");
     keyDataPairList.add(pair);
 
-    assertFalse(validator.isValid(keyDataPairList, null));
+    assertThat(validator.isValid(keyDataPairList, null)).isFalse();
   }
 
   @Test
-  public void testTypePackageIsValidIfDataValueIsNotEmpty() {
+  void testTypePackageIsValidIfDataValueIsNotEmpty() {
     ComplementParameterSetKeyDataPair pair = new ComplementParameterSetKeyDataPair();
     pair.setKey("type_package");
     pair.setData("bag");
     keyDataPairList.add(pair);
 
-    assertTrue(validator.isValid(keyDataPairList, null));
+    assertThat(validator.isValid(keyDataPairList, null)).isTrue();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/NotNullPurposeExitBipValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/NotNullPurposeExitBipValidatorTest.java
@@ -1,34 +1,33 @@
 package uk.gov.defra.tracesx.notificationschema.validation.annotations;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.ForImportOrAdmissionEnum.DEFINITIVE_IMPORT;
 import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.PurposeGroupEnum.RE_IMPORT;
 import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.PurposeGroupEnum.TRANSIT_TO_3RD_COUNTRY;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.defra.tracesx.notificationschema.representation.PartOne;
 import uk.gov.defra.tracesx.notificationschema.representation.Purpose;
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.ForImportOrAdmissionEnum;
 
-@RunWith(MockitoJUnitRunner.class)
-public class NotNullPurposeExitBipValidatorTest {
+@ExtendWith(MockitoExtension.class)
+class NotNullPurposeExitBipValidatorTest {
 
   private NotNullPurposeExitBipValidator validator;
 
-  private PartOne partOne = new PartOne();
+  private final PartOne partOne = new PartOne();
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     validator = new NotNullPurposeExitBipValidator();
     partOne.setPurpose(new Purpose());
   }
 
   @Test
-  public void validatorShouldReturnTrueIfPurposeIsNull() {
+  void validatorShouldReturnTrueIfPurposeIsNull() {
     // Given
     partOne.setPurpose(null);
 
@@ -36,11 +35,11 @@ public class NotNullPurposeExitBipValidatorTest {
     boolean result = validator.isValid(partOne, null);
 
     // Then
-    assertTrue(result);
+    assertThat(result).isTrue();
   }
 
   @Test
-  public void validatorShouldReturnTrueIfForImportOrAdmissionIsTemporaryAdmissionHorsesAndPurposeExitBipIsNotNull() {
+  void validatorShouldReturnTrueIfForImportOrAdmissionIsTemporaryAdmissionHorsesAndPurposeExitBipIsNotNull() {
     // Given
     partOne.getPurpose().setForImportOrAdmission(ForImportOrAdmissionEnum.TEMPORARY_ADMISSION_HORSES);
     partOne.getPurpose().setExitBIP("Some BIP");
@@ -49,11 +48,11 @@ public class NotNullPurposeExitBipValidatorTest {
     boolean result = validator.isValid(partOne, null);
 
     // Then
-    assertTrue(result);
+    assertThat(result).isTrue();
   }
 
   @Test
-  public void validatorShouldReturnFalseIfForImportOrAdmissionIsTemporaryAdmissionHorsesAndPurposeExitBipIsNull() {
+  void validatorShouldReturnFalseIfForImportOrAdmissionIsTemporaryAdmissionHorsesAndPurposeExitBipIsNull() {
     // Given
     partOne.getPurpose().setForImportOrAdmission(ForImportOrAdmissionEnum.TEMPORARY_ADMISSION_HORSES);
     partOne.getPurpose().setExitBIP(null);
@@ -62,11 +61,11 @@ public class NotNullPurposeExitBipValidatorTest {
     boolean result = validator.isValid(partOne, null);
 
     // Then
-    assertFalse(result);
+    assertThat(result).isFalse();
   }
 
   @Test
-  public void validatorShouldReturnTrueIfForImportOrAdmissionIsHorsesReEntry() {
+  void validatorShouldReturnTrueIfForImportOrAdmissionIsHorsesReEntry() {
     // Given
     partOne.getPurpose().setForImportOrAdmission(ForImportOrAdmissionEnum.HORSES_RE_ENTRY);
 
@@ -74,11 +73,11 @@ public class NotNullPurposeExitBipValidatorTest {
     boolean result = validator.isValid(partOne, null);
 
     // Then
-    assertTrue(result);
+    assertThat(result).isTrue();
   }
 
   @Test
-  public void isValid_ReturnsTrue_WhenForImportOrAdmissionIsDefinitiveImport() {
+  void isValid_ReturnsTrue_WhenForImportOrAdmissionIsDefinitiveImport() {
     // Given
     partOne.getPurpose().setForImportOrAdmission(DEFINITIVE_IMPORT);
 
@@ -86,11 +85,11 @@ public class NotNullPurposeExitBipValidatorTest {
     boolean result = validator.isValid(partOne, null);
 
     // Then
-    assertTrue(result);
+    assertThat(result).isTrue();
   }
 
   @Test
-  public void isValid_ReturnsFalse_WhenPurposeGroupTransitToThirdCountryAndPurposeExitBipIsNull() {
+  void isValid_ReturnsFalse_WhenPurposeGroupTransitToThirdCountryAndPurposeExitBipIsNull() {
     // Given
     partOne.getPurpose().setPurposeGroup(TRANSIT_TO_3RD_COUNTRY);
     partOne.getPurpose().setExitBIP(null);
@@ -99,11 +98,11 @@ public class NotNullPurposeExitBipValidatorTest {
     boolean result = validator.isValid(partOne, null);
 
     // Then
-    assertFalse(result);
+    assertThat(result).isFalse();
   }
 
   @Test
-  public void isValid_ReturnsTrue_WhenPurposeGroupTransitToThirdCountryAndPurposeExitBipNotNull() {
+  void isValid_ReturnsTrue_WhenPurposeGroupTransitToThirdCountryAndPurposeExitBipNotNull() {
     // Given
     partOne.getPurpose().setPurposeGroup(TRANSIT_TO_3RD_COUNTRY);
     partOne.getPurpose().setExitBIP("Exit Bip");
@@ -112,11 +111,11 @@ public class NotNullPurposeExitBipValidatorTest {
     boolean result = validator.isValid(partOne, null);
 
     // Then
-    assertTrue(result);
+    assertThat(result).isTrue();
   }
 
   @Test
-  public void isValid_ReturnsTrue_WhenPurposeGroupNotTransitToThirdCountry() {
+  void isValid_ReturnsTrue_WhenPurposeGroupNotTransitToThirdCountry() {
     // Given
     partOne.getPurpose().setPurposeGroup(RE_IMPORT);
 
@@ -124,6 +123,6 @@ public class NotNullPurposeExitBipValidatorTest {
     boolean result = validator.isValid(partOne, null);
 
     // Then
-    assertTrue(result);
+    assertThat(result).isTrue();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/NotNullTemporaryExitBipValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/NotNullTemporaryExitBipValidatorTest.java
@@ -9,23 +9,16 @@ import static uk.gov.defra.tracesx.notificationschema.representation.enumeration
 import jakarta.validation.ConstraintValidatorContext;
 import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorContext;
 import org.hibernate.validator.constraintvalidation.HibernateConstraintViolationBuilder;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.theories.DataPoints;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.defra.tracesx.notificationschema.representation.Decision;
-import uk.gov.defra.tracesx.notificationschema.representation.enumeration.DecisionEnum;
 
-@RunWith(MockitoJUnitRunner.class)
-public class NotNullTemporaryExitBipValidatorTest {
+@ExtendWith(MockitoExtension.class)
+class NotNullTemporaryExitBipValidatorTest {
 
-  @DataPoints("Other decisions")
-  public static final DecisionEnum[] decisions =
-      new DecisionEnum[]{
-          ACCEPTABLE_FOR_TEMPORARY_IMPORT
-      };
   @Mock
   HibernateConstraintValidatorContext hibernateConstraintValidatorContextMock;
   @Mock
@@ -37,11 +30,13 @@ public class NotNullTemporaryExitBipValidatorTest {
   private NotNullTemporaryExitBipValidator validator;
   private Decision decision;
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     validator = new NotNullTemporaryExitBipValidator();
     this.decision = Decision.builder().build();
+  }
 
+  void validatorMocking() {
     when(constraintValidatorContextMock
         .unwrap(HibernateConstraintValidatorContext.class))
         .thenReturn(hibernateConstraintValidatorContextMock);
@@ -55,24 +50,25 @@ public class NotNullTemporaryExitBipValidatorTest {
   }
 
   @Test
-  public void isValid_ReturnsTrue_WhenNoPartTwo() {
+  void isValid_ReturnsTrue_WhenNoPartTwo() {
     assertThat(validator.isValid(null, constraintValidatorContextMock)).isTrue();
   }
 
   @Test
-  public void isValid_ReturnsTrue_WhenNoDecision() {
+  void isValid_ReturnsTrue_WhenNoDecision() {
     assertThat(validator.isValid(decision, constraintValidatorContextMock)).isTrue();
   }
 
   @Test
-  public void isValid_ReturnsTrue_WhenDecisionIsNull() {
+  void isValid_ReturnsTrue_WhenDecisionIsNull() {
     decision.setDecision(null);
 
     assertThat(validator.isValid(decision, constraintValidatorContextMock)).isTrue();
   }
 
   @Test
-  public void isValid_ReturnsFalse_WhenTemporaryExitBipIsNull() {
+  void isValid_ReturnsFalse_WhenTemporaryExitBipIsNull() {
+    validatorMocking();
     decision.setDecision(ACCEPTABLE_FOR_TEMPORARY_IMPORT);
     decision.setTemporaryExitBip(null);
 
@@ -80,7 +76,7 @@ public class NotNullTemporaryExitBipValidatorTest {
   }
 
   @Test
-  public void isValid_ReturnsTrue_WhenTemporaryExitBipIsNullAndAcceptableForTransit() {
+  void isValid_ReturnsTrue_WhenTemporaryExitBipIsNullAndAcceptableForTransit() {
     decision.setDecision(ACCEPTABLE_FOR_TRANSIT);
     decision.setTemporaryExitBip(null);
 
@@ -88,7 +84,8 @@ public class NotNullTemporaryExitBipValidatorTest {
   }
 
   @Test
-  public void isValid_ReturnsFalse_WhenTemporaryExitBipIsEmptyString() {
+  void isValid_ReturnsFalse_WhenTemporaryExitBipIsEmptyString() {
+    validatorMocking();
     decision.setDecision(ACCEPTABLE_FOR_TEMPORARY_IMPORT);
     decision.setTemporaryExitBip("");
 
@@ -96,7 +93,7 @@ public class NotNullTemporaryExitBipValidatorTest {
   }
 
   @Test
-  public void isValid_ReturnsTrue_WhenDecisionIsAcceptableForTemporaryImport() {
+  void isValid_ReturnsTrue_WhenDecisionIsAcceptableForTemporaryImport() {
     decision.setDecision(ACCEPTABLE_FOR_TEMPORARY_IMPORT);
     decision.setTemporaryExitBip("GBPHD1");
 

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/NotNullTranshipmentBipValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/NotNullTranshipmentBipValidatorTest.java
@@ -9,29 +9,20 @@ import static uk.gov.defra.tracesx.notificationschema.representation.enumeration
 import jakarta.validation.ConstraintValidatorContext;
 import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorContext;
 import org.hibernate.validator.constraintvalidation.HibernateConstraintViolationBuilder;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.theories.DataPoints;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.defra.tracesx.notificationschema.representation.Decision;
-import uk.gov.defra.tracesx.notificationschema.representation.enumeration.DecisionEnum;
 
-@RunWith(MockitoJUnitRunner.class)
-public class NotNullTranshipmentBipValidatorTest {
+@ExtendWith(MockitoExtension.class)
+class NotNullTranshipmentBipValidatorTest {
 
-  @DataPoints("Other decisions")
-  public static final DecisionEnum[] decisions =
-      new DecisionEnum[]{
-          ACCEPTABLE_FOR_TRANSHIPMENT
-      };
   @Mock
   HibernateConstraintValidatorContext hibernateConstraintValidatorContextMock;
   @Mock
   ConstraintValidatorContext constraintValidatorContextMock;
-  @Mock
-  ConstraintValidatorContext.ConstraintViolationBuilder constraintViolationBuilderMock;
   @Mock
   HibernateConstraintViolationBuilder hibernateConstraintViolationBuilder;
   @Mock
@@ -39,11 +30,13 @@ public class NotNullTranshipmentBipValidatorTest {
   private NotNullTranshipmentBipValidator validator;
   private Decision decision;
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     validator = new NotNullTranshipmentBipValidator();
     this.decision = Decision.builder().build();
+  }
 
+  void validatorMocking() {
     when(constraintValidatorContextMock
         .unwrap(HibernateConstraintValidatorContext.class))
         .thenReturn(hibernateConstraintValidatorContextMock);
@@ -57,24 +50,25 @@ public class NotNullTranshipmentBipValidatorTest {
   }
 
   @Test
-  public void isValid_ReturnsTrue_WhenNoPartTwo() {
+  void isValid_ReturnsTrue_WhenNoPartTwo() {
     assertThat(validator.isValid(null, constraintValidatorContextMock)).isTrue();
   }
 
   @Test
-  public void isValid_ReturnsTrue_WhenNoDecision() {
+  void isValid_ReturnsTrue_WhenNoDecision() {
     assertThat(validator.isValid(decision, constraintValidatorContextMock)).isTrue();
   }
 
   @Test
-  public void isValid_ReturnsTrue_WhenDecisionIsNull() {
+  void isValid_ReturnsTrue_WhenDecisionIsNull() {
     decision.setDecision(null);
 
     assertThat(validator.isValid(decision, constraintValidatorContextMock)).isTrue();
   }
 
   @Test
-  public void isValid_ReturnsFalse_WhenTranshipmentBipIsNull() {
+  void isValid_ReturnsFalse_WhenTranshipmentBipIsNull() {
+    validatorMocking();
     decision.setDecision(ACCEPTABLE_FOR_TRANSHIPMENT);
     decision.setTranshipmentBip(null);
 
@@ -82,7 +76,7 @@ public class NotNullTranshipmentBipValidatorTest {
   }
 
   @Test
-  public void isValid_ReturnsTrue_WhenTranshipmentBipIsNullAndAcceptableForTransit() {
+  void isValid_ReturnsTrue_WhenTranshipmentBipIsNullAndAcceptableForTransit() {
     decision.setDecision(ACCEPTABLE_FOR_TRANSIT);
     decision.setTranshipmentBip(null);
 
@@ -90,7 +84,8 @@ public class NotNullTranshipmentBipValidatorTest {
   }
 
   @Test
-  public void isValid_ReturnsFalse_WhenTranshipmentBipIsEmptyString() {
+  void isValid_ReturnsFalse_WhenTranshipmentBipIsEmptyString() {
+    validatorMocking();
     decision.setDecision(ACCEPTABLE_FOR_TRANSHIPMENT);
     decision.setTranshipmentBip("");
 
@@ -98,7 +93,7 @@ public class NotNullTranshipmentBipValidatorTest {
   }
 
   @Test
-  public void isValid_ReturnsTrue_WhenDecisionIsAcceptableForTranshipment() {
+  void isValid_ReturnsTrue_WhenDecisionIsAcceptableForTranshipment() {
     decision.setDecision(ACCEPTABLE_FOR_TRANSHIPMENT);
     decision.setTranshipmentBip("GBPHD1");
 

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/NotNullTranshipmentThirdCountryValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/NotNullTranshipmentThirdCountryValidatorTest.java
@@ -9,23 +9,15 @@ import static uk.gov.defra.tracesx.notificationschema.representation.enumeration
 import jakarta.validation.ConstraintValidatorContext;
 import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorContext;
 import org.hibernate.validator.constraintvalidation.HibernateConstraintViolationBuilder;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.theories.DataPoints;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.defra.tracesx.notificationschema.representation.Decision;
-import uk.gov.defra.tracesx.notificationschema.representation.enumeration.DecisionEnum;
 
-@RunWith(MockitoJUnitRunner.class)
-public class NotNullTranshipmentThirdCountryValidatorTest {
-
-  @DataPoints("Other decisions")
-  public static final DecisionEnum[] decisions =
-      new DecisionEnum[]{
-          ACCEPTABLE_FOR_TRANSHIPMENT
-      };
+@ExtendWith(MockitoExtension.class)
+class NotNullTranshipmentThirdCountryValidatorTest {
   @Mock
   HibernateConstraintValidatorContext hibernateConstraintValidatorContextMock;
   @Mock
@@ -37,11 +29,13 @@ public class NotNullTranshipmentThirdCountryValidatorTest {
   private NotNullTranshipmentThirdCountryValidator validator;
   private Decision decision;
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     validator = new NotNullTranshipmentThirdCountryValidator();
     this.decision = Decision.builder().build();
+  }
 
+  void validatorMocking() {
     when(constraintValidatorContextMock
         .unwrap(HibernateConstraintValidatorContext.class))
         .thenReturn(hibernateConstraintValidatorContextMock);
@@ -55,24 +49,25 @@ public class NotNullTranshipmentThirdCountryValidatorTest {
   }
 
   @Test
-  public void isValid_ReturnsTrue_WhenNoPartTwo() {
+  void isValid_ReturnsTrue_WhenNoPartTwo() {
     assertThat(validator.isValid(null, constraintValidatorContextMock)).isTrue();
   }
 
   @Test
-  public void isValid_ReturnsTrue_WhenNoDecision() {
+  void isValid_ReturnsTrue_WhenNoDecision() {
     assertThat(validator.isValid(decision, constraintValidatorContextMock)).isTrue();
   }
 
   @Test
-  public void isValid_ReturnsTrue_WhenDecisionIsNull() {
+  void isValid_ReturnsTrue_WhenDecisionIsNull() {
     decision.setDecision(null);
 
     assertThat(validator.isValid(decision, constraintValidatorContextMock)).isTrue();
   }
 
   @Test
-  public void isValid_ReturnsFalse_WhenTranshipmentBipIsNull() {
+  void isValid_ReturnsFalse_WhenTranshipmentBipIsNull() {
+    validatorMocking();
     decision.setDecision(ACCEPTABLE_FOR_TRANSHIPMENT);
     decision.setTranshipmentThirdCountry(null);
 
@@ -80,7 +75,7 @@ public class NotNullTranshipmentThirdCountryValidatorTest {
   }
 
   @Test
-  public void isValid_ReturnsTrue_WhenTranshipmentThirdCountryIsNullAndAcceptableForTransit() {
+  void isValid_ReturnsTrue_WhenTranshipmentThirdCountryIsNullAndAcceptableForTransit() {
     decision.setDecision(ACCEPTABLE_FOR_TRANSIT);
     decision.setTranshipmentThirdCountry(null);
 
@@ -88,7 +83,8 @@ public class NotNullTranshipmentThirdCountryValidatorTest {
   }
 
   @Test
-  public void isValid_ReturnsFalse_WhenTranshipmentThirdCountryIsEmptyString() {
+  void isValid_ReturnsFalse_WhenTranshipmentThirdCountryIsEmptyString() {
+    validatorMocking();
     decision.setDecision(ACCEPTABLE_FOR_TRANSHIPMENT);
     decision.setTranshipmentThirdCountry("");
 
@@ -96,7 +92,7 @@ public class NotNullTranshipmentThirdCountryValidatorTest {
   }
 
   @Test
-  public void isValid_ReturnsTrue_WhenDecisionIsAcceptableForTranshipment() {
+  void isValid_ReturnsTrue_WhenDecisionIsAcceptableForTranshipment() {
     decision.setDecision(ACCEPTABLE_FOR_TRANSHIPMENT);
     decision.setTranshipmentThirdCountry("AF");
 

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/NotNullTransitDestinationThirdCountryValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/NotNullTransitDestinationThirdCountryValidatorTest.java
@@ -10,23 +10,15 @@ import static uk.gov.defra.tracesx.notificationschema.representation.enumeration
 import jakarta.validation.ConstraintValidatorContext;
 import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorContext;
 import org.hibernate.validator.constraintvalidation.HibernateConstraintViolationBuilder;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.theories.DataPoints;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.defra.tracesx.notificationschema.representation.Decision;
-import uk.gov.defra.tracesx.notificationschema.representation.enumeration.DecisionEnum;
 
-@RunWith(MockitoJUnitRunner.class)
-public class NotNullTransitDestinationThirdCountryValidatorTest {
-
-  @DataPoints("Other decisions")
-  public static final DecisionEnum[] decisions =
-      new DecisionEnum[]{
-          ACCEPTABLE_FOR_TRANSIT
-      };
+@ExtendWith(MockitoExtension.class)
+class NotNullTransitDestinationThirdCountryValidatorTest {
   @Mock
   HibernateConstraintValidatorContext hibernateConstraintValidatorContextMock;
   @Mock
@@ -38,11 +30,13 @@ public class NotNullTransitDestinationThirdCountryValidatorTest {
   private NotNullTransitDestinationThirdCountryValidator validator;
   private Decision decision;
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     validator = new NotNullTransitDestinationThirdCountryValidator();
     this.decision = Decision.builder().build();
+  }
 
+  void validatorMocking() {
     when(constraintValidatorContextMock
         .unwrap(HibernateConstraintValidatorContext.class))
         .thenReturn(hibernateConstraintValidatorContextMock);
@@ -56,24 +50,25 @@ public class NotNullTransitDestinationThirdCountryValidatorTest {
   }
 
   @Test
-  public void isValid_ReturnsTrue_WhenNoPartTwo() {
+  void isValid_ReturnsTrue_WhenNoPartTwo() {
     assertThat(validator.isValid(null, constraintValidatorContextMock)).isTrue();
   }
 
   @Test
-  public void isValid_ReturnsTrue_WhenNoDecision() {
+  void isValid_ReturnsTrue_WhenNoDecision() {
     assertThat(validator.isValid(decision, constraintValidatorContextMock)).isTrue();
   }
 
   @Test
-  public void isValid_ReturnsTrue_WhenDecisionIsNull() {
+  void isValid_ReturnsTrue_WhenDecisionIsNull() {
     decision.setDecision(null);
 
     assertThat(validator.isValid(decision, constraintValidatorContextMock)).isTrue();
   }
 
   @Test
-  public void isValid_ReturnsFalse_WhenTransitDestinationThirdCountryIsNull() {
+  void isValid_ReturnsFalse_WhenTransitDestinationThirdCountryIsNull() {
+    validatorMocking();
     decision.setDecision(ACCEPTABLE_FOR_TRANSIT);
     decision.setTransitDestinationThirdCountry(null);
 
@@ -81,7 +76,7 @@ public class NotNullTransitDestinationThirdCountryValidatorTest {
   }
 
   @Test
-  public void isValid_ReturnsTrue_WhenTransitDestinationThirdCountryIsNullAndAcceptableForTranshipment() {
+  void isValid_ReturnsTrue_WhenTransitDestinationThirdCountryIsNullAndAcceptableForTranshipment() {
     decision.setDecision(ACCEPTABLE_FOR_TRANSHIPMENT);
     decision.setTransitDestinationThirdCountry(null);
 
@@ -89,7 +84,8 @@ public class NotNullTransitDestinationThirdCountryValidatorTest {
   }
 
   @Test
-  public void isValid_ReturnsFalse_WhenTransitDestinationThirdCountryIsEmptyString() {
+  void isValid_ReturnsFalse_WhenTransitDestinationThirdCountryIsEmptyString() {
+    validatorMocking();
     decision.setDecision(ACCEPTABLE_FOR_TRANSIT);
     decision.setTransitDestinationThirdCountry("");
 
@@ -97,7 +93,7 @@ public class NotNullTransitDestinationThirdCountryValidatorTest {
   }
 
   @Test
-  public void isValid_ReturnsTrue_WhenDecisionIsAcceptableForTransit() {
+  void isValid_ReturnsTrue_WhenDecisionIsAcceptableForTransit() {
     decision.setDecision(ACCEPTABLE_FOR_TRANSIT);
     decision.setTransitDestinationThirdCountry("AF");
 

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/NotNullTransitExitBipValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/NotNullTransitExitBipValidatorTest.java
@@ -9,23 +9,16 @@ import static uk.gov.defra.tracesx.notificationschema.representation.enumeration
 import jakarta.validation.ConstraintValidatorContext;
 import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorContext;
 import org.hibernate.validator.constraintvalidation.HibernateConstraintViolationBuilder;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.theories.DataPoints;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.defra.tracesx.notificationschema.representation.Decision;
-import uk.gov.defra.tracesx.notificationschema.representation.enumeration.DecisionEnum;
 
-@RunWith(MockitoJUnitRunner.class)
-public class NotNullTransitExitBipValidatorTest {
+@ExtendWith(MockitoExtension.class)
+class NotNullTransitExitBipValidatorTest {
 
-  @DataPoints("Other decisions")
-  public static final DecisionEnum[] decisions =
-      new DecisionEnum[]{
-          ACCEPTABLE_FOR_TRANSIT
-      };
   @Mock
   HibernateConstraintValidatorContext hibernateConstraintValidatorContextMock;
   @Mock
@@ -37,11 +30,13 @@ public class NotNullTransitExitBipValidatorTest {
   private NotNullTransitExitBipValidator validator;
   private Decision decision;
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     validator = new NotNullTransitExitBipValidator();
     this.decision = Decision.builder().build();
+  }
 
+  void validatorMocking() {
     when(constraintValidatorContextMock
         .unwrap(HibernateConstraintValidatorContext.class))
         .thenReturn(hibernateConstraintValidatorContextMock);
@@ -55,24 +50,25 @@ public class NotNullTransitExitBipValidatorTest {
   }
 
   @Test
-  public void isValid_ReturnsTrue_WhenNoPartTwo() {
+  void isValid_ReturnsTrue_WhenNoPartTwo() {
     assertThat(validator.isValid(null, constraintValidatorContextMock)).isTrue();
   }
 
   @Test
-  public void isValid_ReturnsTrue_WhenNoDecision() {
+  void isValid_ReturnsTrue_WhenNoDecision() {
     assertThat(validator.isValid(decision, constraintValidatorContextMock)).isTrue();
   }
 
   @Test
-  public void isValid_ReturnsTrue_WhenDecisionIsNull() {
+  void isValid_ReturnsTrue_WhenDecisionIsNull() {
     decision.setDecision(null);
 
     assertThat(validator.isValid(decision, constraintValidatorContextMock)).isTrue();
   }
 
   @Test
-  public void isValid_ReturnsFalse_WhenTransitExitBipIsNull() {
+  void isValid_ReturnsFalse_WhenTransitExitBipIsNull() {
+    validatorMocking();
     decision.setDecision(ACCEPTABLE_FOR_TRANSIT);
     decision.setTransitExitBip(null);
 
@@ -80,7 +76,7 @@ public class NotNullTransitExitBipValidatorTest {
   }
 
   @Test
-  public void isValid_ReturnsTrue_WhenTransitExitBipIsNullAndAcceptableForTranshipment() {
+  void isValid_ReturnsTrue_WhenTransitExitBipIsNullAndAcceptableForTranshipment() {
     decision.setDecision(ACCEPTABLE_FOR_TRANSHIPMENT);
     decision.setTransitExitBip(null);
 
@@ -88,7 +84,8 @@ public class NotNullTransitExitBipValidatorTest {
   }
 
   @Test
-  public void isValid_ReturnsFalse_WhenTransitExitBipIsEmptyString() {
+  void isValid_ReturnsFalse_WhenTransitExitBipIsEmptyString() {
+    validatorMocking();
     decision.setDecision(ACCEPTABLE_FOR_TRANSIT);
     decision.setTransitExitBip("");
 
@@ -96,7 +93,7 @@ public class NotNullTransitExitBipValidatorTest {
   }
 
   @Test
-  public void isValid_ReturnsTrue_WhenDecisionIsAcceptableForTransit() {
+  void isValid_ReturnsTrue_WhenDecisionIsAcceptableForTransit() {
     decision.setDecision(ACCEPTABLE_FOR_TRANSIT);
     decision.setTransitExitBip("GBPHD1");
 

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/NotNullTransitThirdCountryValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/NotNullTransitThirdCountryValidatorTest.java
@@ -9,23 +9,16 @@ import static uk.gov.defra.tracesx.notificationschema.representation.enumeration
 import jakarta.validation.ConstraintValidatorContext;
 import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorContext;
 import org.hibernate.validator.constraintvalidation.HibernateConstraintViolationBuilder;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.theories.DataPoints;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.defra.tracesx.notificationschema.representation.Decision;
-import uk.gov.defra.tracesx.notificationschema.representation.enumeration.DecisionEnum;
 
-@RunWith(MockitoJUnitRunner.class)
-public class NotNullTransitThirdCountryValidatorTest {
+@ExtendWith(MockitoExtension.class)
+class NotNullTransitThirdCountryValidatorTest {
 
-  @DataPoints("Other decisions")
-  public static final DecisionEnum[] decisions =
-      new DecisionEnum[]{
-          ACCEPTABLE_FOR_TRANSIT
-      };
   @Mock
   HibernateConstraintValidatorContext hibernateConstraintValidatorContextMock;
   @Mock
@@ -37,11 +30,13 @@ public class NotNullTransitThirdCountryValidatorTest {
   private NotNullTransitThirdCountryValidator validator;
   private Decision decision;
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     validator = new NotNullTransitThirdCountryValidator();
     this.decision = Decision.builder().build();
+  }
 
+  void validatorMocking() {
     when(constraintValidatorContextMock
         .unwrap(HibernateConstraintValidatorContext.class))
         .thenReturn(hibernateConstraintValidatorContextMock);
@@ -55,24 +50,25 @@ public class NotNullTransitThirdCountryValidatorTest {
   }
 
   @Test
-  public void isValid_ReturnsTrue_WhenNoPartTwo() {
+  void isValid_ReturnsTrue_WhenNoPartTwo() {
     assertThat(validator.isValid(null, constraintValidatorContextMock)).isTrue();
   }
 
   @Test
-  public void isValid_ReturnsTrue_WhenNoDecision() {
+  void isValid_ReturnsTrue_WhenNoDecision() {
     assertThat(validator.isValid(decision, constraintValidatorContextMock)).isTrue();
   }
 
   @Test
-  public void isValid_ReturnsTrue_WhenDecisionIsNull() {
+  void isValid_ReturnsTrue_WhenDecisionIsNull() {
     decision.setDecision(null);
 
     assertThat(validator.isValid(decision, constraintValidatorContextMock)).isTrue();
   }
 
   @Test
-  public void isValid_ReturnsFalse_WhenTransitThirdCountryIsNull() {
+  void isValid_ReturnsFalse_WhenTransitThirdCountryIsNull() {
+    validatorMocking();
     decision.setDecision(ACCEPTABLE_FOR_TRANSIT);
     decision.setTransitThirdCountry(null);
 
@@ -80,7 +76,7 @@ public class NotNullTransitThirdCountryValidatorTest {
   }
 
   @Test
-  public void isValid_ReturnsTrue_WhenTransitThirdCountryIsNullAndAcceptableForTranshipment() {
+  void isValid_ReturnsTrue_WhenTransitThirdCountryIsNullAndAcceptableForTranshipment() {
     decision.setDecision(ACCEPTABLE_FOR_TRANSHIPMENT);
     decision.setTransitThirdCountry(null);
 
@@ -88,7 +84,8 @@ public class NotNullTransitThirdCountryValidatorTest {
   }
 
   @Test
-  public void isValid_ReturnsFalse_WhenTransitThirdCountryIsEmptyString() {
+  void isValid_ReturnsFalse_WhenTransitThirdCountryIsEmptyString() {
+    validatorMocking();
     decision.setDecision(ACCEPTABLE_FOR_TRANSIT);
     decision.setTransitThirdCountry("");
 
@@ -96,7 +93,7 @@ public class NotNullTransitThirdCountryValidatorTest {
   }
 
   @Test
-  public void isValid_ReturnsTrue_WhenDecisionIsAcceptableForTransit() {
+  void isValid_ReturnsTrue_WhenDecisionIsAcceptableForTransit() {
     decision.setDecision(ACCEPTABLE_FOR_TRANSIT);
     decision.setTransitThirdCountry("AF");
 

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/NotificationSealsContainersTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/NotificationSealsContainersTest.java
@@ -7,11 +7,11 @@ import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validation;
 import jakarta.validation.Validator;
 import org.hibernate.validator.messageinterpolation.ParameterMessageInterpolator;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import uk.gov.defra.tracesx.notificationschema.representation.NotificationSealsContainers;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationHighRiskNonChedppFieldValidation;
 
-public class NotificationSealsContainersTest {
+class NotificationSealsContainersTest {
 
   private static final Validator VALIDATOR =
       Validation.byDefaultProvider()
@@ -21,7 +21,7 @@ public class NotificationSealsContainersTest {
           .getValidator();
 
   @Test
-  public void validation_ReturnsNoViolations_WhenContainerNumberProvided() {
+  void validation_ReturnsNoViolations_WhenContainerNumberProvided() {
 
     NotificationSealsContainers sealsContainers = new NotificationSealsContainers();
     sealsContainers.setContainerNumber("12345675");
@@ -33,7 +33,7 @@ public class NotificationSealsContainersTest {
   }
 
   @Test
-  public void validation_ReturnsViolation_WhenContainerNumberIsNotProvided() {
+  void validation_ReturnsViolation_WhenContainerNumberIsNotProvided() {
 
     NotificationSealsContainers sealsContainers = new NotificationSealsContainers();
     Set<ConstraintViolation<NotificationSealsContainers>> violations = VALIDATOR.validate(

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/PhysicalCheckReasonNotDoneValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/PhysicalCheckReasonNotDoneValidatorTest.java
@@ -1,63 +1,62 @@
 package uk.gov.defra.tracesx.notificationschema.validation.annotations;
 
 import static java.lang.Boolean.FALSE;
-import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.assertFalse;
+import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.PhysicalCheckNotDoneReason.OTHER;
 import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.PhysicalCheckNotDoneReason.REDUCED_CHECKS_REGIME;
 import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.Result.NOT_DONE;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import uk.gov.defra.tracesx.notificationschema.representation.ConsignmentCheck;
 
-public class PhysicalCheckReasonNotDoneValidatorTest {
+class PhysicalCheckReasonNotDoneValidatorTest {
 
   private PhysicalCheckReasonNotDoneValidator validator;
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     validator = new PhysicalCheckReasonNotDoneValidator();
   }
 
   @Test
-  public void testThatValidatorReturnsTrueIfNullPassed() {
-    assertTrue(validator.isValid(null, null));
+  void testThatValidatorReturnsTrueIfNullPassed() {
+    assertThat(validator.isValid(null, null)).isTrue();
   }
 
   @Test
-  public void testThatValidatorReturnsTrueIfIsPhysicalCheckDoneReturnsNull() {
+  void testThatValidatorReturnsTrueIfIsPhysicalCheckDoneReturnsNull() {
     ConsignmentCheck check = new ConsignmentCheck();
 
-    assertTrue(validator.isValid(check, null));
+    assertThat(validator.isValid(check, null)).isTrue();
   }
 
   @Test
-  public void
+  void
   testThatValidatorReturnsFalseIfPhysicalCheckIsNotDoneAndPhysicalCheckNotDoneReasonIsNull() {
     ConsignmentCheck check = new ConsignmentCheck();
     check.setPhysicalCheckResult(NOT_DONE);
 
-    assertFalse(validator.isValid(check, null));
+    assertThat(validator.isValid(check, null)).isFalse();
   }
 
   @Test
-  public void
+  void
   testThatValidatorReturnsTrueIfPhysicalCheckIsNotDoneAndPhysicalCheckNotDoneReasonIsReducedChecksRegime() {
     ConsignmentCheck check = new ConsignmentCheck();
     check.setPhysicalCheckDone(FALSE);
     check.setPhysicalCheckNotDoneReason(REDUCED_CHECKS_REGIME);
 
-    assertTrue(validator.isValid(check, null));
+    assertThat(validator.isValid(check, null)).isTrue();
   }
 
   @Test
-  public void
+  void
   testThatValidatorReturnsTrueIfPhysicalCheckIsNotDoneAndPhysicalCheckNotDoneReasonIsOther() {
     ConsignmentCheck check = new ConsignmentCheck();
     check.setPhysicalCheckDone(FALSE);
     check.setPhysicalCheckNotDoneReason(OTHER);
 
-    assertTrue(validator.isValid(check, null));
+    assertThat(validator.isValid(check, null)).isTrue();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/PhysicalCheckResultTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/PhysicalCheckResultTest.java
@@ -1,84 +1,83 @@
 package uk.gov.defra.tracesx.notificationschema.validation.annotations;
 
-import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.assertFalse;
+import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.Result.NOT_SATISFACTORY;
 import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.Result.SATISFACTORY;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import uk.gov.defra.tracesx.notificationschema.representation.ConsignmentCheck;
 
-public class PhysicalCheckResultTest {
+class PhysicalCheckResultTest {
 
   private PhysicalCheckResultValidator validator;
   private ConsignmentCheck consignmentCheck;
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     validator = new PhysicalCheckResultValidator();
     consignmentCheck = new ConsignmentCheck();
   }
 
   @Test
-  public void testThatValidatorReturnsTrueIfNullPassed() {
-    assertTrue(validator.isValid(null, null));
+  void testThatValidatorReturnsTrueIfNullPassed() {
+    assertThat(validator.isValid(null, null)).isTrue();
   }
 
   @Test
-  public void testThatValidatorReturnsTrueIfPhysicalCheckResultReturnsNull() {
-    assertTrue(validator.isValid(new ConsignmentCheck(), null));
+  void testThatValidatorReturnsTrueIfPhysicalCheckResultReturnsNull() {
+    assertThat(validator.isValid(new ConsignmentCheck(), null)).isTrue();
   }
 
   @Test
-  public void
+  void
   testThatValidatorReturnsFalseIfPhysicalCheckResultReturnsTrueButPhysicalCheckResultReturnsNull() {
     consignmentCheck.setPhysicalCheckDone(true);
 
-    assertFalse(validator.isValid(consignmentCheck, null));
+    assertThat(validator.isValid(consignmentCheck, null)).isFalse();
   }
 
   @Test
-  public void
+  void
   testThatValidatorReturnsTrueIfPhysicalCheckResultReturnsFalseButPhysicalCheckResultReturnsNull() {
     consignmentCheck.setPhysicalCheckDone(false);
 
-    assertTrue(validator.isValid(consignmentCheck, null));
+    assertThat(validator.isValid(consignmentCheck, null)).isTrue();
   }
 
   @Test
-  public void
+  void
   testThatValidatorReturnsTrueIfPhysicalCheckResultReturnsTrueAndPhysicalCheckResultReturnsSatisfactory() {
     consignmentCheck.setPhysicalCheckDone(true);
     consignmentCheck.setPhysicalCheckResult(SATISFACTORY);
 
-    assertTrue(validator.isValid(consignmentCheck, null));
+    assertThat(validator.isValid(consignmentCheck, null)).isTrue();
   }
 
   @Test
-  public void
+  void
   testThatValidatorReturnsTrueIfPhysicalCheckResultReturnsTrueAndPhysicalCheckResultReturnsNotSatisfactory() {
     consignmentCheck.setPhysicalCheckDone(true);
     consignmentCheck.setPhysicalCheckResult(NOT_SATISFACTORY);
 
-    assertTrue(validator.isValid(consignmentCheck, null));
+    assertThat(validator.isValid(consignmentCheck, null)).isTrue();
   }
 
   @Test
-  public void
+  void
   testThatValidatorReturnsTrueIfPhysicalCheckResultReturnsFalseAndPhysicalCheckResultReturnsSatisfactory() {
     consignmentCheck.setPhysicalCheckDone(false);
     consignmentCheck.setPhysicalCheckResult(SATISFACTORY);
 
-    assertTrue(validator.isValid(consignmentCheck, null));
+    assertThat(validator.isValid(consignmentCheck, null)).isTrue();
   }
 
   @Test
-  public void
+  void
   testThatValidatorReturnsTrueIfPhysicalCheckResultReturnsFalseAndPhysicalCheckResultReturnsNotSatisfactory() {
     consignmentCheck.setPhysicalCheckDone(false);
     consignmentCheck.setPhysicalCheckResult(NOT_SATISFACTORY);
 
-    assertTrue(validator.isValid(consignmentCheck, null));
+    assertThat(validator.isValid(consignmentCheck, null)).isTrue();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/PhytosanitaryCertificateAttachmentRequiredValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/PhytosanitaryCertificateAttachmentRequiredValidatorTest.java
@@ -5,21 +5,21 @@ import static uk.gov.defra.tracesx.notificationschema.representation.enumeration
 import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.DocumentType.VETERINARY_HEALTH_CERTIFICATE;
 
 import java.util.UUID;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import uk.gov.defra.tracesx.notificationschema.representation.AccompanyingDocument;
 
-public class PhytosanitaryCertificateAttachmentRequiredValidatorTest {
+class PhytosanitaryCertificateAttachmentRequiredValidatorTest {
 
   private PhytosanitaryCertificateAttachmentRequiredValidator validator;
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     validator = new PhytosanitaryCertificateAttachmentRequiredValidator();
   }
 
   @Test
-  public void isValid_ReturnsTrue_WhenDocumentTypeNull() {
+  void isValid_ReturnsTrue_WhenDocumentTypeNull() {
     // Given
     AccompanyingDocument accompanyingDocument = AccompanyingDocument.builder().build();
 
@@ -31,7 +31,7 @@ public class PhytosanitaryCertificateAttachmentRequiredValidatorTest {
   }
 
   @Test
-  public void isValid_ReturnsTrue_WhenNotPhytosanitaryCertificate() {
+  void isValid_ReturnsTrue_WhenNotPhytosanitaryCertificate() {
     // Given
     AccompanyingDocument accompanyingDocument = AccompanyingDocument.builder()
         .documentType(VETERINARY_HEALTH_CERTIFICATE)
@@ -45,7 +45,7 @@ public class PhytosanitaryCertificateAttachmentRequiredValidatorTest {
   }
 
   @Test
-  public void isValid_ReturnsFalse_WhenAttachmentNotPresent() {
+  void isValid_ReturnsFalse_WhenAttachmentNotPresent() {
     // Given
     AccompanyingDocument accompanyingDocument = AccompanyingDocument.builder()
         .documentType(PHYTOSANITARY_CERTIFICATE)
@@ -59,7 +59,7 @@ public class PhytosanitaryCertificateAttachmentRequiredValidatorTest {
   }
 
   @Test
-  public void isValid_ReturnsTrue_WhenAttachmentPresent() {
+  void isValid_ReturnsTrue_WhenAttachmentPresent() {
     // Given
     AccompanyingDocument accompanyingDocument = AccompanyingDocument.builder()
         .documentType(PHYTOSANITARY_CERTIFICATE)

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/PhytosanitaryCertificateRequiredValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/PhytosanitaryCertificateRequiredValidatorTest.java
@@ -5,8 +5,8 @@ import static uk.gov.defra.tracesx.notificationschema.representation.enumeration
 
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import uk.gov.defra.tracesx.notificationschema.representation.AccompanyingDocument;
 import uk.gov.defra.tracesx.notificationschema.representation.Commodities;
 import uk.gov.defra.tracesx.notificationschema.representation.ComplementParameterSet;
@@ -14,7 +14,7 @@ import uk.gov.defra.tracesx.notificationschema.representation.ComplementParamete
 import uk.gov.defra.tracesx.notificationschema.representation.PartOne;
 import uk.gov.defra.tracesx.notificationschema.representation.VeterinaryInformation;
 
-public class PhytosanitaryCertificateRequiredValidatorTest {
+class PhytosanitaryCertificateRequiredValidatorTest {
 
   private static final String REGULATORY_AUTHORITY = "regulatory_authority";
   private static final String JOINT = "JOINT";
@@ -23,13 +23,13 @@ public class PhytosanitaryCertificateRequiredValidatorTest {
 
   private PhytosanitaryCertificateRequiredValidator validator;
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     validator = new PhytosanitaryCertificateRequiredValidator();
   }
 
   @Test
-  public void isValid_ReturnsTrue_WhenComplementParameterSetNull() {
+  void isValid_ReturnsTrue_WhenComplementParameterSetNull() {
     // Given
     PartOne partOne = PartOne.builder()
         .commodities(Commodities.builder().build())
@@ -43,7 +43,7 @@ public class PhytosanitaryCertificateRequiredValidatorTest {
   }
 
   @Test
-  public void isValid_ReturnsTrue_WhenKeyDataPairNull() {
+  void isValid_ReturnsTrue_WhenKeyDataPairNull() {
     // Given
     List<ComplementParameterSetKeyDataPair> keyDataPairs = new ArrayList<>();
     keyDataPairs.add(ComplementParameterSetKeyDataPair.builder().build());
@@ -65,7 +65,7 @@ public class PhytosanitaryCertificateRequiredValidatorTest {
   }
 
   @Test
-  public void isValid_ReturnsTrue_WhenKeyNull() {
+  void isValid_ReturnsTrue_WhenKeyNull() {
     // Given
     PartOne partOne = PartOne.builder()
         .commodities(Commodities.builder()
@@ -85,7 +85,7 @@ public class PhytosanitaryCertificateRequiredValidatorTest {
   }
 
   @Test
-  public void isValid_ReturnsTrue_WhenDataNull() {
+  void isValid_ReturnsTrue_WhenDataNull() {
     // Given
     PartOne partOne = PartOne.builder()
         .commodities(Commodities.builder()
@@ -107,7 +107,7 @@ public class PhytosanitaryCertificateRequiredValidatorTest {
   }
 
   @Test
-  public void isValid_ReturnsTrue_WhenNoPhsiOrJointCommodities() {
+  void isValid_ReturnsTrue_WhenNoPhsiOrJointCommodities() {
     // Given
     PartOne partOne = PartOne.builder()
         .commodities(Commodities.builder()
@@ -133,7 +133,7 @@ public class PhytosanitaryCertificateRequiredValidatorTest {
   }
 
   @Test
-  public void isValid_ReturnsFalse_WhenVeterinaryInformationNull() {
+  void isValid_ReturnsFalse_WhenVeterinaryInformationNull() {
     // Given
     PartOne partOne = PartOne.builder()
         .commodities(Commodities.builder()
@@ -156,7 +156,7 @@ public class PhytosanitaryCertificateRequiredValidatorTest {
   }
 
   @Test
-  public void isValid_ReturnsFalse_WhenAccompanyingDocumentsNull() {
+  void isValid_ReturnsFalse_WhenAccompanyingDocumentsNull() {
     // Given
     PartOne partOne = PartOne.builder()
         .commodities(Commodities.builder()
@@ -180,7 +180,7 @@ public class PhytosanitaryCertificateRequiredValidatorTest {
   }
 
   @Test
-  public void isValid_ReturnsFalse_WhenPhsiAndNoPhytosanitaryCertificate() {
+  void isValid_ReturnsFalse_WhenPhsiAndNoPhytosanitaryCertificate() {
     // Given
     PartOne partOne = PartOne.builder()
         .commodities(Commodities.builder()
@@ -206,7 +206,7 @@ public class PhytosanitaryCertificateRequiredValidatorTest {
   }
 
   @Test
-  public void isValid_ReturnsFalse_WhenJointAndNoPhytosanitaryCertificate() {
+  void isValid_ReturnsFalse_WhenJointAndNoPhytosanitaryCertificate() {
     // Given
     PartOne partOne = PartOne.builder()
         .commodities(Commodities.builder()
@@ -232,7 +232,7 @@ public class PhytosanitaryCertificateRequiredValidatorTest {
   }
 
   @Test
-  public void isValid_ReturnsTrue_WhenPhsiAndPhytosanitaryCertificate() {
+  void isValid_ReturnsTrue_WhenPhsiAndPhytosanitaryCertificate() {
     // Given
     PartOne partOne = PartOne.builder()
         .commodities(Commodities.builder()
@@ -259,7 +259,7 @@ public class PhytosanitaryCertificateRequiredValidatorTest {
   }
 
   @Test
-  public void isValid_ReturnsTrue_WhenJointAndPhytosanitaryCertifiate() {
+  void isValid_ReturnsTrue_WhenJointAndPhytosanitaryCertifiate() {
     // Given
     PartOne partOne = PartOne.builder()
         .commodities(Commodities.builder()

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/PortOfEntryAndPointOfEntryNotEmptyValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/PortOfEntryAndPointOfEntryNotEmptyValidatorTest.java
@@ -1,30 +1,30 @@
 package uk.gov.defra.tracesx.notificationschema.validation.annotations;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import uk.gov.defra.tracesx.notificationschema.representation.PartOne;
 
-@RunWith(MockitoJUnitRunner.class)
-public class PortOfEntryAndPointOfEntryNotEmptyValidatorTest {
+class PortOfEntryAndPointOfEntryNotEmptyValidatorTest {
 
   private PortOfEntryAndPointOfEntryNotEmptyValidator validator;
 
   private PartOne partOne;
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     validator = new PortOfEntryAndPointOfEntryNotEmptyValidator();
     partOne = new PartOne();
   }
 
   @Test
-  public void validatorShouldReturnFalseIfPartOneIsNull() {
+  void validatorShouldReturnFalseIfPartOneIsNull() {
     // Given
     partOne = null;
 
@@ -32,26 +32,20 @@ public class PortOfEntryAndPointOfEntryNotEmptyValidatorTest {
     boolean result = validator.isValid(partOne, null);
 
     // Then
-    assertFalse(result);
+    assertThat(result).isFalse();
   }
 
-  @Test
-  public void validatorShouldHandleTestCasesCorrectly() {
-    ArrayList<ValidatorTestCase> expectedResultTestCases = buildExpectedResults();
-    for (ValidatorTestCase nextExpectedResult: expectedResultTestCases) {
-      runAndCheckValidation(nextExpectedResult);
-    }
-  }
-
-  private void runAndCheckValidation(ValidatorTestCase validatorTestCase){
-    partOne.setPointOfEntry(validatorTestCase.pointOfEntry);
-    partOne.setPortOfEntry(validatorTestCase.portOfEntry);
+  @ParameterizedTest
+  @MethodSource("buildExpectedResults")
+  void validatorShouldHandleTestCasesCorrectly(ValidatorTestCase testCase) {
+    partOne.setPointOfEntry(testCase.pointOfEntry);
+    partOne.setPortOfEntry(testCase.portOfEntry);
     boolean result = validator.isValid(partOne, null);
 
-    assertEquals(validatorTestCase.expectedResult, result);
+    assertThat(result).isEqualTo(testCase.expectedResult);
   }
 
-  private ArrayList<ValidatorTestCase> buildExpectedResults(){
+  private static Stream<Arguments> buildExpectedResults() {
     ArrayList<ValidatorTestCase> list = new ArrayList<>();
     // Both set
     list.add(new ValidatorTestCase("PORT","POINT",true));
@@ -73,18 +67,11 @@ public class PortOfEntryAndPointOfEntryNotEmptyValidatorTest {
     list.add(new ValidatorTestCase(null,"POINT",false));
     list.add(new ValidatorTestCase("","POINT",false));
     list.add(new ValidatorTestCase("","POINT",false));
-    return list;
+    return list.stream().map(Arguments::of);
   }
 
-  private static class ValidatorTestCase {
-    public String portOfEntry;
-    public String pointOfEntry;
-    public boolean expectedResult;
+  private record ValidatorTestCase(String portOfEntry, String pointOfEntry,
+                                   boolean expectedResult) {
 
-    public ValidatorTestCase(String portOfEntry, String pointOfEntry, boolean expectedResult){
-      this.pointOfEntry = pointOfEntry;
-      this.portOfEntry = portOfEntry;
-      this.expectedResult = expectedResult;
-    }
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/PortOfExitAndExitBipNotEmptyValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/PortOfExitAndExitBipNotEmptyValidatorTest.java
@@ -1,32 +1,32 @@
 package uk.gov.defra.tracesx.notificationschema.validation.annotations;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import uk.gov.defra.tracesx.notificationschema.representation.PartOne;
 import uk.gov.defra.tracesx.notificationschema.representation.Purpose;
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.ForImportOrAdmissionEnum;
 
-@RunWith(MockitoJUnitRunner.class)
-public class PortOfExitAndExitBipNotEmptyValidatorTest {
+class PortOfExitAndExitBipNotEmptyValidatorTest {
 
   private PortOfExitAndExitBipNotEmptyValidator validator;
 
   private PartOne partOne;
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     validator = new PortOfExitAndExitBipNotEmptyValidator();
     partOne = new PartOne();
   }
 
   @Test
-  public void validatorShouldReturnTrueIfPartOneIsNull() {
+  void validatorShouldReturnTrueIfPartOneIsNull() {
     // Given
     partOne = null;
 
@@ -34,11 +34,11 @@ public class PortOfExitAndExitBipNotEmptyValidatorTest {
     boolean result = validator.isValid(partOne, null);
 
     // Then
-    assertTrue(result);
+    assertThat(result).isTrue();
   }
 
   @Test
-  public void validatorShouldReturnTrueIfPurposeIsNull() {
+  void validatorShouldReturnTrueIfPurposeIsNull() {
     // Given
     partOne = new PartOne();
 
@@ -46,32 +46,25 @@ public class PortOfExitAndExitBipNotEmptyValidatorTest {
     boolean result = validator.isValid(partOne, null);
 
     // Then
-    assertTrue(result);
+    assertThat(result).isTrue();
   }
 
-  @Test
-  public void validatorShouldHandleTestCasesCorrectly() {
-    ArrayList<ValidatorTestCase> expectedResultTestCases = buildExpectedResults();
-    for (ValidatorTestCase nextExpectedResult: expectedResultTestCases) {
-      runAndCheckValidation(nextExpectedResult);
-    }
-  }
-
-  private void runAndCheckValidation(ValidatorTestCase validatorTestCase){
-    partOne.setPortOfExit(validatorTestCase.portOfExit);
-    if (validatorTestCase.purpose != null) {
-      Purpose purpose = Purpose.builder().forImportOrAdmission(validatorTestCase.purpose).exitBIP(
-          validatorTestCase.exitBip).build();
+  @ParameterizedTest
+  @MethodSource("buildExpectedResults")
+  void validatorShouldHandleTestCasesCorrectly(ValidatorTestCase testCase) {
+    partOne.setPortOfExit(testCase.portOfExit);
+    if (testCase.purpose != null) {
+      Purpose purpose = Purpose.builder().forImportOrAdmission(testCase.purpose).exitBIP(
+          testCase.exitBip).build();
       partOne.setPurpose(purpose);
     }
 
-
     boolean result = validator.isValid(partOne, null);
 
-    assertEquals(validatorTestCase.expectedResult, result);
+    assertThat(result).isEqualTo(testCase.expectedResult);
   }
 
-  private ArrayList<ValidatorTestCase> buildExpectedResults(){
+  private static Stream<Arguments> buildExpectedResults(){
     ArrayList<ValidatorTestCase> list = new ArrayList<>();
 
     // Purpose set to Temporary admission horses
@@ -122,20 +115,10 @@ public class PortOfExitAndExitBipNotEmptyValidatorTest {
     list.add(new ValidatorTestCase("PORT",null,null,true));
     list.add(new ValidatorTestCase(null,null,null,true));
 
-    return list;
+    return list.stream().map(Arguments::of);
   }
 
-  private static class ValidatorTestCase {
-    public String portOfExit;
-    public String exitBip;
-    public boolean expectedResult;
-    ForImportOrAdmissionEnum purpose;
-
-    public ValidatorTestCase(String portOfExit, String exitBip, ForImportOrAdmissionEnum purpose, boolean expectedResult){
-      this.exitBip = exitBip;
-      this.portOfExit = portOfExit;
-      this.expectedResult = expectedResult;
-      this.purpose = purpose;
-    }
+  private record ValidatorTestCase(String portOfExit, String exitBip, ForImportOrAdmissionEnum purpose,
+                                   boolean expectedResult) {
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/QuantityImpValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/QuantityImpValidatorTest.java
@@ -1,27 +1,25 @@
 package uk.gov.defra.tracesx.notificationschema.validation.annotations;
 
-import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.assertFalse;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import jakarta.validation.ConstraintValidatorContext;
-import jakarta.validation.ConstraintValidatorContext.ConstraintViolationBuilder;
 import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorContext;
 import org.hibernate.validator.constraintvalidation.HibernateConstraintViolationBuilder;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.defra.tracesx.notificationschema.representation.ComplementParameterSet;
 import uk.gov.defra.tracesx.notificationschema.representation.ComplementParameterSetKeyDataPair;
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.ImpQuantityDataKeys;
 
-@RunWith(MockitoJUnitRunner.class)
-public class QuantityImpValidatorTest {
+@ExtendWith(MockitoExtension.class)
+class QuantityImpValidatorTest {
 
   private List<ComplementParameterSet> complementParameterSets;
   private QuantityImpValidator validator;
@@ -33,80 +31,91 @@ public class QuantityImpValidatorTest {
   @Mock
   HibernateConstraintViolationBuilder hibernateConstraintViolationBuilder;
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     validator = new QuantityImpValidator();
     complementParameterSets = new ArrayList<>();
+
+  }
+
+  void validatorMocking() {
     when(constraintValidatorContextMock.unwrap(HibernateConstraintValidatorContext.class))
         .thenReturn(hibernateConstraintValidatorContextMock);
 
     when(hibernateConstraintValidatorContextMock
         .buildConstraintViolationWithTemplate("Weight must be entered"))
         .thenReturn(hibernateConstraintViolationBuilder);
-
   }
 
   @Test
-  public void testThatValidatorReturnsTrue_IfNullPassed() {
-    assertTrue(validator.isValid(null, constraintValidatorContextMock));
+  void testThatValidatorReturnsTrue_IfNullPassed() {
+    assertThat(validator.isValid(null, constraintValidatorContextMock)).isTrue();
   }
 
   @Test
-  public void testThatValidatorReturnsTrue_IfSets_Empty() {
+  void testThatValidatorReturnsTrue_IfSets_Empty() {
     complementParameterSets = Collections.emptyList();
-    assertTrue(validator.isValid(complementParameterSets, constraintValidatorContextMock));
+    assertThat(validator.isValid(complementParameterSets, constraintValidatorContextMock)).isTrue();
   }
 
   @Test
-  public void testThatValidatorReturnsFalse_IfSets_ContainsNotExpectedValue() {
+  void testThatValidatorReturnsFalse_IfSets_ContainsNotExpectedValue() {
     addKeyDataPairValues("unknown", "unknown");
-    assertFalse(validator.isValid(complementParameterSets, constraintValidatorContextMock));
+    assertThat(
+        validator.isValid(complementParameterSets, constraintValidatorContextMock)).isFalse();
   }
 
   @Test
-  public void testThatValidatorReturnsFalse_IfSets_Contains1NullDataValue() {
+  void testThatValidatorReturnsFalse_IfSets_Contains1NullDataValue() {
     addKeyDataPairValues(ImpQuantityDataKeys.ANIMALS.getValue(), null);
-    assertFalse(validator.isValid(complementParameterSets, constraintValidatorContextMock));
+    assertThat(
+        validator.isValid(complementParameterSets, constraintValidatorContextMock)).isFalse();
   }
 
   @Test
-  public void testThatValidatorReturnsFalse_IfSets_Contains1BlankDataValue() {
+  void testThatValidatorReturnsFalse_IfSets_Contains1BlankDataValue() {
     addKeyDataPairValues(ImpQuantityDataKeys.ANIMALS.getValue(), "");
-    assertFalse(validator.isValid(complementParameterSets, constraintValidatorContextMock));
+    assertThat(
+        validator.isValid(complementParameterSets, constraintValidatorContextMock)).isFalse();
   }
 
   @Test
-  public void testThatValidatorReturnsFalse_IfSets_ContainsAnyNullDataValue() {
+  void testThatValidatorReturnsFalse_IfSets_ContainsAnyNullDataValue() {
     addKeyDataPairValues(ImpQuantityDataKeys.ANIMALS.getValue(), "1");
     addKeyDataPairValues(ImpQuantityDataKeys.ANIMALS.getValue(), null);
-    assertFalse(validator.isValid(complementParameterSets, constraintValidatorContextMock));
+    assertThat(
+        validator.isValid(complementParameterSets, constraintValidatorContextMock)).isFalse();
   }
 
   @Test
-  public void testThatValidatorReturnsFalse_IfSets_ContainsAnyBlankDataValue() {
+  void testThatValidatorReturnsFalse_IfSets_ContainsAnyBlankDataValue() {
     addKeyDataPairValues(ImpQuantityDataKeys.ANIMALS.getValue(), "");
     addKeyDataPairValues(ImpQuantityDataKeys.ANIMALS.getValue(), null);
-    assertFalse(validator.isValid(complementParameterSets, constraintValidatorContextMock));
+    assertThat(
+        validator.isValid(complementParameterSets, constraintValidatorContextMock)).isFalse();
   }
 
   @Test
-  public void testThatValidatorReturnsTrue_IfSets_ContainsCorrectValue() {
+  void testThatValidatorReturnsTrue_IfSets_ContainsCorrectValue() {
     addKeyDataPairValues(ImpQuantityDataKeys.ANIMALS.getValue(), "1");
-    assertTrue(validator.isValid(complementParameterSets, constraintValidatorContextMock));
+    assertThat(validator.isValid(complementParameterSets, constraintValidatorContextMock)).isTrue();
   }
 
   @Test
-  public void testThatValidatorReturnsFalse_IfWeight_ContainsAnyNullValue() {
+  void testThatValidatorReturnsFalse_IfWeight_ContainsAnyNullValue() {
+    validatorMocking();
     addKeyDataPairValues(ImpQuantityDataKeys.WEIGHT.getValue(), "");
     addKeyDataPairValues(ImpQuantityDataKeys.WEIGHT.getValue(), null);
-    assertFalse(validator.isValid(complementParameterSets, constraintValidatorContextMock));
+    assertThat(
+        validator.isValid(complementParameterSets, constraintValidatorContextMock)).isFalse();
   }
 
   @Test
-  public void testThatValidatorReturnsFalse_IfKetDataPair_ContainsNullValue() {
+  void testThatValidatorReturnsFalse_IfKetDataPair_ContainsNullValue() {
     addKeyDataPairValues(null, "");
     addKeyDataPairValues(ImpQuantityDataKeys.WEIGHT.getValue(), null);
-    assertFalse(validator.isValid(complementParameterSets, constraintValidatorContextMock));
+    assertThat(
+        validator.isValid(complementParameterSets, constraintValidatorContextMock)).isFalse();
   }
 
   private void addKeyDataPairValues(String key, String value) {

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/SpecificWarehouseValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/SpecificWarehouseValidatorTest.java
@@ -1,76 +1,56 @@
 package uk.gov.defra.tracesx.notificationschema.validation.annotations;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.DecisionEnum.ACCEPTABLE_FOR_INTERNAL_MARKET;
+import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.DecisionEnum.ACCEPTABLE_FOR_SPECIFIC_WAREHOUSE;
-import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.DecisionEnum.ACCEPTABLE_FOR_TEMPORARY_IMPORT;
-import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.DecisionEnum.ACCEPTABLE_FOR_TRANSHIPMENT;
-import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.DecisionEnum.ACCEPTABLE_FOR_TRANSIT;
-import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.DecisionEnum.ACCEPTABLE_IF_CHANNELED;
-import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.DecisionEnum.NON_ACCEPTABLE;
 import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.SpecificWarehouseNonConformingConsignmentEnum.CUSTOMWAREHOUSE;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.theories.DataPoints;
-import org.junit.experimental.theories.FromDataPoints;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import uk.gov.defra.tracesx.notificationschema.representation.Decision;
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.DecisionEnum;
 
-@RunWith(Theories.class)
-public class SpecificWarehouseValidatorTest {
+class SpecificWarehouseValidatorTest {
 
   private SpecificWarehouseValidator validator;
 
   private Decision decision;
 
-  @DataPoints("Other decisions")
-  public static final DecisionEnum[] decisions =
-      new DecisionEnum[]{
-          ACCEPTABLE_IF_CHANNELED,
-          ACCEPTABLE_FOR_INTERNAL_MARKET,
-          ACCEPTABLE_FOR_TEMPORARY_IMPORT,
-          ACCEPTABLE_FOR_TRANSHIPMENT,
-          ACCEPTABLE_FOR_TRANSIT,
-          NON_ACCEPTABLE
-      };
-
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     this.validator = new SpecificWarehouseValidator();
     this.decision = Decision.builder().build();
   }
 
   @Test
-  public void isValid_DecisionSpecificWarehouseAndEmptySpecificWarehouseNonConformingConsignment_isFalse() {
+  void isValid_DecisionSpecificWarehouseAndEmptySpecificWarehouseNonConformingConsignment_isFalse() {
     decision.setDecision(ACCEPTABLE_FOR_SPECIFIC_WAREHOUSE);
 
     final boolean result = validator.isValid(decision, null);
 
-    assertFalse(result);
+    assertThat(result).isFalse();
   }
 
-  @Theory
-  public void isValid_OtherDecisionsWithoutSpecificWarehouse_isTrue(
-      @FromDataPoints("Other decisions") DecisionEnum decisionValue) {
+  @ParameterizedTest
+  @EnumSource(value = DecisionEnum.class, names = {"ACCEPTABLE_IF_CHANNELED",
+      "ACCEPTABLE_FOR_INTERNAL_MARKET", "ACCEPTABLE_FOR_TEMPORARY_IMPORT",
+      "ACCEPTABLE_FOR_TRANSHIPMENT", "ACCEPTABLE_FOR_TRANSIT", "NON_ACCEPTABLE"})
+  void isValid_OtherDecisionsWithoutSpecificWarehouse_isTrue(DecisionEnum decisionValue) {
     decision.setDecision(decisionValue);
 
     final boolean result = validator.isValid(decision, null);
 
-    assertTrue(result);
+    assertThat(result).isTrue();
   }
 
   @Test
-  public void isValid_DecisionSpecificWarehouseAndNotEmptySpecificWarehouseNonConformingConsignment_isTrue() {
+  void isValid_DecisionSpecificWarehouseAndNotEmptySpecificWarehouseNonConformingConsignment_isTrue() {
     decision.setDecision(ACCEPTABLE_FOR_SPECIFIC_WAREHOUSE);
     decision.setSpecificWarehouseNonConformingConsignment(CUSTOMWAREHOUSE);
 
     final boolean result = validator.isValid(decision, null);
 
-    assertTrue(result);
+    assertThat(result).isTrue();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ValidStatusValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ValidStatusValidatorTest.java
@@ -1,19 +1,18 @@
 package uk.gov.defra.tracesx.notificationschema.validation.annotations;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 import jakarta.validation.ConstraintValidatorContext;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import uk.gov.defra.tracesx.notificationschema.representation.Notification;
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.NotificationTypeEnum;
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.StatusEnum;
 
-public class ValidStatusValidatorTest {
+class ValidStatusValidatorTest {
 
   @Test
-  public void alwaysValidIfDraftStatus() {
+  void alwaysValidIfDraftStatus() {
     ValidStatusValidator statusValidator = new ValidStatusValidator();
     ConstraintValidatorContext mockContext = mock(ConstraintValidatorContext.class);
     Notification notification = new Notification();
@@ -21,11 +20,11 @@ public class ValidStatusValidatorTest {
 
     boolean valid = statusValidator.isValid(notification, mockContext);
 
-    assertTrue(valid);
+    assertThat(valid).isTrue();
   }
 
   @Test
-  public void invalidIfNoTypeAndNotInDraftStatus() {
+  void invalidIfNoTypeAndNotInDraftStatus() {
     ValidStatusValidator statusValidator = new ValidStatusValidator();
     ConstraintValidatorContext mockContext = mock(ConstraintValidatorContext.class);
     Notification notification = new Notification();
@@ -33,11 +32,11 @@ public class ValidStatusValidatorTest {
 
     boolean valid = statusValidator.isValid(notification, mockContext);
 
-    assertFalse(valid);
+    assertThat(valid).isFalse();
   }
 
   @Test
-  public void validIfHasTypeAndNotInDraftStatus() {
+  void validIfHasTypeAndNotInDraftStatus() {
     ValidStatusValidator statusValidator = new ValidStatusValidator();
     ConstraintValidatorContext mockContext = mock(ConstraintValidatorContext.class);
     Notification notification = new Notification();
@@ -46,17 +45,17 @@ public class ValidStatusValidatorTest {
 
     boolean valid = statusValidator.isValid(notification, mockContext);
 
-    assertTrue(valid);
+    assertThat(valid).isTrue();
   }
 
   @Test
-  public void statusCannotBeNull() {
+  void statusCannotBeNull() {
     ValidStatusValidator statusValidator = new ValidStatusValidator();
     ConstraintValidatorContext mockContext = mock(ConstraintValidatorContext.class);
     Notification notification = new Notification();
 
     boolean valid = statusValidator.isValid(notification, mockContext);
 
-    assertFalse(valid);
+    assertThat(valid).isFalse();
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/utils/ConsignmentCheckUtilTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/utils/ConsignmentCheckUtilTest.java
@@ -1,98 +1,97 @@
 package uk.gov.defra.tracesx.notificationschema.validation.utils;
 
-import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.assertFalse;
+import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.defra.tracesx.notificationschema.validation.utils.ConsignmentCheckUtil.isExistingCHEDANotification;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import uk.gov.defra.tracesx.notificationschema.representation.ConsignmentCheck;
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.Result;
 
-public class ConsignmentCheckUtilTest {
+class ConsignmentCheckUtilTest {
 
   ConsignmentCheck consignmentCheck;
 
-  @Before
-  public void setUp() throws Exception {
+  @BeforeEach
+  void setUp() {
     consignmentCheck = new ConsignmentCheck();
   }
 
   @Test
-  public void isValid_returnsFalse_whenDocumentCheckSatisfactoryEuStandardAndNationalRequirementNull() {
-    assertFalse(isExistingCHEDANotification(consignmentCheck));
+  void isValid_returnsFalse_whenDocumentCheckSatisfactoryEuStandardAndNationalRequirementNull() {
+    assertThat(isExistingCHEDANotification(consignmentCheck)).isFalse();
   }
 
   @Test
-  public void isChedAAlreadyCreatedAndChecksSetToEuSatisfactoryAndNationalSatisfactory_thenResultIsTrue() {
+  void isChedAAlreadyCreatedAndChecksSetToEuSatisfactoryAndNationalSatisfactory_thenResultIsTrue() {
     consignmentCheck.setDocumentCheckResult(Result.NOT_SET);
     consignmentCheck.setEuStandard(Result.SATISFACTORY);
     consignmentCheck.setNationalRequirements(Result.SATISFACTORY);
 
-    assertTrue(isExistingCHEDANotification(consignmentCheck));
+    assertThat(isExistingCHEDANotification(consignmentCheck)).isTrue();
   }
 
   @Test
-  public void isChedAAlreadyCreatedAndChecksSetToEuNotSatisfactoryAndNationalSatisfactory_thenResultIsTrue() {
+  void isChedAAlreadyCreatedAndChecksSetToEuNotSatisfactoryAndNationalSatisfactory_thenResultIsTrue() {
     consignmentCheck.setDocumentCheckResult(Result.NOT_SET);
     consignmentCheck.setEuStandard(Result.NOT_SATISFACTORY);
     consignmentCheck.setNationalRequirements(Result.SATISFACTORY);
 
-    assertTrue(isExistingCHEDANotification(consignmentCheck));
+    assertThat(isExistingCHEDANotification(consignmentCheck)).isTrue();
   }
 
   @Test
-  public void isChedAAlreadyCreatedAndChecksSetToEuSatisfactoryAndNationalNotSatisfactory_thenResultIsTrue() {
+  void isChedAAlreadyCreatedAndChecksSetToEuSatisfactoryAndNationalNotSatisfactory_thenResultIsTrue() {
     consignmentCheck.setDocumentCheckResult(Result.NOT_SET);
     consignmentCheck.setEuStandard(Result.SATISFACTORY);
     consignmentCheck.setNationalRequirements(Result.NOT_SATISFACTORY);
 
-    assertTrue(isExistingCHEDANotification(consignmentCheck));
+    assertThat(isExistingCHEDANotification(consignmentCheck)).isTrue();
   }
 
   @Test
-  public void isChedAAlreadyCreatedAndChecksSetToEuNotSatisfactoryAndNationalNotSatisfactory_thenResultIsTrue() {
+  void isChedAAlreadyCreatedAndChecksSetToEuNotSatisfactoryAndNationalNotSatisfactory_thenResultIsTrue() {
     consignmentCheck.setDocumentCheckResult(Result.NOT_SET);
     consignmentCheck.setEuStandard(Result.NOT_SATISFACTORY);
     consignmentCheck.setNationalRequirements(Result.NOT_SATISFACTORY);
 
-    assertTrue(isExistingCHEDANotification(consignmentCheck));
+    assertThat(isExistingCHEDANotification(consignmentCheck)).isTrue();
   }
 
   @Test
-  public void isChedANewWithSetToEuSatisfactoryAndNationalSatisfactory_thenResultIsFalse() {
+  void isChedANewWithSetToEuSatisfactoryAndNationalSatisfactory_thenResultIsFalse() {
     consignmentCheck.setDocumentCheckResult(Result.SATISFACTORY);
     consignmentCheck.setEuStandard(Result.SATISFACTORY);
     consignmentCheck.setNationalRequirements(Result.SATISFACTORY);
 
-    assertFalse(isExistingCHEDANotification(consignmentCheck));
+    assertThat(isExistingCHEDANotification(consignmentCheck)).isFalse();
   }
 
   @Test
-  public void isChedANewWithSetToEuNotSatisfactoryAndNationalSatisfactory_thenResultIsFalse() {
+  void isChedANewWithSetToEuNotSatisfactoryAndNationalSatisfactory_thenResultIsFalse() {
     consignmentCheck.setDocumentCheckResult(Result.SATISFACTORY);
     consignmentCheck.setEuStandard(Result.NOT_SATISFACTORY);
     consignmentCheck.setNationalRequirements(Result.SATISFACTORY);
 
-    assertFalse(isExistingCHEDANotification(consignmentCheck));
+    assertThat(isExistingCHEDANotification(consignmentCheck)).isFalse();
   }
 
   @Test
-  public void isChedANewWithSetToEuSatisfactoryAndNationalNotSatisfactory_thenResultIsFalse() {
+  void isChedANewWithSetToEuSatisfactoryAndNationalNotSatisfactory_thenResultIsFalse() {
     consignmentCheck.setDocumentCheckResult(Result.SATISFACTORY);
     consignmentCheck.setEuStandard(Result.SATISFACTORY);
     consignmentCheck.setNationalRequirements(Result.NOT_SATISFACTORY);
 
-    assertFalse(isExistingCHEDANotification(consignmentCheck));
+    assertThat(isExistingCHEDANotification(consignmentCheck)).isFalse();
   }
 
   @Test
-  public void isChedANewWithSetToEuNotSatisfactoryAndNationalNotSatisfactory_thenResultIsFalse() {
+  void isChedANewWithSetToEuNotSatisfactoryAndNationalNotSatisfactory_thenResultIsFalse() {
     consignmentCheck.setDocumentCheckResult(Result.SATISFACTORY);
     consignmentCheck.setEuStandard(Result.NOT_SATISFACTORY);
     consignmentCheck.setNationalRequirements(Result.NOT_SATISFACTORY);
 
-    assertFalse(isExistingCHEDANotification(consignmentCheck));
+    assertThat(isExistingCHEDANotification(consignmentCheck)).isFalse();
   }
 
 }


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Eric Kennedy (Kainos) |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [IMTA:18684 code smells in notification s...](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/432) |
> | **GitLab MR Number** | [432](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/432) |
> | **Date Originally Opened** | Fri, 8 Nov 2024 |
> | **Approved on GitLab by** | @dannyjo, Jana Latzberg (Kainos), Lewis Birks (Kainos), joe hoy (KAINOS), philip munaawa1 (Kainos) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: [Jira Ticket](https://eaflood.atlassian.net/browse/IMTA-18684)
### :link: [Jira Ticket](https://eaflood.atlassian.net/browse/IMTA-19216)

### :chart_with_upwards_trend: [SonarQube Report](https://vss-sonarqube.azure.defra.cloud/dashboard?branch=feature%2FIMTA-18684-code-smells-in-notification-schema&id=Imports-Notification-Schema)

### :building_construction: [Jenkins Pipeline](https://jenkins-imports.azure.defra.cloud/job/imports-notification-schema/job/feature%2FIMTA-18684-code-smells-in-notification-schema/)

### :book: Changes:

- migrated to Junit5 from 4
- stripped out Junit vintage engine
- Assertions have all been moved to `org.assertj.core.api.Assertions` for standardisation
- theories / Datasource have been replaced by  @ParameterizedTest 
- fixed various code smells 

![Screenshot_2024-11-13_at_10.12.45](/uploads/47cc625dc9f3889ce52e5b77c06e601f/Screenshot_2024-11-13_at_10.12.45.png)