### PR TITLE
IMTA-9779: Add REENFORCED_CHECK value to RiskDecision enum

### DIFF
--- a/imports-frontend-entities/package-lock.json
+++ b/imports-frontend-entities/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipaffs/imports-frontend-entities",
-  "version": "1.0.188",
+  "version": "1.0.189",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/imports-frontend-entities/package.json
+++ b/imports-frontend-entities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipaffs/imports-frontend-entities",
-  "version": "1.0.188",
+  "version": "1.0.189",
   "repository": {
     "type": "git"
   },

--- a/notification-schema-core/resources/notification-schema.json
+++ b/notification-schema-core/resources/notification-schema.json
@@ -2521,7 +2521,8 @@
           "enum": [
             "REQUIRED",
             "NOTREQUIRED",
-            "INCONCLUSIVE"
+            "INCONCLUSIVE",
+            "REENFORCED_CHECK"
           ]
         },
         "hmiDecision": {

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/RiskDecision.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/RiskDecision.java
@@ -7,7 +7,8 @@ import java.util.Arrays;
 public enum RiskDecision {
   REQUIRED("REQUIRED"),
   NOT_REQUIRED("NOTREQUIRED"),
-  INCONCLUSIVE("INCONCLUSIVE");
+  INCONCLUSIVE("INCONCLUSIVE"),
+  REENFORCED_CHECK("REENFORCED_CHECK");
 
   private String value;
 


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Reece Bennett (KAINOS) |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [IMTA-9779: Add REENFORCED_CHECK value to...](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/222) |
> | **GitLab MR Number** | [222](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/222) |
> | **Date Originally Opened** | Wed, 14 Jul 2021 |
> | **Approved on GitLab by** | bridget.hodgson (Kainos), dominik henjes (KAINOS), iwan roberts (KAINOS), kingsley.Osime (Kainos) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: Ticket: https://eaflood.atlassian.net/browse/IMTA-9779