### PR TITLE
IMTA-9980 added validation for seal number and container number so that empty…

### DIFF
--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/PartOne.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/PartOne.java
@@ -30,6 +30,7 @@ import uk.gov.defra.tracesx.notificationschema.validation.annotations.ChedppIsPo
 import uk.gov.defra.tracesx.notificationschema.validation.annotations.ChedppMinValueKeyDataPair;
 import uk.gov.defra.tracesx.notificationschema.validation.annotations.ChedppNotNullKeyDataPair;
 import uk.gov.defra.tracesx.notificationschema.validation.annotations.ChedppPodRequired;
+import uk.gov.defra.tracesx.notificationschema.validation.annotations.ContainerNumberNotEmpty;
 import uk.gov.defra.tracesx.notificationschema.validation.annotations.ImpPlaceOfOriginNotNull;
 import uk.gov.defra.tracesx.notificationschema.validation.annotations.ImpPortOfEntry;
 import uk.gov.defra.tracesx.notificationschema.validation.annotations.ImpPortOfExit;
@@ -39,6 +40,7 @@ import uk.gov.defra.tracesx.notificationschema.validation.annotations.NotNullPur
 import uk.gov.defra.tracesx.notificationschema.validation.annotations.NotNullPurposeExitDate;
 import uk.gov.defra.tracesx.notificationschema.validation.annotations.NotNullWoodPackagingCommodity;
 import uk.gov.defra.tracesx.notificationschema.validation.annotations.PhytosanitaryCertificateRequired;
+import uk.gov.defra.tracesx.notificationschema.validation.annotations.SealNumberNotEmpty;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCedFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationChedppFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCvedaFieldValidation;
@@ -327,6 +329,16 @@ public class PartOne {
   private String importerLocalReferenceNumber;
   private Route route;
 
+  @SealNumberNotEmpty(
+      groups = NotificationHighRiskFieldValidation.class,
+      message =
+          "{uk.gov.defra.tracesx.notificationschema.representation.partone.sealsContainers"
+              + ".sealNumber.not.null}")
+  @ContainerNumberNotEmpty(
+      groups = NotificationHighRiskFieldValidation.class,
+      message =
+          "{uk.gov.defra.tracesx.notificationschema.representation.partone.sealsContainers"
+              + ".containerNumber.not.null}")
   private List<NotificationSealsContainers> sealsContainers;
 
   @JsonSerialize(using = IsoOffsetDateTimeSerializer.class)

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ContainerNumberNotEmpty.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ContainerNumberNotEmpty.java
@@ -1,0 +1,25 @@
+package uk.gov.defra.tracesx.notificationschema.validation.annotations;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+@Target({TYPE, ANNOTATION_TYPE, FIELD})
+@Retention(RUNTIME)
+@Constraint(validatedBy = ContainerNumberNotEmptyValidator.class)
+@Documented
+public @interface ContainerNumberNotEmpty {
+
+  String message() default "Enter the container number";
+
+  Class<?>[] groups() default {};
+
+  Class<? extends Payload>[] payload() default {};
+}

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ContainerNumberNotEmptyValidator.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ContainerNumberNotEmptyValidator.java
@@ -1,0 +1,30 @@
+package uk.gov.defra.tracesx.notificationschema.validation.annotations;
+
+import org.apache.commons.lang3.StringUtils;
+import uk.gov.defra.tracesx.notificationschema.representation.NotificationSealsContainers;
+
+import java.util.List;
+import java.util.Objects;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class ContainerNumberNotEmptyValidator
+    implements ConstraintValidator<ContainerNumberNotEmpty, List<NotificationSealsContainers>> {
+
+  @Override
+  public void initialize(ContainerNumberNotEmpty constraintAnnotation) {
+    // no action
+  }
+
+  @Override
+  public boolean isValid(List<NotificationSealsContainers> notificationSealsContainers,
+      ConstraintValidatorContext context) {
+    if (notificationSealsContainers == null || notificationSealsContainers.isEmpty()) {
+      return true;
+    }
+
+    return notificationSealsContainers.stream()
+        .filter(Objects::nonNull)
+        .noneMatch(container -> StringUtils.isBlank(container.getContainerNumber()));
+  }
+}

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/SealNumberNotEmpty.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/SealNumberNotEmpty.java
@@ -1,0 +1,25 @@
+package uk.gov.defra.tracesx.notificationschema.validation.annotations;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+@Target({TYPE, ANNOTATION_TYPE, FIELD})
+@Retention(RUNTIME)
+@Constraint(validatedBy = SealNumberNotEmptyValidator.class)
+@Documented
+public @interface SealNumberNotEmpty {
+
+  String message() default "Enter the seal number";
+
+  Class<?>[] groups() default {};
+
+  Class<? extends Payload>[] payload() default {};
+}

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/SealNumberNotEmptyValidator.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/SealNumberNotEmptyValidator.java
@@ -1,0 +1,30 @@
+package uk.gov.defra.tracesx.notificationschema.validation.annotations;
+
+import org.apache.commons.lang3.StringUtils;
+import uk.gov.defra.tracesx.notificationschema.representation.NotificationSealsContainers;
+
+import java.util.List;
+import java.util.Objects;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class SealNumberNotEmptyValidator
+    implements ConstraintValidator<SealNumberNotEmpty, List<NotificationSealsContainers>> {
+
+  @Override
+  public void initialize(SealNumberNotEmpty constraintAnnotation) {
+    // no action
+  }
+
+  @Override
+  public boolean isValid(List<NotificationSealsContainers> notificationSealsContainers,
+      ConstraintValidatorContext context) {
+    if (notificationSealsContainers == null || notificationSealsContainers.isEmpty()) {
+      return true;
+    }
+
+    return notificationSealsContainers.stream()
+        .filter(Objects::nonNull)
+        .noneMatch(container -> StringUtils.isBlank(container.getSealNumber()));
+  }
+}

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ContainerNumberNotEmptyValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ContainerNumberNotEmptyValidatorTest.java
@@ -1,0 +1,87 @@
+package uk.gov.defra.tracesx.notificationschema.validation.annotations;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.defra.tracesx.notificationschema.representation.NotificationSealsContainers;
+
+import java.util.Collections;
+import java.util.List;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ContainerNumberNotEmptyValidatorTest {
+
+  private ContainerNumberNotEmptyValidator validator;
+
+  private List<NotificationSealsContainers> notificationSealsContainers;
+
+  @Before
+  public void setUp() {
+    validator = new ContainerNumberNotEmptyValidator();
+    NotificationSealsContainers container = new NotificationSealsContainers();
+    container.setContainerNumber("valid seal number");
+    notificationSealsContainers = List.of(container);
+  }
+
+  @Test
+  public void validatorShouldReturnTrueIfSealContainersIsNull() {
+    // Given
+    notificationSealsContainers = null;
+
+    // When
+    boolean result = validator.isValid(notificationSealsContainers, null);
+
+    // Then
+    assertTrue(result);
+  }
+
+  @Test
+  public void validatorShouldReturnTrueIfSealContainersIsEmpty() {
+    // Given
+    notificationSealsContainers = Collections.emptyList();
+
+    // When
+    boolean result = validator.isValid(notificationSealsContainers, null);
+
+    // Then
+    assertTrue(result);
+  }
+
+  @Test
+  public void validatorShouldReturnFalseIfContainerNumberIsNull() {
+    // Given
+    notificationSealsContainers.get(0).setContainerNumber(null);
+
+    // When
+    boolean result = validator.isValid(notificationSealsContainers, null);
+
+    // Then
+    assertFalse(result);
+  }
+
+  @Test
+  public void validatorShouldReturnFalseIfContainerNumberIsEmpty() {
+    // Given
+    notificationSealsContainers.get(0).setContainerNumber("");
+
+
+    // When
+    boolean result = validator.isValid(notificationSealsContainers, null);
+
+    // Then
+    assertFalse(result);
+  }
+
+  @Test
+  public void validatorShouldReturnTrueIfTheContainerNumberHasAValue() {
+    // When
+    boolean result = validator.isValid(notificationSealsContainers, null);
+
+    // Then
+    assertTrue(result);
+  }
+}

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/SealNumberNotEmptyValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/SealNumberNotEmptyValidatorTest.java
@@ -1,0 +1,87 @@
+package uk.gov.defra.tracesx.notificationschema.validation.annotations;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.defra.tracesx.notificationschema.representation.NotificationSealsContainers;
+
+import java.util.Collections;
+import java.util.List;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SealNumberNotEmptyValidatorTest {
+
+  private SealNumberNotEmptyValidator validator;
+
+  private List<NotificationSealsContainers> notificationSealsContainers;
+
+  @Before
+  public void setUp() {
+    validator = new SealNumberNotEmptyValidator();
+    NotificationSealsContainers container = new NotificationSealsContainers();
+    container.setSealNumber("valid seal number");
+    notificationSealsContainers = List.of(container);
+  }
+
+  @Test
+  public void validatorShouldReturnTrueIfSealContainersIsNull() {
+    // Given
+    notificationSealsContainers = null;
+    // When
+    boolean result = validator.isValid(notificationSealsContainers, null);
+
+    // Then
+    assertTrue(result);
+  }
+
+  @Test
+  public void validatorShouldReturnTrueIfSealContainersIsEmpty() {
+    // Given
+    notificationSealsContainers = Collections.emptyList();
+
+    // When
+    boolean result = validator.isValid(notificationSealsContainers, null);
+
+    // Then
+    assertTrue(result);
+  }
+
+  @Test
+  public void validatorShouldReturnFalseIfContainerSealNumberIsNull() {
+    // Given
+    notificationSealsContainers.get(0).setSealNumber(null);
+
+
+    // When
+    boolean result = validator.isValid(notificationSealsContainers, null);
+
+    // Then
+    assertFalse(result);
+  }
+
+  @Test
+  public void validatorShouldReturnFalseIfContainerSealNumberIsEmpty() {
+    // Given
+    notificationSealsContainers.get(0).setSealNumber("");
+
+
+    // When
+    boolean result = validator.isValid(notificationSealsContainers, null);
+
+    // Then
+    assertFalse(result);
+  }
+
+  @Test
+  public void validatorShouldReturnTrueIfTheSealNumberHasAValue() {
+    // When
+    boolean result = validator.isValid(notificationSealsContainers, null);
+
+    // Then
+    assertTrue(result);
+  }
+}


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Holmes, Nathanael (Kainos) |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [IMTA-9980 added validation for seal numb...](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/223) |
> | **GitLab MR Number** | [223](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/223) |
> | **Date Originally Opened** | Tue, 27 Jul 2021 |
> | **Approved on GitLab by** | Callum Atwal (kainos), Reece Bennett (KAINOS), Sean Treanor (KAINOS), iwan roberts (KAINOS) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: Ticket: https://eaflood.atlassian.net/browse/IMTA-9980
### :book: Changes:
* Added validation to sealNumber and containerNumber fields if a sealContainer object is present in sealContainers
