### PR TITLE
IMTA-19037 update BCP validation for single journey CHED-A

### DIFF
--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/Commodities.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/Commodities.java
@@ -26,13 +26,14 @@ import uk.gov.defra.tracesx.notificationschema.validation.annotations.Retrospect
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCedOrCvedpFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationChedppFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCvedaEuFieldValidation;
+import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCvedaEuSingleJourneyValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCvedaFieldValidation;
+import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCvedaRowSingleJourneyValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCvedpEuFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationHighRiskEuCedFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationHighRiskFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationLowRiskFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationSingleCedValidation;
-import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationSingleCvedaValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationSingleCvedpFieldValidation;
 
 @Builder(toBuilder = true)
@@ -208,7 +209,8 @@ public class Commodities {
       groups = {
           NotificationCvedaFieldValidation.class,
           NotificationCvedaEuFieldValidation.class,
-          NotificationSingleCvedaValidation.class
+          NotificationCvedaEuSingleJourneyValidation.class,
+          NotificationCvedaRowSingleJourneyValidation.class
       },
       message =
           "{uk.gov.defra.tracesx.notificationschema.representation.partone.commodities"

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/ComplementParameterSet.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/ComplementParameterSet.java
@@ -20,11 +20,12 @@ import uk.gov.defra.tracesx.notificationschema.validation.annotations.NotNullKey
 import uk.gov.defra.tracesx.notificationschema.validation.annotations.RetrospectiveCloningProperty;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCedOrCvedpFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCvedaEuFieldValidation;
+import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCvedaEuSingleJourneyValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCvedaFieldValidation;
+import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCvedaRowSingleJourneyValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCvedpEuFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationHighRiskEuCedFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationSingleCedValidation;
-import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationSingleCvedaValidation;
 
 @Builder(toBuilder = true)
 @Data
@@ -87,7 +88,10 @@ public class ComplementParameterSet {
           "{uk.gov.defra.tracesx.notificationschema.representation.partone.commodities"
               + ".complementparameterset.keydatapair.number_animal.message}")
   @MinValueKeyDataPair(
-      groups = NotificationSingleCvedaValidation.class,
+      groups = {
+          NotificationCvedaEuSingleJourneyValidation.class,
+          NotificationCvedaRowSingleJourneyValidation.class
+      },
       field = NUMBER_ANIMAL,
       message =
           "{uk.gov.defra.tracesx.notificationschema.representation.partone.commodities"

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/ConsignmentCheck.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/ConsignmentCheck.java
@@ -25,7 +25,7 @@ import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCed
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCedOrCvedpFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCvedaEuFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCvedaFieldValidation;
-import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCvedaNonEuFieldValidation;
+import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCvedaRowFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCvedpFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationDocumentCheckValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationHighRiskEUDocumentCheckValidation;
@@ -79,19 +79,19 @@ import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationHig
         "{uk.gov.defra.tracesx.notificationschema.representation.parttwo.consignmentcheck"
             + ".reasonidentitychecknotdone.not.null}")
 @EuStandardValidator(
-    groups = NotificationCvedaNonEuFieldValidation.class,
+    groups = NotificationCvedaRowFieldValidation.class,
     message =
         "{uk.gov.defra.tracesx.notificationschema.representation.parttwo.consignmentcheck"
             + ".eustandard.not.null}")
 @ChedaDocumentCheckResult(
-    groups = NotificationCvedaNonEuFieldValidation.class,
+    groups = NotificationCvedaRowFieldValidation.class,
     message =
         "{uk.gov.defra.tracesx.notificationschema.representation.parttwo.consignmentcheck"
             + ".documentarycheck.invalid.nonhighriskeu}")
 public class ConsignmentCheck {
 
   @NotNull(
-      groups = NotificationCvedaNonEuFieldValidation.class,
+      groups = NotificationCvedaRowFieldValidation.class,
       message =
           "{uk.gov.defra.tracesx.notificationschema.representation.parttwo.consignmentcheck"
               + ".eustandard.not.null}")

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/MeansOfTransportAfterBip.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/MeansOfTransportAfterBip.java
@@ -10,8 +10,6 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.TransportMethod;
-import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationSingleCedValidation;
-import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationSingleCvedaValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.TransporterDetailsRequiredCEDValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.TransporterDetailsRequiredEuCvedPSoleValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.TransporterDetailsRequiredEuCvedaValidation;

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/MeansOfTransportBeforeBip.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/MeansOfTransportBeforeBip.java
@@ -13,12 +13,13 @@ import uk.gov.defra.tracesx.notificationschema.representation.enumeration.Transp
 import uk.gov.defra.tracesx.notificationschema.validation.annotations.RetrospectiveCloningProperty;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationChedppFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCvedaEuFieldValidation;
+import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCvedaEuSingleJourneyValidation;
+import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCvedaRowSingleJourneyValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCvedpEuFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCvedpEuTransportFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationHighRiskEuCedFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationHighRiskFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationSingleCedValidation;
-import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationSingleCvedaValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationSingleCvedpFieldValidation;
 
 @Builder
@@ -49,7 +50,8 @@ public class MeansOfTransportBeforeBip implements MeansOfTransport {
   @NotEmpty(
       groups = {
           NotificationCvedaEuFieldValidation.class,
-          NotificationSingleCvedaValidation.class,
+          NotificationCvedaEuSingleJourneyValidation.class,
+          NotificationCvedaRowSingleJourneyValidation.class
       },
       message =
           "{uk.gov.defra.tracesx.notificationschema.representation.partone"
@@ -78,7 +80,8 @@ public class MeansOfTransportBeforeBip implements MeansOfTransport {
   @NotNull(
       groups = {
           NotificationCvedaEuFieldValidation.class,
-          NotificationSingleCvedaValidation.class
+          NotificationCvedaEuSingleJourneyValidation.class,
+          NotificationCvedaRowSingleJourneyValidation.class
       },
       message =
           "{uk.gov.defra.tracesx.notificationschema.representation.partone"
@@ -137,7 +140,8 @@ public class MeansOfTransportBeforeBip implements MeansOfTransport {
       groups = {
           NotificationCvedaEuFieldValidation.class,
           NotificationSingleCedValidation.class,
-          NotificationSingleCvedaValidation.class
+          NotificationCvedaEuSingleJourneyValidation.class,
+          NotificationCvedaRowSingleJourneyValidation.class
       },
       message =
            "{uk.gov.defra.tracesx.notificationschema.representation.partone"

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/NotificationSealsContainers.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/NotificationSealsContainers.java
@@ -13,12 +13,13 @@ import uk.gov.defra.tracesx.notificationschema.validation.annotations.Retrospect
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCedFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationChedppFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCvedaEuFieldValidation;
+import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCvedaEuSingleJourneyValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCvedaFieldValidation;
+import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCvedaRowSingleJourneyValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCvedpEuFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationHighRiskEuCedFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationHighRiskNonChedppFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationSingleCedValidation;
-import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationSingleCvedaValidation;
 
 @Builder
 @Data
@@ -39,7 +40,8 @@ public class NotificationSealsContainers {
   @NotBlank(
       groups = {
           NotificationSingleCedValidation.class,
-          NotificationSingleCvedaValidation.class
+          NotificationCvedaEuSingleJourneyValidation.class,
+          NotificationCvedaRowSingleJourneyValidation.class
       },
       message = "Add seal number")
   @RetrospectiveCloningProperty()
@@ -55,7 +57,8 @@ public class NotificationSealsContainers {
   @NotBlank(
       groups = {
           NotificationSingleCedValidation.class,
-          NotificationSingleCvedaValidation.class
+          NotificationCvedaEuSingleJourneyValidation.class,
+          NotificationCvedaRowSingleJourneyValidation.class
       },
       message = "Add container or trailer number")
   @RetrospectiveCloningProperty()

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/PartOne.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/PartOne.java
@@ -54,7 +54,9 @@ import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCed
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationChedppFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationContactDetailsEuFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCvedaEuFieldValidation;
+import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCvedaEuSingleJourneyValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCvedaFieldValidation;
+import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCvedaRowSingleJourneyValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCvedpEuFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationGvmsRouteValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationHighRiskEuCedFieldValidation;
@@ -62,7 +64,6 @@ import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationHig
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationHighRiskFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationLowRiskFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationSingleCedValidation;
-import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationSingleCvedaValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationSingleCvedpFieldValidationHighRiskJourney;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationTransporterContactDetailsEuFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationVeterinaryApprovedEstablishmentValidation;
@@ -121,7 +122,7 @@ import uk.gov.defra.tracesx.notificationschema.validation.groups.TransporterDeta
 @PortOfEntryAndPointOfEntryNotEmpty(
     groups = {
         NotificationCvedaEuFieldValidation.class,
-        NotificationSingleCvedaValidation.class
+        NotificationCvedaEuSingleJourneyValidation.class
     },
     message = "{uk.gov.defra.tracesx.notificationschema.representation.partone.portofentry"
         + ".pointofentry.eucveda.not.null}")
@@ -172,7 +173,8 @@ public class PartOne {
   @NotNull(
       groups = {
           NotificationSingleCedValidation.class,
-          NotificationSingleCvedaValidation.class
+          NotificationCvedaEuSingleJourneyValidation.class,
+          NotificationCvedaRowSingleJourneyValidation.class
       },
       message = "{uk.gov.defra.tracesx.notificationschema.representation.partone.singleced"
           + ".consignor.not.null}")
@@ -196,7 +198,8 @@ public class PartOne {
   @NotNull(
       groups = {
           NotificationSingleCedValidation.class,
-          NotificationSingleCvedaValidation.class
+          NotificationCvedaEuSingleJourneyValidation.class,
+          NotificationCvedaRowSingleJourneyValidation.class
       },
       message = "{uk.gov.defra.tracesx.notificationschema.representation.partone.singleced"
           + ".consignee.not.null}")
@@ -220,7 +223,8 @@ public class PartOne {
   @NotNull(
       groups = {
           NotificationSingleCedValidation.class,
-          NotificationSingleCvedaValidation.class
+          NotificationCvedaEuSingleJourneyValidation.class,
+          NotificationCvedaRowSingleJourneyValidation.class
       },
       message = "{uk.gov.defra.tracesx.notificationschema.representation.partone.singleced"
           + ".importer.not.null}")
@@ -246,7 +250,8 @@ public class PartOne {
   @NotNull(
       groups = {
           NotificationSingleCedValidation.class,
-          NotificationSingleCvedaValidation.class
+          NotificationCvedaEuSingleJourneyValidation.class,
+          NotificationCvedaRowSingleJourneyValidation.class
       },
       message =
           "{uk.gov.defra.tracesx.notificationschema.representation.partone.singleced"
@@ -333,7 +338,10 @@ public class PartOne {
   private Purpose purpose;
 
   @NotBlank(
-      groups = NotificationHighRiskFieldValidation.class,
+      groups = {
+          NotificationHighRiskFieldValidation.class,
+          NotificationCvedaRowSingleJourneyValidation.class
+      },
       message = "{uk.gov.defra.tracesx.notificationschema.representation.partone.pointofentry"
           + ".not.null}")
   @NotBlank(
@@ -367,7 +375,8 @@ public class PartOne {
   @NotNull(
       groups = {
           NotificationCvedaEuFieldValidation.class,
-          NotificationSingleCvedaValidation.class
+          NotificationCvedaEuSingleJourneyValidation.class,
+          NotificationCvedaRowSingleJourneyValidation.class
       },
       message = "{uk.gov.defra.tracesx.notificationschema.representation.partone.arrivaldate"
           + ".eucveda.not.null}")
@@ -402,7 +411,8 @@ public class PartOne {
   @NotNull(
       groups = {
           NotificationCvedaEuFieldValidation.class,
-          NotificationSingleCvedaValidation.class
+          NotificationCvedaEuSingleJourneyValidation.class,
+          NotificationCvedaRowSingleJourneyValidation.class
       },
       message = "{uk.gov.defra.tracesx.notificationschema.representation.partone.arrivaltime"
           + ".eucveda.not.null}")
@@ -427,7 +437,8 @@ public class PartOne {
       groups = {
           TransporterDetailsRequiredEuCvedaValidation.class,
           TransporterDetailsRequiredCvedaValidation.class,
-          NotificationSingleCvedaValidation.class
+          NotificationCvedaEuSingleJourneyValidation.class,
+          NotificationCvedaRowSingleJourneyValidation.class
       },
       message = "{uk.gov.defra.tracesx.notificationschema.representation.partone.transporter"
           + ".not.null}")
@@ -531,7 +542,8 @@ public class PartOne {
   @NotNull(
       groups = {
           TransporterDetailsRequiredEuCvedaValidation.class,
-          NotificationSingleCvedaValidation.class
+          NotificationCvedaEuSingleJourneyValidation.class,
+          NotificationCvedaRowSingleJourneyValidation.class
       },
       message =
           "{uk.gov.defra.tracesx.notificationschema.representation.partone"

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/Party.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/Party.java
@@ -14,13 +14,14 @@ import uk.gov.defra.tracesx.notificationschema.representation.enumeration.PartyT
 import uk.gov.defra.tracesx.notificationschema.validation.ErrorCodes;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationChedppFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCvedaEuFieldValidation;
+import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCvedaEuSingleJourneyValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCvedaFieldValidation;
+import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCvedaRowSingleJourneyValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCvedpEuFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationHighRiskEuCedFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationHighRiskFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationHighRiskNonChedppFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationSingleCedValidation;
-import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationSingleCvedaValidation;
 
 @Builder
 @Data
@@ -55,7 +56,8 @@ public class Party {
           NotificationCvedaEuFieldValidation.class,
           NotificationHighRiskEuCedFieldValidation.class,
           NotificationSingleCedValidation.class,
-          NotificationSingleCvedaValidation.class
+          NotificationCvedaEuSingleJourneyValidation.class,
+          NotificationCvedaRowSingleJourneyValidation.class
       },
       message = "{uk.gov.defra.tracesx.notificationschema.representation.partone.personResponsible"
           + ".address.eucveda.not.empty}")

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/groups/NotificationCvedaEuSingleJourneyValidation.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/groups/NotificationCvedaEuSingleJourneyValidation.java
@@ -1,5 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.validation.groups;
 
-public interface NotificationSingleCvedaValidation {
+public interface NotificationCvedaEuSingleJourneyValidation {
 
 }

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/groups/NotificationCvedaRowFieldValidation.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/groups/NotificationCvedaRowFieldValidation.java
@@ -1,5 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.validation.groups;
 
-public interface NotificationCvedaNonEuFieldValidation {
+public interface NotificationCvedaRowFieldValidation {
 
 }

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/groups/NotificationCvedaRowSingleJourneyValidation.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/groups/NotificationCvedaRowSingleJourneyValidation.java
@@ -1,0 +1,5 @@
+package uk.gov.defra.tracesx.notificationschema.validation.groups;
+
+public interface NotificationCvedaRowSingleJourneyValidation {
+
+}


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | @crosslandwa |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [IMTA-19037 update BCP validation for sin...](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/438) |
> | **GitLab MR Number** | [438](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/438) |
> | **Date Originally Opened** | Mon, 10 Mar 2025 |
> | **Approved on GitLab by** | @khanhassan, andrew roberts (Equal experts) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

rename NotificationSingleCvedaValidation to NotificationCvedaEuSingleJourneyValidation and create NotificationCvedaRowSingleJourneyValidation

apply both EuSingleJourneyValidation and RowSingleJourneyValidation classes everywhere the (old) SingleCvedaValidation was applied...

...accept where validation of portOfEntry/pointOfEntry is concerned - apply different validation rules such that
- for (single journey) EU portOfEntry and pointOfEntry are both required
- for (single journey) RoW only pointOfEntry is required

also
- rename NotificationCvedaNonEuFieldValidation to NotificationCvedaRowFieldValidation for consistency