### PR TITLE
IMTA-19882 Update NotNullTransitThirdCountry for partTwo.decision to only check chedp

### DIFF
--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/Decision.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/Decision.java
@@ -104,7 +104,7 @@ import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationNot
         "{uk.gov.defra.tracesx.notificationschema.representation.parttwo.decision"
             + ".transitexitbip.not.null}")
 @NotNullTransitThirdCountry(
-    groups = NotificationCvedaOrCvedpFieldValidation.class,
+    groups = NotificationCvedpFieldValidation.class,
     message =
         "{uk.gov.defra.tracesx.notificationschema.representation.parttwo.decision"
             + ".transitthirdcountry.not.null}")


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | @amieljemei |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [IMTA-19882 Update NotNullTransitThirdCou...](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/447) |
> | **GitLab MR Number** | [447](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/447) |
> | **Date Originally Opened** | Fri, 4 Apr 2025 |
> | **Approved on GitLab by** | @andrewjharrison |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: [Jira Ticket](https://eaflood.atlassian.net/browse/IMTA-19882)

### :chart_with_upwards_trend: [SonarQube Report](https://vss-sonarqube.azure.defra.cloud/dashboard?branch=feature%2FIMTA-19882-remove-notNull-third-transit-validation&id=Imports-Notification-Schema)

### :building_construction: [Jenkins Pipeline](https://jenkins-imports.azure.defra.cloud/job/imports-notification-schema/job/feature%2FIMTA-19882-remove-notNull-third-transit-validation/)

### :book: Changes:

-