### PR TITLE
IMTA-19822 Validate that exit poe selected for EU Ched-A temporary admission horses

### DIFF
--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/PartOne.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/PartOne.java
@@ -131,7 +131,10 @@ import uk.gov.defra.tracesx.notificationschema.validation.groups.TransporterDeta
     message = "{uk.gov.defra.tracesx.notificationschema.representation.partone.portofentry"
         + ".pointofentry.eucvedp.not.null}")
 @PortOfExitAndExitBipNotEmpty(
-    groups = {NotificationCvedaEuFieldValidation.class},
+    groups = {
+        NotificationCvedaEuFieldValidation.class,
+        NotificationCvedaEuSingleJourneyValidation.class
+    },
     message = "{uk.gov.defra.tracesx.notificationschema.representation.partone.portofexit"
         + ".exitbip.eucveda.not.null}")
 public class PartOne {


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | @crosslandwa |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [IMTA-19822 Validate that exit poe select...](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/439) |
> | **GitLab MR Number** | [439](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/439) |
> | **Date Originally Opened** | Thu, 20 Mar 2025 |
> | **Approved on GitLab by** | @dannyjo, andrew roberts (Equal experts) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Fix bug where validation not applied when single journey enabled