### PR TITLE
IMTA-9758: Updating schema to accommodate for region iso codes

### DIFF
--- a/imports-frontend-entities/package-lock.json
+++ b/imports-frontend-entities/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipaffs/imports-frontend-entities",
-  "version": "1.0.183",
+  "version": "1.0.185",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/imports-frontend-entities/package.json
+++ b/imports-frontend-entities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipaffs/imports-frontend-entities",
-  "version": "1.0.183",
+  "version": "1.0.185",
   "repository": {
     "type": "git"
   },

--- a/notification-schema-core/resources/notification-schema.json
+++ b/notification-schema-core/resources/notification-schema.json
@@ -2318,9 +2318,9 @@
     "Country": {
       "type": "string",
       "minLength": 2,
-      "maxLength": 3,
-      "pattern": "^[A-Z]{2,3}$",
-      "description": "2-3 digits ISO code of country"
+      "maxLength": 6,
+      "pattern": "^([A-Z]{2}||[A-Z]{2}-[A-Z]{2,3})$",
+      "description": "ISO code of country"
     },
     "SealContainer": {
       "type": "object",


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Sean Treanor (KAINOS) |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [IMTA-9758: Updating schema to accommodat...](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/218) |
> | **GitLab MR Number** | [218](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/218) |
> | **Date Originally Opened** | Thu, 24 Jun 2021 |
> | **Approved on GitLab by** | Holmes, Nathanael (Kainos), Stephen McVeigh, dominik henjes (KAINOS), iwan roberts (KAINOS) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: Ticket: https://eaflood.atlassian.net/browse/IMTA-9758
### :book: Changes:
* Updated country max length to 6
* Updated the value regex to support region codes with with "AA", "AA-AA" and "AA-AAA" formats.