### PR TITLE
IMTA-9759: Add Risk Decision Override fields to schema

### DIFF
--- a/imports-frontend-entities/src/entities/inspection_override.js
+++ b/imports-frontend-entities/src/entities/inspection_override.js
@@ -1,0 +1,17 @@
+const handler = require('./base/handler')
+
+module.exports = class InspectionOverride {
+
+  constructor(obj) {
+
+    if (!obj) {
+      obj = {}
+    }
+
+    this.originalDecision = obj.originalDecision
+    this.overriddenOn = obj.overriddenOn
+    this.overriddenBy = obj.overriddenBy
+
+    return Object.seal(new Proxy(this, handler))
+  }
+}

--- a/imports-frontend-entities/src/entities/part_two.js
+++ b/imports-frontend-entities/src/entities/part_two.js
@@ -10,6 +10,7 @@ const ConsignmentValidation = require('./consignment_validation')
 const EconomicOperator = require('./economic_operator')
 const AccompanyingDocument = require('./accompanying_document')
 const CommodityChecks = require('./commodity_checks')
+const InspectionOverride = require('./inspection_override')
 const { getList } = require('../utils/list')
 
 module.exports = class PartTwo {
@@ -47,6 +48,8 @@ module.exports = class PartTwo {
     this.phsiAutoCleared = obj.phsiAutoCleared
     this.hmiAutoCleared = obj.hmiAutoCleared
     this.inspectionRequired = obj.inspectionRequired
+    this.inspectionOverride = _.get(obj, 'inspectionOverride')
+        ? new InspectionOverride(obj.inspectionOverride) : undefined
 
     return Object.seal(new Proxy(this, handler))
   }

--- a/notification-schema-core/resources/notification-schema.json
+++ b/notification-schema-core/resources/notification-schema.json
@@ -787,6 +787,15 @@
     }
   },
   "definitions": {
+    "InspectionRequired": {
+      "type": "string",
+      "description": "Inspection required",
+      "enum": [
+        "Required",
+        "Inconclusive",
+        "Not required"
+      ]
+    },
     "ReferenceNumber": {
       "type": "string",
       "minLength": 1,
@@ -1247,13 +1256,27 @@
           "description": "Have the HMI regulated commodities been auto cleared?"
         },
         "inspectionRequired": {
-          "type": "string",
-          "description": "Inspection required",
-          "enum": [
-            "Required",
-            "Inconclusive",
-            "Not required"
-          ]
+          "$ref": "#/definitions/InspectionRequired",
+          "description": "Inspection required"
+        },
+        "inspectionOverride": {
+          "type": "object",
+          "description": "Details about the manual inspection override",
+          "properties": {
+            "originalDecision": {
+              "$ref": "#/definitions/InspectionRequired",
+              "description": "Original inspection decision"
+            },
+            "overriddenOn": {
+              "type": "string",
+              "javaType": "java.time.LocalDateTime",
+              "description": "The time the risk decision is overridden"
+            },
+            "overriddenBy": {
+              "$ref": "#/definitions/UserInformation",
+              "description": "User entity who has manually overridden the inspection"
+            }
+          }
         }
       }
     },

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/InspectionOverride.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/InspectionOverride.java
@@ -1,0 +1,33 @@
+package uk.gov.defra.tracesx.notificationschema.representation;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import uk.gov.defra.tracesx.notificationschema.representation.enumeration.InspectionRequired;
+import uk.gov.defra.tracesx.notificationschema.representation.serialisation.IsoOffsetDateTimeDeserializer;
+import uk.gov.defra.tracesx.notificationschema.representation.serialisation.IsoOffsetDateTimeSerializer;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Data
+@JsonInclude(Include.NON_EMPTY)
+@NoArgsConstructor(access = AccessLevel.PUBLIC)
+@AllArgsConstructor(access = AccessLevel.PUBLIC)
+public class InspectionOverride {
+
+  private InspectionRequired originalDecision;
+
+  @JsonSerialize(using = IsoOffsetDateTimeSerializer.class)
+  @JsonDeserialize(using = IsoOffsetDateTimeDeserializer.class)
+  private LocalDateTime overriddenOn;
+
+  private UserInformation overriddenBy;
+
+}

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/PartTwo.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/PartTwo.java
@@ -105,4 +105,6 @@ public class PartTwo {
   private Boolean hmiAutoCleared;
 
   private InspectionRequired inspectionRequired;
+
+  private InspectionOverride inspectionOverride;
 }


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Stephen McVeigh |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [IMTA-9759: Add Risk Decision Override fi...](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/224) |
> | **GitLab MR Number** | [224](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/224) |
> | **Date Originally Opened** | Mon, 2 Aug 2021 |
> | **Approved on GitLab by** | Callum Atwal (kainos), James Taylor, Juliano Saunders (Kainos), Karimou Lawani (kainos) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: Ticket: https://eaflood.atlassian.net/browse/IMTA-9759
### :book: Changes:
* Add fields for risk decision override: 
1.  Original decision
2.  Timestamp
3. Overridden by