### PR TITLE
IMTA-8508: Fix notification submitted without a BCP

### DIFF
--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/PartOne.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/PartOne.java
@@ -49,6 +49,7 @@ import java.time.LocalTime;
 import java.util.List;
 import java.util.Set;
 import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 
 @Builder
@@ -191,7 +192,7 @@ public class PartOne {
       message = "{uk.gov.defra.tracesx.notificationschema.representation.partone.purpose.not.null}")
   private Purpose purpose;
 
-  @NotNull(
+  @NotBlank(
       groups = NotificationHighRiskFieldValidation.class,
       message = "{uk.gov.defra.tracesx.notificationschema.representation.partone.pointofentry"
           + ".not.null}")


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Marina Tihova (Kainos) |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [IMTA-8508: Fix notification submitted wi...](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/195) |
> | **GitLab MR Number** | [195](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/195) |
> | **Date Originally Opened** | Mon, 22 Mar 2021 |
> | **Approved on GitLab by** | Callum Atwal (kainos), Nicholas Martin, kamil mojek (KAINOS), lee mason (KAINOS) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

[**JIRA ticket**](https://eaflood.atlassian.net/browse/IMTA-8508):sparkles:
<br>Changed `pointOfEntry` validation to consider both empty strings and null values as errors