### PR TITLE
IMTA-20120 Add missing Ched A validation

### DIFF
--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/PartOne.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/PartOne.java
@@ -34,6 +34,7 @@ import uk.gov.defra.tracesx.notificationschema.representation.serialisation.IsoO
 import uk.gov.defra.tracesx.notificationschema.representation.serialisation.IsoTimeDeserializer;
 import uk.gov.defra.tracesx.notificationschema.representation.serialisation.IsoTimeSerializer;
 import uk.gov.defra.tracesx.notificationschema.validation.ValidationMessageCode;
+import uk.gov.defra.tracesx.notificationschema.validation.annotations.ChedaPartOneDestinationCountryProvided;
 import uk.gov.defra.tracesx.notificationschema.validation.annotations.ChedaPurposeExitDateNotNull;
 import uk.gov.defra.tracesx.notificationschema.validation.annotations.ChedppInvalidPodCheck;
 import uk.gov.defra.tracesx.notificationschema.validation.annotations.ChedppIsPositiveDoubleKeyDataPair;
@@ -94,6 +95,7 @@ import uk.gov.defra.tracesx.notificationschema.validation.groups.TransporterDeta
     groups = {
         NotificationCvedaFieldValidation.class,
         NotificationHighRiskEuChedValidation.class,
+        NotificationCvedaRowSingleJourneyValidation.class
     },
     message = "{uk.gov.defra.tracesx.notificationschema.representation.partone.purpose"
         + ".exitbip.not.null}")
@@ -146,6 +148,13 @@ import uk.gov.defra.tracesx.notificationschema.validation.groups.TransporterDeta
     },
     message = "{uk.gov.defra.tracesx.notificationschema.representation.partone.purpose"
     + ".exitdate.not.null}")
+@ChedaPartOneDestinationCountryProvided(
+    groups = {
+        NotificationCvedaEuSingleJourneyValidation.class,
+        NotificationCvedaRowSingleJourneyValidation.class
+    },
+    message = "{uk.gov.defra.tracesx.notificationschema.representation.partone.purpose"
+    + ".thirdcountry.not.null}")
 @PermanentAddress(
     groups = NotificationCvedaEuSingleJourneyValidation.class,
     message = "{uk.gov.defra.tracesx.notificationschema.representation.partone"

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedaPartOneDestinationCountryProvided.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedaPartOneDestinationCountryProvided.java
@@ -1,0 +1,24 @@
+package uk.gov.defra.tracesx.notificationschema.validation.annotations;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Target({TYPE, ANNOTATION_TYPE})
+@Retention(RUNTIME)
+@Constraint(validatedBy = ChedaPartOneDestinationCountryValidator.class)
+@Documented
+public @interface ChedaPartOneDestinationCountryProvided {
+
+  String message() default "Add the destination country";
+
+  Class<?>[] groups() default {};
+
+  Class<? extends Payload>[] payload() default {};
+}

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedaPartOneDestinationCountryValidator.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedaPartOneDestinationCountryValidator.java
@@ -1,0 +1,28 @@
+package uk.gov.defra.tracesx.notificationschema.validation.annotations;
+
+import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.PurposeGroupEnum.TRANSIT_TO_3RD_COUNTRY;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import uk.gov.defra.tracesx.notificationschema.representation.PartOne;
+import uk.gov.defra.tracesx.notificationschema.representation.Purpose;
+
+public class ChedaPartOneDestinationCountryValidator implements
+    ConstraintValidator<ChedaPartOneDestinationCountryProvided, PartOne> {
+
+  @Override
+  public boolean isValid(PartOne partOne, ConstraintValidatorContext constraintValidatorContext) {
+
+    if (partOne == null || partOne.getPurpose() == null) {
+      return true;
+    }
+
+    Purpose purpose = partOne.getPurpose();
+
+    if (TRANSIT_TO_3RD_COUNTRY.equals(purpose.getPurposeGroup())) {
+      return purpose.getThirdCountry() != null && !purpose.getThirdCountry().trim().isEmpty();
+    }
+
+    return true;
+  }
+}

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedaPartOneDestinationCountryValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedaPartOneDestinationCountryValidatorTest.java
@@ -1,0 +1,130 @@
+package uk.gov.defra.tracesx.notificationschema.validation.annotations;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.defra.tracesx.notificationschema.representation.PartOne;
+import uk.gov.defra.tracesx.notificationschema.representation.Purpose;
+import uk.gov.defra.tracesx.notificationschema.representation.enumeration.ForImportOrAdmissionEnum;
+import uk.gov.defra.tracesx.notificationschema.representation.enumeration.PurposeGroupEnum;
+
+@ExtendWith(MockitoExtension.class)
+class ChedaPartOneDestinationCountryValidatorTest {
+
+  private final ChedaPartOneDestinationCountryValidator validator = new ChedaPartOneDestinationCountryValidator();
+
+
+  @Test
+  void isValid_ReturnsTrueIfPurposeIsNull() {
+    var partOne = PartOne.builder().purpose(null).build();
+
+    assertThat(validator.isValid(partOne, null)).isTrue();
+  }
+
+  @ParameterizedTest
+  @MethodSource("allChedAPurposes")
+  void isValid_ReturnsTrueIfThirdCountryIsPopulated(PartOne partOne) {
+    partOne.getPurpose().setThirdCountry("A value");
+
+    assertThat(validator.isValid(partOne, null)).isTrue();
+  }
+
+  private static Stream<Arguments> allChedAPurposes() {
+    return Stream.of(
+        internalMarket(),
+        transhipment(),
+        transit(),
+        reEntry(),
+        temporaryAdmissionHorses()
+    ).map(Arguments::of);
+  }
+
+  @Test
+  void isValid_ReturnsTrueIfThirdCountryNotProvided_ForInternalMarket() {
+    var partOne = internalMarket();
+    partOne.getPurpose().setThirdCountry(null);
+
+    assertThat(validator.isValid(partOne, null)).isTrue();
+  }
+
+  @Test
+  void isValid_ReturnsTrueIfThirdCountryNotProvided_ForTranshipment() {
+    var partOne = transhipment();
+    partOne.getPurpose().setThirdCountry(null);
+
+    assertThat(validator.isValid(partOne, null)).isTrue();
+  }
+
+  @Test
+  void isValid_ReturnsFalseIfThirdCountryNotProvided_ForTransit() {
+    var partOne = transit();
+    partOne.getPurpose().setThirdCountry(null);
+
+    assertThat(validator.isValid(partOne, null)).isFalse();
+  }
+
+  @Test
+  void isValid_ReturnsTrueIfThirdCountryNotProvided_ForReEntry() {
+    var partOne = reEntry();
+    partOne.getPurpose().setThirdCountry(null);
+
+    assertThat(validator.isValid(partOne, null)).isTrue();
+  }
+
+  @Test
+  void isValid_ReturnsTrueIfThirdCountryNotProvided_ForTemporaryAdmissionHorses() {
+    var partOne = temporaryAdmissionHorses();
+    partOne.getPurpose().setThirdCountry(null);
+
+    assertThat(validator.isValid(partOne, null)).isTrue();
+  }
+
+  private static PartOne internalMarket() {
+    return PartOne.builder()
+        .purpose(Purpose.builder()
+            .forImportOrAdmission(ForImportOrAdmissionEnum.DEFINITIVE_IMPORT)
+            .purposeGroup(PurposeGroupEnum.RE_IMPORT)
+            .build())
+        .build();
+  }
+
+  private static PartOne transhipment() {
+    return PartOne.builder()
+        .purpose(Purpose.builder()
+            .purposeGroup(PurposeGroupEnum.TRANSHIPMENT_TO)
+            .build())
+        .build();
+  }
+
+  private static PartOne transit() {
+    return PartOne.builder()
+        .purpose(Purpose.builder()
+            .purposeGroup(PurposeGroupEnum.TRANSIT_TO_3RD_COUNTRY)
+            .build())
+        .build();
+  }
+
+  private static PartOne reEntry() {
+    return PartOne.builder()
+        .purpose(Purpose.builder()
+            .forImportOrAdmission(ForImportOrAdmissionEnum.HORSES_RE_ENTRY)
+            .purposeGroup(PurposeGroupEnum.RE_IMPORT)
+            .build())
+        .build();
+  }
+
+  private static PartOne temporaryAdmissionHorses() {
+    return PartOne.builder()
+        .purpose(Purpose.builder()
+            .forImportOrAdmission(ForImportOrAdmissionEnum.TEMPORARY_ADMISSION_HORSES)
+            .purposeGroup(PurposeGroupEnum.RE_IMPORT)
+            .build())
+        .build();
+  }
+}


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | @crosslandwa |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [IMTA-20120 Add missing Ched A validation](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/451) |
> | **GitLab MR Number** | [451](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/451) |
> | **Date Originally Opened** | Wed, 21 May 2025 |
> | **Approved on GitLab by** | @amieljemei, @dannyjo |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

- Exit BIP validation for RoW Ched A, Transit or Temporary Admission Horses
- Destination Country validation for EU/RoW Ched A, Transit