### PR TITLE
IMTA-6780: removed parent from pom-sonar.xml

### DIFF
--- a/imports-frontend-entities/pom-sonar.xml
+++ b/imports-frontend-entities/pom-sonar.xml
@@ -2,17 +2,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <parent>
-    <groupId>uk.gov.defra.tracesx</groupId>
-    <artifactId>IPAFFS-Common-Schema</artifactId>
-    <version>1.0.62-SNAPSHOT</version>
-  </parent>
-
   <properties>
     <node.version>v10.17.0</node.version>
     <frontend-maven-plugin.version>1.4</frontend-maven-plugin.version>
   </properties>
 
+  <groupId>uk.gov.defra.tracesx</groupId>
   <artifactId>node-common-notification-schema</artifactId>
   <version>1.0.62-SNAPSHOT</version>
   <name>notification-frontend-entities</name>


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Ghost User |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [IMTA-6780: removed parent from pom-sonar...](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/79) |
> | **GitLab MR Number** | [79](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/79) |
> | **Date Originally Opened** | Mon, 16 Mar 2020 |
> | **Approved on GitLab by** | Reece Bennett (KAINOS), daniel brennan (KAINOS), marcus bond (KAINOS) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

IMTA-6780: removed parent from pom-sonar.xml

https://eaflood.atlassian.net/browse/IMTA-6780