### PR TITLE
IMTA-16937 add free text input box into part 2 decision

### DIFF
--- a/imports-frontend-entities/src/entities/consignment_check.js
+++ b/imports-frontend-entities/src/entities/consignment_check.js
@@ -20,6 +20,7 @@ module.exports = class ConsignmentCheck {
     this.laboratoryCheckDone = obj.laboratoryCheckDone
     this.laboratoryCheckResult = obj.laboratoryCheckResult
     this.identityCheckNotDoneReason = obj.identityCheckNotDoneReason
+    this.documentCheckAdditionalDetails = obj.documentCheckAdditionalDetails
 
     return Object.seal(new Proxy(this, handler))
   }

--- a/notification-schema-core/resources/notification-schema.json
+++ b/notification-schema-core/resources/notification-schema.json
@@ -1292,6 +1292,12 @@
         "laboratoryCheckResult": {
           "$ref": "#/definitions/Result",
           "description": "Result of laboratory tests"
+        },
+        "documentCheckAdditionalDetails": {
+          "type": "string",
+          "minLength": 0,
+          "maxLength": 150,
+          "description": "Additional details for document check"
         }
       }
     },

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/ConsignmentCheck.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/ConsignmentCheck.java
@@ -166,4 +166,6 @@ public class ConsignmentCheck {
   private Boolean laboratoryCheckDone;
 
   private Result laboratoryCheckResult;
+
+  private String documentCheckAdditionalDetails;
 }


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | niamh mclarnon (Kainos) |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [IMTA-16937 add free text input box into ...](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/433) |
> | **GitLab MR Number** | [433](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/433) |
> | **Date Originally Opened** | Thu, 14 Nov 2024 |
> | **Approved on GitLab by** | Harrison Duffield (Kainos), Jonathan Magee, Lewis Birks (Kainos), Mayuresh Kadu (Kainos), Phani Yallam |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: [Jira Ticket](https://eaflood.atlassian.net/browse/IMTA-16937)

### :chart_with_upwards_trend: [SonarQube Report](https://vss-sonarqube.azure.defra.cloud/dashboard?branch=feature%2FIMTA-16937-add-free-text-input-box-into-part-2-decision&id=Imports-Notification-Schema)

### :book: Changes:

- add `documentCheckAdditionalDetails` field