### PR TITLE
IMTA-3130: Removed the JsonCreator annotation, so now when serialised with…

### DIFF
--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/AnalysisType.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/AnalysisType.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum AnalysisType {
@@ -14,7 +13,6 @@ public enum AnalysisType {
     this.value = value;
   }
 
-  @JsonCreator
   public static AnalysisType fromValue(String text) {
     for (AnalysisType u : AnalysisType.values()) {
       if (u.value.equalsIgnoreCase(text)) {

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/AnimalCertification.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/AnimalCertification.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum AnimalCertification {
@@ -33,7 +32,6 @@ public enum AnimalCertification {
     this.value = value;
   }
 
-  @JsonCreator
   public static AnimalCertification fromValue(String text) {
     for (AnimalCertification b : AnimalCertification.values()) {
       if (b.value.equals(text)) {

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/AnimalsUnit.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/AnimalsUnit.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum AnimalsUnit {
@@ -13,7 +12,6 @@ public enum AnimalsUnit {
     this.value = value;
   }
 
-  @JsonCreator
   public static AnimalsUnit fromValue(String text) {
     for (AnimalsUnit u : AnimalsUnit.values()) {
       if (u.value.equalsIgnoreCase(text)) {

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/AuthorityType.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/AuthorityType.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum AuthorityType {
@@ -15,7 +14,6 @@ public enum AuthorityType {
     this.value = value;
   }
 
-  @JsonCreator
   public static AuthorityType fromValue(String text) {
     for (AuthorityType b : AuthorityType.values()) {
       if (String.valueOf(b.value).equals(text)) {

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ChedppNotAcceptableCommodityOrPackageEnum.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ChedppNotAcceptableCommodityOrPackageEnum.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 import java.util.Arrays;
@@ -16,7 +15,6 @@ public enum ChedppNotAcceptableCommodityOrPackageEnum {
     this.value = value;
   }
 
-  @JsonCreator
   public static ChedppNotAcceptableCommodityOrPackageEnum fromValue(String text) {
     return Arrays.stream(ChedppNotAcceptableCommodityOrPackageEnum.values())
         .filter(label -> label.value.equals(text))

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ChedppNotAcceptableReasonEnum.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ChedppNotAcceptableReasonEnum.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 import java.util.Arrays;
@@ -42,7 +41,6 @@ public enum ChedppNotAcceptableReasonEnum {
     this.value = value;
   }
 
-  @JsonCreator
   public static ChedppNotAcceptableReasonEnum fromValue(String text) {
     return Arrays.stream(ChedppNotAcceptableReasonEnum.values())
         .filter(label -> label.value.equals(text))

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/CommodityIntention.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/CommodityIntention.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum CommodityIntention {
@@ -15,7 +14,6 @@ public enum CommodityIntention {
     this.value = value;
   }
 
-  @JsonCreator
   public static CommodityIntention fromValue(String text) {
     for (CommodityIntention b : CommodityIntention.values()) {
       if (b.value.equals(text)) {

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/CommodityTemperature.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/CommodityTemperature.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum CommodityTemperature {
@@ -14,7 +13,6 @@ public enum CommodityTemperature {
     this.value = value;
   }
 
-  @JsonCreator
   public static CommodityTemperature fromValue(String text) {
     for (CommodityTemperature u : CommodityTemperature.values()) {
       if (u.value.equalsIgnoreCase(text)) {

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/Conclusion.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/Conclusion.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum Conclusion {
@@ -15,7 +14,6 @@ public enum Conclusion {
     this.value = value;
   }
 
-  @JsonCreator
   public static Conclusion fromValue(String text) {
     for (Conclusion u : Conclusion.values()) {
       if (u.value.equalsIgnoreCase(text)) {

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ConservationOfSample.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ConservationOfSample.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum ConservationOfSample {
@@ -14,7 +13,6 @@ public enum ConservationOfSample {
     this.value = value;
   }
 
-  @JsonCreator
   public static ConservationOfSample fromValue(String text) {
     for (ConservationOfSample u : ConservationOfSample.values()) {
       if (u.value.equalsIgnoreCase(text)) {

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ConsignmentLeave.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ConsignmentLeave.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum ConsignmentLeave {
@@ -19,7 +18,6 @@ public enum ConsignmentLeave {
     return this.value;
   }
 
-  @JsonCreator
   public static ConsignmentLeave fromValue(String text) {
     for (ConsignmentLeave consignmentLeave : ConsignmentLeave.values()) {
       if (consignmentLeave.value.equals(text)) {

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ControlStatus.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ControlStatus.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum ControlStatus {
@@ -18,7 +17,6 @@ public enum ControlStatus {
     return this.value;
   }
 
-  @JsonCreator
   public static ControlStatus fromValue(String text) {
     for (ControlStatus controlStatus : ControlStatus.values()) {
       if (controlStatus.value.equals(text)) {

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/DecisionEnum.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/DecisionEnum.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import uk.gov.defra.tracesx.notificationschema.validation.CED;
 import uk.gov.defra.tracesx.notificationschema.validation.CHEDPP;
@@ -48,7 +47,6 @@ public enum DecisionEnum implements EntityProperty {
     this.value = value;
   }
 
-  @JsonCreator
   public static DecisionEnum fromValue(String text) {
     for (DecisionEnum b : DecisionEnum.values()) {
       if (b.value.equals(text)) {

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/DefinitiveImportPurposeEnum.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/DefinitiveImportPurposeEnum.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import uk.gov.defra.tracesx.notificationschema.validation.CVEDA;
 import uk.gov.defra.tracesx.notificationschema.validation.EntityProperty;
@@ -19,7 +18,6 @@ public enum DefinitiveImportPurposeEnum implements EntityProperty {
     this.value = value;
   }
 
-  @JsonCreator
   public static DefinitiveImportPurposeEnum fromValue(String text) {
     for (DefinitiveImportPurposeEnum b : DefinitiveImportPurposeEnum.values()) {
       if (b.value.equals(text)) {

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/DocumentType.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/DocumentType.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum DocumentType {
@@ -33,7 +32,6 @@ public enum DocumentType {
     this.value = value;
   }
 
-  @JsonCreator
   public static DocumentType fromValue(String text) {
     for (DocumentType t : DocumentType.values()) {
       if (t.value.equalsIgnoreCase(text)) {

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/EconomicOperatorStatus.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/EconomicOperatorStatus.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum EconomicOperatorStatus {
@@ -14,7 +13,6 @@ public enum EconomicOperatorStatus {
     this.value = value;
   }
 
-  @JsonCreator
   public static EconomicOperatorStatus fromValue(String text) {
     for (EconomicOperatorStatus u : EconomicOperatorStatus.values()) {
       if (u.value.equalsIgnoreCase(text)) {

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/EconomicOperatorType.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/EconomicOperatorType.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum EconomicOperatorType {
@@ -23,7 +22,6 @@ public enum EconomicOperatorType {
     this.value = value;
   }
 
-  @JsonCreator
   public static EconomicOperatorType fromValue(String text) {
     for (EconomicOperatorType u : EconomicOperatorType.values()) {
       if (u.value.equalsIgnoreCase(text)) {

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ExternalSystem.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ExternalSystem.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum ExternalSystem {
@@ -12,7 +11,6 @@ public enum ExternalSystem {
     this.value = value;
   }
 
-  @JsonCreator
   public static ExternalSystem fromValue(String text) {
     for (ExternalSystem b : ExternalSystem.values()) {
       if (String.valueOf(b.value).equals(text)) {

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ForImportOrAdmissionEnum.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ForImportOrAdmissionEnum.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum ForImportOrAdmissionEnum {
@@ -14,7 +13,6 @@ public enum ForImportOrAdmissionEnum {
     this.value = value;
   }
 
-  @JsonCreator
   public static ForImportOrAdmissionEnum fromValue(String text) {
     for (ForImportOrAdmissionEnum u : ForImportOrAdmissionEnum.values()) {
       if (u.value.equalsIgnoreCase(text)) {

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ForNonConformingEnum.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ForNonConformingEnum.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum ForNonConformingEnum {
@@ -15,7 +14,6 @@ public enum ForNonConformingEnum {
     this.value = value;
   }
 
-  @JsonCreator
   public static ForNonConformingEnum fromValue(String text) {
     for (ForNonConformingEnum u : ForNonConformingEnum.values()) {
       if (u.value.equalsIgnoreCase(text)) {

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/FreeCirculationPurposeEnum.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/FreeCirculationPurposeEnum.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import uk.gov.defra.tracesx.notificationschema.validation.CED;
 import uk.gov.defra.tracesx.notificationschema.validation.CHEDPP;
@@ -35,7 +34,6 @@ public enum FreeCirculationPurposeEnum implements EntityProperty {
     this.value = value;
   }
 
-  @JsonCreator
   public static FreeCirculationPurposeEnum fromValue(String text) {
     for (FreeCirculationPurposeEnum b : FreeCirculationPurposeEnum.values()) {
       if (b.value.equals(text)) {

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/IUUOption.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/IUUOption.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum IUUOption {
@@ -13,7 +12,6 @@ public enum IUUOption {
     this.value = value;
   }
 
-  @JsonCreator
   public static IUUOption fromValue(String text) {
     for (IUUOption u : IUUOption.values()) {
       if (u.value.equalsIgnoreCase(text)) {

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/IdentificationCheckType.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/IdentificationCheckType.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum IdentificationCheckType {
@@ -13,7 +12,6 @@ public enum IdentificationCheckType {
     this.value = value;
   }
 
-  @JsonCreator
   public static IdentificationCheckType fromValue(String text) {
     for (IdentificationCheckType u : IdentificationCheckType.values()) {
       if (u.value.equalsIgnoreCase(text)) {

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/IfChanneledOptionEnum.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/IfChanneledOptionEnum.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import uk.gov.defra.tracesx.notificationschema.validation.CHEDPP;
 import uk.gov.defra.tracesx.notificationschema.validation.CVEDP;
@@ -20,7 +19,6 @@ public enum IfChanneledOptionEnum implements EntityProperty {
     this.value = value;
   }
 
-  @JsonCreator
   public static IfChanneledOptionEnum fromValue(String text) {
     for (IfChanneledOptionEnum u : IfChanneledOptionEnum.values()) {
       if (u.value.equalsIgnoreCase(text)) {

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ImpQuantityDataKeys.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/ImpQuantityDataKeys.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum ImpQuantityDataKeys {
@@ -15,7 +14,6 @@ public enum ImpQuantityDataKeys {
     this.value = value;
   }
 
-  @JsonCreator
   public static ImpQuantityDataKeys fromValue(String text) {
     for (ImpQuantityDataKeys u : ImpQuantityDataKeys.values()) {
       if (u.value.equalsIgnoreCase(text)) {

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/InternalMarketPurpose.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/InternalMarketPurpose.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum InternalMarketPurpose {
@@ -16,7 +15,6 @@ public enum InternalMarketPurpose {
     this.value = value;
   }
 
-  @JsonCreator
   public static InternalMarketPurpose fromValue(String text) {
     for (InternalMarketPurpose u : InternalMarketPurpose.values()) {
       if (u.value.equalsIgnoreCase(text)) {

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/NotAcceptableActionEnum.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/NotAcceptableActionEnum.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import uk.gov.defra.tracesx.notificationschema.validation.CED;
 import uk.gov.defra.tracesx.notificationschema.validation.CHEDPP;
@@ -50,7 +49,6 @@ public enum NotAcceptableActionEnum implements EntityProperty {
     this.value = value;
   }
 
-  @JsonCreator
   public static NotAcceptableActionEnum fromValue(String text) {
     for (NotAcceptableActionEnum b : NotAcceptableActionEnum.values()) {
       if (b.value.equals(text)) {

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/NotAcceptableActionReasonEnum.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/NotAcceptableActionReasonEnum.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 import java.util.Arrays;
@@ -18,7 +17,6 @@ public enum NotAcceptableActionReasonEnum {
     this.value = value;
   }
 
-  @JsonCreator
   public static NotAcceptableActionReasonEnum fromValue(String text) {
     return Arrays.stream(NotAcceptableActionReasonEnum.values())
         .filter(label -> label.value.equals(text))

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/NotAcceptableReasonsEnum.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/NotAcceptableReasonsEnum.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum NotAcceptableReasonsEnum {
@@ -32,7 +31,6 @@ public enum NotAcceptableReasonsEnum {
     this.value = value;
   }
 
-  @JsonCreator
   public static NotAcceptableReasonsEnum fromValue(String text) {
     for (NotAcceptableReasonsEnum b : NotAcceptableReasonsEnum.values()) {
       if (b.value.equals(text)) {

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/NotificationTypeEnum.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/NotificationTypeEnum.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum NotificationTypeEnum {
@@ -16,7 +15,6 @@ public enum NotificationTypeEnum {
     this.value = value;
   }
 
-  @JsonCreator
   public static NotificationTypeEnum fromValue(String text) {
     for (NotificationTypeEnum b : NotificationTypeEnum.values()) {
       if (b.value.equals(text)) {

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/PackageType.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/PackageType.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum PackageType {
@@ -34,7 +33,6 @@ public enum PackageType {
     this.value = value;
   }
 
-  @JsonCreator
   public static PackageType fromValue(String text) {
     for (PackageType u : PackageType.values()) {
       if (u.value.equalsIgnoreCase(text)) {

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/PartyType.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/PartyType.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum PartyType {
@@ -13,7 +12,6 @@ public enum PartyType {
     this.value = value;
   }
 
-  @JsonCreator
   public static PartyType fromValue(String text) {
     for (PartyType u : PartyType.values()) {
       if (u.value.equalsIgnoreCase(text)) {

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/PhysicalCheckNotDoneReason.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/PhysicalCheckNotDoneReason.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum PhysicalCheckNotDoneReason {
@@ -13,7 +12,6 @@ public enum PhysicalCheckNotDoneReason {
     this.value = value;
   }
 
-  @JsonCreator
   public static PhysicalCheckNotDoneReason fromValue(String text) {
     for (PhysicalCheckNotDoneReason u : PhysicalCheckNotDoneReason.values()) {
       if (u.value.equalsIgnoreCase(text)) {

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/PurposeGroupEnum.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/PurposeGroupEnum.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum PurposeGroupEnum {
@@ -19,7 +18,6 @@ public enum PurposeGroupEnum {
     this.value = value;
   }
 
-  @JsonCreator
   public static PurposeGroupEnum fromValue(String text) {
     for (PurposeGroupEnum u : PurposeGroupEnum.values()) {
       if (u.value.equalsIgnoreCase(text)) {

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/Result.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/Result.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum Result {
@@ -16,7 +15,6 @@ public enum Result {
     this.value = value;
   }
 
-  @JsonCreator
   public static Result fromValue(String text) {
     for (Result u : Result.values()) {
       if (u.value.equalsIgnoreCase(text)) {

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/SpecificWarehouseNonConformingConsignmentEnum.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/SpecificWarehouseNonConformingConsignmentEnum.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import uk.gov.defra.tracesx.notificationschema.validation.CHEDPP;
 import uk.gov.defra.tracesx.notificationschema.validation.CVEDP;
@@ -26,7 +25,6 @@ public enum SpecificWarehouseNonConformingConsignmentEnum implements EntityPrope
     this.value = value;
   }
 
-  @JsonCreator
   public static SpecificWarehouseNonConformingConsignmentEnum fromValue(String text) {
     for (SpecificWarehouseNonConformingConsignmentEnum b :
         SpecificWarehouseNonConformingConsignmentEnum.values()) {

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/StatusEnum.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/StatusEnum.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum StatusEnum {
@@ -21,7 +20,6 @@ public enum StatusEnum {
     this.value = value;
   }
 
-  @JsonCreator
   public static StatusEnum fromValue(String text) {
     for (StatusEnum b : StatusEnum.values()) {
       if (b.value.equals(text)) {

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/TestReason.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/TestReason.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum TestReason {
@@ -17,7 +16,6 @@ public enum TestReason {
     this.value = value;
   }
 
-  @JsonCreator
   public static TestReason fromValue(String text) {
     for (TestReason u : TestReason.values()) {
       if (u.value.equalsIgnoreCase(text)) {

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/TransportMethod.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/TransportMethod.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum TransportMethod {
@@ -19,7 +18,6 @@ public enum TransportMethod {
     this.value = value;
   }
 
-  @JsonCreator
   public static TransportMethod fromValue(String text) {
     for (TransportMethod u : TransportMethod.values()) {
       if (u.value.equalsIgnoreCase(text)) {

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/TransportType.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/TransportType.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum TransportType {
@@ -18,7 +17,6 @@ public enum TransportType {
     this.value = value;
   }
 
-  @JsonCreator
   public static TransportType fromValue(String text) {
     for (TransportType b : TransportType.values()) {
       if (String.valueOf(b.value).equals(text)) {


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | lee mason (KAINOS) |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [IMTA-3130: Removed the JsonCreator annot...](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/139) |
> | **GitLab MR Number** | [139](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/139) |
> | **Date Originally Opened** | Tue, 6 Oct 2020 |
> | **Approved on GitLab by** | Blakeley, Paul (Kainos), Nicholas Martin, Popa, Paul (Kainos), kingsley.Osime (Kainos) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

IMTA-3130: Removed the JsonCreator annotation, so now when serialised with incorrect enums will throw an IllegalArgumentException