### PR TITLE
IMTA-9990: add decision locking fields

### DIFF
--- a/imports-frontend-entities/package-lock.json
+++ b/imports-frontend-entities/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipaffs/imports-frontend-entities",
-  "version": "1.0.189",
+  "version": "1.0.192",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/imports-frontend-entities/package.json
+++ b/imports-frontend-entities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipaffs/imports-frontend-entities",
-  "version": "1.0.189",
+  "version": "1.0.192",
   "repository": {
     "type": "git"
   },

--- a/imports-frontend-entities/src/entities/notification.js
+++ b/imports-frontend-entities/src/entities/notification.js
@@ -43,6 +43,8 @@ module.exports = class Notification {
     this.replacedBy = obj.replacedBy
     this.lastUpdatedBy = obj.lastUpdatedBy
     this.agencyOrganisationId = obj.agencyOrganisationId
+    this.riskDecisionLockingTime = obj.riskDecisionLockingTime;
+    this.isRiskDecisionLocked = obj.isRiskDecisionLocked;
 
     validate(this)
 

--- a/notification-schema-core/resources/notification-schema.json
+++ b/notification-schema-core/resources/notification-schema.json
@@ -784,6 +784,15 @@
     "agencyOrganisationId": {
       "type": "string",
       "description": "Organisation id which the agent user belongs to, stored against each notification which has been raised on behalf of another organisation"
+    },
+    "riskDecisionLockingTime": {
+      "type": "string",
+      "javaType": "java.time.LocalDateTime",
+      "description": "Date and Time when risk decision was locked"
+    },
+    "isRiskDecisionLocked": {
+      "type": "boolean",
+      "description": "is the risk decision locked?"
     }
   },
   "definitions": {

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/Notification.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/Notification.java
@@ -148,4 +148,10 @@ public class Notification {
   public boolean isChedpp() {
     return NotificationTypeEnum.CHEDPP.equals(type);
   }
+
+  @JsonSerialize(using = IsoOffsetDateTimeSerializer.class)
+  @JsonDeserialize(using = IsoOffsetDateTimeDeserializer.class)
+  private LocalDateTime riskDecisionLockingTime;
+
+  private Boolean isRiskDecisionLocked;
 }


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Joshua Craig (Kainos) |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [IMTA-9990: add decision locking fields](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/225) |
> | **GitLab MR Number** | [225](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/225) |
> | **Date Originally Opened** | Thu, 5 Aug 2021 |
> | **Approved on GitLab by** | Callum Atwal (kainos), Kelly Moore, dominik henjes (KAINOS), kingsley.Osime (Kainos) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: Ticket: https://eaflood.atlassian.net/browse/IMTA-9990

### :book: Changes:

Added fields: 
* notification.riskDecisionLockingTime - datetime, nullable
* notification.isRiskDecisionLocked - Boolean, nullable