### PR TITLE
IMTA-19804 - Add requiredInspectionRate to CommodityRiskResult

### DIFF
--- a/imports-frontend-entities/src/entities/commodity_risk_result.js
+++ b/imports-frontend-entities/src/entities/commodity_risk_result.js
@@ -5,6 +5,7 @@ module.exports = class CommodityRiskResult {
 
     this.riskDecision = obj.riskDecision
     this.exitRiskDecision = obj.exitRiskDecision
+    this.requiredInspectionRate = obj.requiredInspectionRate
     this.hmiDecision = obj.hmiDecision
     this.phsiDecision = obj.phsiDecision
     this.phsiClassification = obj.phsiClassification

--- a/notification-schema-core/resources/notification-schema.json
+++ b/notification-schema-core/resources/notification-schema.json
@@ -2916,6 +2916,12 @@
             "INCONCLUSIVE"
           ]
         },
+        "requiredInspectionRate": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 100,
+          "description": "The required inspection rate as a percentage designated by the Risk Engine for this Commodity"
+        },
         "hmiDecision": {
           "type": "string",
           "description": "HMI decision required",

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/CommodityRiskResult.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/CommodityRiskResult.java
@@ -20,13 +20,15 @@ import uk.gov.defra.tracesx.notificationschema.representation.enumeration.RiskDe
 @AllArgsConstructor(access = AccessLevel.PUBLIC)
 public class CommodityRiskResult {
 
+  private UUID uniqueId;
   private RiskDecision riskDecision;
   private RiskDecision exitRiskDecision;
+  private Integer requiredInspectionRate;
+
   private HmiDecision hmiDecision;
   private PhsiDecision phsiDecision;
   private PhsiClassification phsiClassification;
   private Phsi phsi;
-  private UUID uniqueId;
   private String eppoCode;
   private String variety;
   private Boolean isWoody;


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | @iangriffiths89 |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [IMTA-19804 - Add requiredInspectionRate ...](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/448) |
> | **GitLab MR Number** | [448](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/448) |
> | **Date Originally Opened** | Thu, 17 Apr 2025 |
> | **Approved on GitLab by** | @howzat |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: [Jira Ticket](https://eaflood.atlassian.net/browse/IMTA-19804)

### :chart_with_upwards_trend: [SonarQube Report](https://vss-sonarqube.azure.defra.cloud/dashboard?branch=feature%2FIMTA-19804-add-required-inspection-rate-to-commodity-risk-result&id=Imports-Notification-Schema)

### :building_construction: [Jenkins Pipeline](https://jenkins-imports.azure.defra.cloud/job/imports-notification-schema/job/feature%2FIMTA-19804-add-required-inspection-rate-to-commodity-risk-result/)

### :book: Changes:

-