### PR TITLE
IMTA-7081: Add document attachment fields

### DIFF
--- a/imports-frontend-entities/package-lock.json
+++ b/imports-frontend-entities/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipaffs/imports-frontend-entities",
-  "version": "1.0.66",
+  "version": "1.0.67",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/imports-frontend-entities/package.json
+++ b/imports-frontend-entities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipaffs/imports-frontend-entities",
-  "version": "1.0.66",
+  "version": "1.0.67",
   "repository": {
     "type": "git"
   },

--- a/imports-frontend-entities/src/entities/accompanying_document.js
+++ b/imports-frontend-entities/src/entities/accompanying_document.js
@@ -11,6 +11,9 @@ module.exports = class AccompanyingDocument {
     this.documentType = obj.documentType
     this.documentReference = obj.documentReference
     this.documentIssueDate = obj.documentIssueDate
+    this.attachmentId = obj.attachmentId
+    this.attachmentFilename = obj.attachmentFilename
+    this.attachmentContentType = obj.attachmentContentType
 
     return Object.seal(new Proxy(this, handler))
   }

--- a/imports-frontend-entities/src/entities/part_two.js
+++ b/imports-frontend-entities/src/entities/part_two.js
@@ -8,6 +8,8 @@ const LaboratoryTests = require('./laboratory_tests')
 const ControlAuthority = require('./control_authority')
 const ConsignmentValidation = require('./consignment_validation')
 const EconomicOperator = require('./economic_operator')
+const AccompanyingDocument = require('./accompanying_document')
+const { getList } = require('../utils/list')
 
 module.exports = class PartTwo {
 
@@ -39,6 +41,7 @@ module.exports = class PartTwo {
     this.checkDate = obj.checkDate
     this.controlledDestination = _.get(obj, 'controlledDestination')
         ? new EconomicOperator(obj.controlledDestination) : undefined
+    this.accompanyingDocuments = getList(_.get(obj, 'accompanyingDocuments', []), AccompanyingDocument)
 
     return Object.seal(new Proxy(this, handler))
   }

--- a/notification-schema-core/resources/notification-schema.json
+++ b/notification-schema-core/resources/notification-schema.json
@@ -1084,6 +1084,13 @@
           "javaType": "java.time.LocalDateTime",
           "format": "date-time",
           "description": "User entered date when the checks were completed"
+        },
+        "accompanyingDocuments": {
+          "type": "array",
+          "description": "Accompanying documents",
+          "items": {
+            "$ref": "#/definitions/AccompanyingDocument"
+          }
         }
       }
     },
@@ -2068,6 +2075,18 @@
           "javaType": "java.time.LocalDate",
           "format": "date",
           "description": "Additional document issue date"
+        },
+        "attachmentId": {
+          "type": "string",
+          "description": "The UUID used for the uploaded file in blob storage"
+        },
+        "attachmentFilename": {
+          "type": "string",
+          "description": "The original filename of the uploaded file"
+        },
+        "attachmentContentType": {
+          "type": "string",
+          "description": "The MIME type of the uploaded file"
         }
       }
     }

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/AccompanyingDocument.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/AccompanyingDocument.java
@@ -14,6 +14,7 @@ import uk.gov.defra.tracesx.notificationschema.representation.serialisation.IsoD
 import uk.gov.defra.tracesx.notificationschema.representation.serialisation.IsoDateSerializer;
 
 import java.time.LocalDate;
+import java.util.UUID;
 
 @Builder
 @Data
@@ -28,4 +29,8 @@ public class AccompanyingDocument {
   @JsonSerialize(using = IsoDateSerializer.class)
   @JsonDeserialize(using = IsoDateDeserializer.class)
   private LocalDate documentIssueDate = null;
+
+  private UUID attachmentId = null;
+  private String attachmentFilename = null;
+  private String attachmentContentType = null;
 }

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/PartTwo.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/PartTwo.java
@@ -89,4 +89,6 @@ public class PartTwo {
   @JsonSerialize(using = IsoOffsetDateTimeSerializer.class)
   @JsonDeserialize(using = IsoOffsetDateTimeDeserializer.class)
   private LocalDateTime checkDate;
+
+  private List<AccompanyingDocument> accompanyingDocuments;
 }


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Reece Bennett (KAINOS) |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [IMTA-7081: Add document attachment field...](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/88) |
> | **GitLab MR Number** | [88](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/88) |
> | **Date Originally Opened** | Fri, 17 Apr 2020 |
> | **Approved on GitLab by** | Blakeley, Paul (Kainos), Ghost User, Stephen Donaghey (KAINOS), lee mason (KAINOS) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Schema changes so document attachment details can be added to the notification.

https://eaflood.atlassian.net/browse/IMTA-7081