### PR TITLE
IMTA 9668 - Store risk assessment outcomes and 'inspection required' in schema

### DIFF
--- a/imports-frontend-entities/package-lock.json
+++ b/imports-frontend-entities/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipaffs/imports-frontend-entities",
-  "version": "1.0.185",
+  "version": "1.0.186",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/imports-frontend-entities/package.json
+++ b/imports-frontend-entities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipaffs/imports-frontend-entities",
-  "version": "1.0.185",
+  "version": "1.0.186",
   "repository": {
     "type": "git"
   },

--- a/imports-frontend-entities/src/entities/commodity_risk_result.js
+++ b/imports-frontend-entities/src/entities/commodity_risk_result.js
@@ -7,6 +7,7 @@ module.exports = class CommodityRiskResult {
       obj = {}
     }
 
+    this.riskDecision = obj.riskDecision
     this.hmiDecision = obj.hmiDecision
     this.phsiDecision = obj.phsiDecision
     this.phsiClassification = obj.phsiClassification

--- a/imports-frontend-entities/src/entities/part_two.js
+++ b/imports-frontend-entities/src/entities/part_two.js
@@ -46,6 +46,7 @@ module.exports = class PartTwo {
     this.commodityChecks = getList(_.get(obj, 'commodityChecks', []), CommodityChecks)
     this.phsiAutoCleared = obj.phsiAutoCleared
     this.hmiAutoCleared = obj.hmiAutoCleared
+    this.inspectionRequired = obj.inspectionRequired
 
     return Object.seal(new Proxy(this, handler))
   }

--- a/notification-schema-core/resources/notification-schema.json
+++ b/notification-schema-core/resources/notification-schema.json
@@ -1241,6 +1241,15 @@
         "hmiAutoCleared": {
           "type": "boolean",
           "description": "Have the HMI regulated commodities been auto cleared?"
+        },
+        "inspectionRequired": {
+          "type": "string",
+          "description": "Inspection required",
+          "enum": [
+            "Required",
+            "Inconclusive",
+            "Not required"
+          ]
         }
       }
     },
@@ -2502,6 +2511,15 @@
       "type": "object",
       "description": "Result of the risk assessment of a commodity",
       "properties": {
+        "riskDecision": {
+          "type": "string",
+          "description": "CHED-A, CHED-D, CHED-P - what is the commodity complement risk decision",
+          "enum": [
+            "REQUIRED",
+            "NOTREQUIRED",
+            "INCONCLUSIVE"
+          ]
+        },
         "hmiDecision": {
           "type": "string",
           "description": "HMI decision required",

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/CommodityRiskResult.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/CommodityRiskResult.java
@@ -10,6 +10,7 @@ import lombok.NoArgsConstructor;
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.HmiDecision;
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.PhsiClassification;
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.PhsiDecision;
+import uk.gov.defra.tracesx.notificationschema.representation.enumeration.RiskDecision;
 
 import java.util.UUID;
 
@@ -20,6 +21,7 @@ import java.util.UUID;
 @AllArgsConstructor(access = AccessLevel.PUBLIC)
 public class CommodityRiskResult {
 
+  private RiskDecision decision;
   private HmiDecision hmiDecision;
   private PhsiDecision phsiDecision;
   private PhsiClassification phsiClassification;

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/PartTwo.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/PartTwo.java
@@ -9,6 +9,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import uk.gov.defra.tracesx.notificationschema.representation.enumeration.InspectionRequired;
 import uk.gov.defra.tracesx.notificationschema.representation.serialisation.IsoOffsetDateTimeDeserializer;
 import uk.gov.defra.tracesx.notificationschema.representation.serialisation.IsoOffsetDateTimeSerializer;
 import uk.gov.defra.tracesx.notificationschema.validation.ValidationMessageCode;
@@ -102,4 +103,6 @@ public class PartTwo {
   private Boolean phsiAutoCleared;
 
   private Boolean hmiAutoCleared;
+
+  private InspectionRequired inspectionRequired;
 }

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/InspectionRequired.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/InspectionRequired.java
@@ -1,0 +1,34 @@
+package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum InspectionRequired {
+  REQUIRED("Required"),
+  INCONCLUSIVE("Inconclusive"),
+  NOT_REQUIRED("Not required");
+
+  private String value;
+
+  InspectionRequired(String value) {
+    this.value = value;
+  }
+
+  public static InspectionRequired fromValue(String text) {
+    for (InspectionRequired u : InspectionRequired.values()) {
+      if (u.value.equalsIgnoreCase(text)) {
+        return u;
+      }
+    }
+    return null;
+  }
+
+  @JsonValue
+  public String getValue() {
+    return value;
+  }
+
+  @Override
+  public String toString() {
+    return value;
+  }
+}

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/RiskDecision.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/RiskDecision.java
@@ -1,0 +1,34 @@
+package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.util.Arrays;
+
+public enum RiskDecision {
+  REQUIRED("REQUIRED"),
+  NOT_REQUIRED("NOTREQUIRED"),
+  INCONCLUSIVE("INCONCLUSIVE");
+
+  private String value;
+
+  RiskDecision(String value) {
+    this.value = value;
+  }
+
+  public static RiskDecision fromValue(String text) {
+    return Arrays.stream(RiskDecision.values())
+        .filter(label -> label.value.equals(text))
+        .findFirst()
+        .orElse(null);
+  }
+
+  @JsonValue
+  public String getValue() {
+    return value;
+  }
+
+  @Override
+  public String toString() {
+    return value;
+  }
+}


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | dominik henjes (KAINOS) |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [IMTA 9668 - Store risk assessment outcom...](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/219) |
> | **GitLab MR Number** | [219](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/219) |
> | **Date Originally Opened** | Thu, 24 Jun 2021 |
> | **Approved on GitLab by** | Holmes, Nathanael (Kainos), Kelly Moore, Reece Bennett (KAINOS), kingsley.Osime (Kainos) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: ticket: https://eaflood.atlassian.net/browse/IMTA-9668
### :book: Changes:
* Add 'Risk Decision' field to RiskResult, which will be used for CHED-A, D, P
* Add 'Inspection Required' field to PartTwo, which will be used for CHED-A, D, P
