### PR TITLE
IMTA 9128 allow port of exit when purpose not set

### DIFF
--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ImpPortOfExitDateInFutureValidator.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ImpPortOfExitDateInFutureValidator.java
@@ -17,10 +17,8 @@ public class ImpPortOfExitDateInFutureValidator
     return Optional.ofNullable(partOne)
         .map(PartOne::getCommodities)
         .map(Commodities::getAnimalsCertifiedAs)
-        .map(
-            certifiedAs ->
-                certifiedAs != AnimalCertification.TRANSIT
-                    || isValidExitDate(Optional.ofNullable(partOne.getPortOfExitDate())))
+        .filter(AnimalCertification.TRANSIT::equals)
+        .map(certifiedAs -> isValidExitDate(Optional.ofNullable(partOne.getPortOfExitDate())))
         .orElse(true);
   }
 

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ImpPortOfExitDateNotNullValidator.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ImpPortOfExitDateNotNullValidator.java
@@ -1,6 +1,5 @@
 package uk.gov.defra.tracesx.notificationschema.validation.annotations;
 
-import uk.gov.defra.tracesx.notificationschema.representation.Commodities;
 import uk.gov.defra.tracesx.notificationschema.representation.PartOne;
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.AnimalCertification;
 
@@ -15,10 +14,10 @@ public class ImpPortOfExitDateNotNullValidator
   public boolean isValid(PartOne partOne, ConstraintValidatorContext constraintValidatorContext) {
     return Optional.ofNullable(partOne)
         .map(PartOne::getCommodities)
-        .map(Commodities::getAnimalsCertifiedAs)
         .map(
-            certifiedAs ->
-                certifiedAs != AnimalCertification.TRANSIT || partOne.getPortOfExitDate() != null)
+            commodities ->
+                commodities.getAnimalsCertifiedAs() != AnimalCertification.TRANSIT
+                    || partOne.getPortOfExitDate() != null)
         .orElse(false);
   }
 }

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ImpPortOfExitValidator.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ImpPortOfExitValidator.java
@@ -1,7 +1,6 @@
 package uk.gov.defra.tracesx.notificationschema.validation.annotations;
 
 import org.apache.commons.lang3.StringUtils;
-import uk.gov.defra.tracesx.notificationschema.representation.Commodities;
 import uk.gov.defra.tracesx.notificationschema.representation.PartOne;
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.AnimalCertification;
 
@@ -15,10 +14,9 @@ public class ImpPortOfExitValidator implements ConstraintValidator<ImpPortOfExit
   public boolean isValid(PartOne partOne, ConstraintValidatorContext constraintValidatorContext) {
     return Optional.ofNullable(partOne)
         .map(PartOne::getCommodities)
-        .map(Commodities::getAnimalsCertifiedAs)
         .map(
-            certifiedAs ->
-                certifiedAs != AnimalCertification.TRANSIT
+            commodities ->
+                commodities.getAnimalsCertifiedAs() != AnimalCertification.TRANSIT
                     || StringUtils.isNotBlank(partOne.getPortOfExit()))
         .orElse(false);
   }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ImpPortOfExitDateNotNullValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ImpPortOfExitDateNotNullValidatorTest.java
@@ -57,16 +57,16 @@ public class ImpPortOfExitDateNotNullValidatorTest {
   }
 
   @Test
-  public void validatorShouldReturnFalseIfAnimalCertificationIsNull() {
+  public void validatorShouldReturnTrueIfAnimalCertificationIsNull() {
     partOne.setCommodities(Commodities.builder().build());
 
     boolean result = validator.isValid(partOne, null);
 
-    assertThat(result).isFalse();
+    assertThat(result).isTrue();
   }
 
   @Theory
-  public void validatorShouldReturnTrueIfAnimalCertificationIsNotTransit(
+  public void validatorShouldReturnTrueIfAnimalCertificationIsSetAndNotTransit(
       @FromDataPoints("Non Transit AnimalCertifications") AnimalCertification animalCertification) {
     partOne.setCommodities(Commodities.builder().animalsCertifiedAs(animalCertification).build());
 

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ImpPortOfExitValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ImpPortOfExitValidatorTest.java
@@ -56,16 +56,16 @@ public class ImpPortOfExitValidatorTest {
   }
 
   @Test
-  public void validatorShouldReturnFalseIfAnimalCertificationIsNull() {
+  public void validatorShouldReturnTrueIfAnimalCertificationIsNull() {
     partOne.setCommodities(Commodities.builder().build());
 
     boolean result = validator.isValid(partOne, null);
 
-    assertThat(result).isFalse();
+    assertThat(result).isTrue();
   }
 
   @Theory
-  public void validatorShouldReturnTrueIfAnimalCertificationIsNotTransit(
+  public void validatorShouldReturnTrueIfAnimalCertificationIsSetAndNotTransit(
       @FromDataPoints("Non Transit AnimalCertifications") AnimalCertification animalCertification) {
     partOne.setCommodities(Commodities.builder().animalsCertifiedAs(animalCertification).build());
 
@@ -86,7 +86,8 @@ public class ImpPortOfExitValidatorTest {
 
   @Test
   public void validatorShouldReturnFalseIfAnimalCertificationIsTransitAndThePortOfExitIsBlank() {
-    partOne.setCommodities(Commodities.builder().build());
+    partOne.setCommodities(
+        Commodities.builder().animalsCertifiedAs(AnimalCertification.TRANSIT).build());
     partOne.setPortOfExit("");
 
     boolean result = validator.isValid(partOne, null);
@@ -97,7 +98,8 @@ public class ImpPortOfExitValidatorTest {
   @Test
   public void
       validatorShouldReturnFalseIfAnimalCertificationIsTransitAndThePortOfExitIsWhitespace() {
-    partOne.setCommodities(Commodities.builder().build());
+    partOne.setCommodities(
+        Commodities.builder().animalsCertifiedAs(AnimalCertification.TRANSIT).build());
     partOne.setPortOfExit("  \t\t\t");
 
     boolean result = validator.isValid(partOne, null);


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | marcus bond (KAINOS) |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [IMTA 9128 allow port of exit when purpos...](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/189) |
> | **GitLab MR Number** | [189](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/189) |
> | **Date Originally Opened** | Thu, 25 Feb 2021 |
> | **Approved on GitLab by** | Blakeley, Paul (Kainos), Carl Evans (KAINOS), Conor McCormick (KAINOS), Kamesh Ganesan (KAINOS), iwan roberts (KAINOS) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Purpose is not mandatory for IMP so validation updated to only trigger when explcitly set to transit