### PR TITLE
IMTA-19531 - Update ChedaDocumentCheckResultValidator to account for all…

### DIFF
--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedaDocumentCheckResultValidator.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedaDocumentCheckResultValidator.java
@@ -17,8 +17,7 @@ public class ChedaDocumentCheckResultValidator implements
     if (consignmentCheck != null && !isExistingCHEDANotification(consignmentCheck)) {
       return (consignmentCheck.getEuStandard() == NOT_SET
           && consignmentCheck.getNationalRequirements() == NOT_SET
-          && (consignmentCheck.getDocumentCheckResult() == SATISFACTORY
-          || consignmentCheck.getDocumentCheckResult() == NOT_SATISFACTORY));
+          && consignmentCheck.getDocumentCheckResult() != NOT_SET);
     }
 
     return true;

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedaDocumentCheckResultValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedaDocumentCheckResultValidatorTest.java
@@ -8,12 +8,10 @@ import static uk.gov.defra.tracesx.notificationschema.representation.enumeration
 import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.Result.SATISFACTORY;
 import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.Result.SATISFACTORY_FOLLOWING_OFFICIAL_INTERVENTION;
 
-import java.time.Month;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
-import org.junit.jupiter.params.provider.ValueSource;
 import uk.gov.defra.tracesx.notificationschema.representation.ConsignmentCheck;
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.Result;
 

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedaDocumentCheckResultValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedaDocumentCheckResultValidatorTest.java
@@ -8,9 +8,14 @@ import static uk.gov.defra.tracesx.notificationschema.representation.enumeration
 import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.Result.SATISFACTORY;
 import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.Result.SATISFACTORY_FOLLOWING_OFFICIAL_INTERVENTION;
 
+import java.time.Month;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import uk.gov.defra.tracesx.notificationschema.representation.ConsignmentCheck;
+import uk.gov.defra.tracesx.notificationschema.representation.enumeration.Result;
 
 class ChedaDocumentCheckResultValidatorTest {
 
@@ -143,14 +148,6 @@ class ChedaDocumentCheckResultValidatorTest {
   }
 
   @Test
-  void isValid_returnsTrue_whenDocumentCheckNullEuStandardAndNationalRequirementNotSet() {
-    check.setEuStandard(NOT_SET);
-    check.setNationalRequirements(NOT_SET);
-
-    assertThat(validator.isValid(check, null)).isFalse();
-  }
-
-  @Test
   void isValid_returnsTrue_whenDocumentCheckEuStandardNullAndNationalRequirementNotSet() {
     check.setDocumentCheckResult(NOT_SET);
     check.setNationalRequirements(NOT_SET);
@@ -166,4 +163,18 @@ class ChedaDocumentCheckResultValidatorTest {
     assertThat(validator.isValid(check, null)).isFalse();
   }
 
+  @ParameterizedTest
+  @EnumSource(Result.class)
+  void isValid_returnsTrue_ForDocumentCheckResultsThatAreNotNotSet(Result result) {
+    check.setEuStandard(NOT_SET);
+    check.setNationalRequirements(NOT_SET);
+
+    check.setDocumentCheckResult(result);
+
+    if (result != NOT_SET) {
+      assertThat(validator.isValid(check, null)).isTrue();
+    } else {
+      assertThat(validator.isValid(check, null)).isFalse();
+    }
+  }
 }


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | @iangriffiths89 |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [IMTA-19531 - Update ChedaDocumentCheckRe...](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/435) |
> | **GitLab MR Number** | [435](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/435) |
> | **Date Originally Opened** | Thu, 6 Mar 2025 |
> | **Approved on GitLab by** | @howzat |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: [Jira Ticket](https://eaflood.atlassian.net/browse/IMTA-19531)

### :chart_with_upwards_trend: [SonarQube Report](https://vss-sonarqube.azure.defra.cloud/dashboard?branch=feature%2FIMTA-19531-update-cheda-document-validation&id=Imports-Notification-Schema)

### :building_construction: [Jenkins Pipeline](https://jenkins-imports.azure.defra.cloud/job/imports-notification-schema/job/feature%2FIMTA-19531-update-cheda-document-validation/)

### :book: Changes:

-