### PR TITLE
IMTA-10138 new options for results

### DIFF
--- a/notification-schema-core/resources/notification-schema.json
+++ b/notification-schema-core/resources/notification-schema.json
@@ -2088,6 +2088,7 @@
       "description": "Result of various checks",
       "enum": [
         "Satisfactory",
+        "Satisfactory following official intervention",
         "Not Satisfactory",
         "Not Done",
         "Derogation",

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/ConsignmentCheck.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/ConsignmentCheck.java
@@ -13,6 +13,7 @@ import uk.gov.defra.tracesx.notificationschema.representation.enumeration.Physic
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.Result;
 import uk.gov.defra.tracesx.notificationschema.validation.annotations.DocumentCheckResult;
 import uk.gov.defra.tracesx.notificationschema.validation.annotations.EuStandardValidator;
+import uk.gov.defra.tracesx.notificationschema.validation.annotations.HighRiskEUDocumentCheckResult;
 import uk.gov.defra.tracesx.notificationschema.validation.annotations.IdentityCheckReasonNotDone;
 import uk.gov.defra.tracesx.notificationschema.validation.annotations.IdentityCheckResult;
 import uk.gov.defra.tracesx.notificationschema.validation.annotations.IdentityCheckType;
@@ -22,6 +23,8 @@ import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCed
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCedOrCvedpFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCvedaFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCvedpFieldValidation;
+import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationDocumentCheckValidation;
+import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationHighRiskEUDocumentCheckValidation;
 
 import javax.validation.constraints.NotNull;
 
@@ -31,10 +34,15 @@ import javax.validation.constraints.NotNull;
 @NoArgsConstructor(access = AccessLevel.PUBLIC)
 @AllArgsConstructor(access = AccessLevel.PUBLIC)
 @DocumentCheckResult(
-    groups = NotificationCedOrCvedpFieldValidation.class,
+    groups = NotificationDocumentCheckValidation.class,
     message =
         "{uk.gov.defra.tracesx.notificationschema.representation.parttwo.consignmentcheck"
-            + ".documentarycheck.not.null}")
+            + ".documentarycheck.invalid.nonhighriskeu}")
+@HighRiskEUDocumentCheckResult(
+    groups = NotificationHighRiskEUDocumentCheckValidation.class,
+    message =
+        "{uk.gov.defra.tracesx.notificationschema.representation.parttwo.consignmentcheck"
+            + ".documentarycheck.invalid.highriskeu}")
 @IdentityCheckType(
     groups = {
         NotificationCvedpFieldValidation.class

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/Result.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/Result.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum Result {
   SATISFACTORY("Satisfactory"),
+  SATISFACTORY_FOLLOWING_OFFICIAL_INTERVENTION("Satisfactory following official intervention"),
   NOT_SATISFACTORY("Not Satisfactory"),
   NOT_DONE("Not Done"),
   DEROGATION("Derogation"),

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/DocumentCheckResultValidator.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/DocumentCheckResultValidator.java
@@ -1,6 +1,7 @@
 package uk.gov.defra.tracesx.notificationschema.validation.annotations;
 
 import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.Result.NOT_SET;
+import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.Result.SATISFACTORY_FOLLOWING_OFFICIAL_INTERVENTION;
 
 import uk.gov.defra.tracesx.notificationschema.representation.ConsignmentCheck;
 
@@ -20,6 +21,9 @@ public class DocumentCheckResultValidator
     if (consignmentCheck == null) {
       return true;
     }
-    return (consignmentCheck.getDocumentCheckResult() != NOT_SET);
+
+    return consignmentCheck.getDocumentCheckResult() != NOT_SET
+        && consignmentCheck.getDocumentCheckResult()
+            != SATISFACTORY_FOLLOWING_OFFICIAL_INTERVENTION;
   }
 }

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/HighRiskEUDocumentCheckResult.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/HighRiskEUDocumentCheckResult.java
@@ -1,0 +1,24 @@
+package uk.gov.defra.tracesx.notificationschema.validation.annotations;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+@Target({TYPE, ANNOTATION_TYPE})
+@Retention(RUNTIME)
+@Constraint(validatedBy = HighRiskEUDocumentCheckResultValidator.class)
+@Documented
+public @interface HighRiskEUDocumentCheckResult {
+
+  String message() default "Invalid option";
+
+  Class<?>[] groups() default {};
+
+  Class<? extends Payload>[] payload() default {};
+}

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/HighRiskEUDocumentCheckResultValidator.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/HighRiskEUDocumentCheckResultValidator.java
@@ -1,0 +1,28 @@
+package uk.gov.defra.tracesx.notificationschema.validation.annotations;
+
+import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.Result.NOT_SET;
+
+import uk.gov.defra.tracesx.notificationschema.representation.ConsignmentCheck;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class HighRiskEUDocumentCheckResultValidator
+    implements ConstraintValidator<HighRiskEUDocumentCheckResult, ConsignmentCheck> {
+
+  @Override
+  public void initialize(HighRiskEUDocumentCheckResult constraintAnnotation) {
+    // no action
+  }
+
+  @Override
+  public boolean isValid(
+      ConsignmentCheck consignmentCheck, ConstraintValidatorContext context) {
+
+    if (consignmentCheck == null) {
+      return true;
+    }
+
+    return consignmentCheck.getDocumentCheckResult() != NOT_SET;
+  }
+}

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/groups/NotificationDocumentCheckValidation.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/groups/NotificationDocumentCheckValidation.java
@@ -1,0 +1,5 @@
+package uk.gov.defra.tracesx.notificationschema.validation.groups;
+
+public interface NotificationDocumentCheckValidation extends NotificationHighRiskFieldValidation {
+
+}

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/groups/NotificationHighRiskEUDocumentCheckValidation.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/groups/NotificationHighRiskEUDocumentCheckValidation.java
@@ -1,0 +1,4 @@
+package uk.gov.defra.tracesx.notificationschema.validation.groups;
+
+public interface NotificationHighRiskEUDocumentCheckValidation
+    extends NotificationHighRiskFieldValidation {}

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/DocumentCheckResultValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/DocumentCheckResultValidatorTest.java
@@ -1,0 +1,66 @@
+package uk.gov.defra.tracesx.notificationschema.validation.annotations;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.Result.NOT_SATISFACTORY;
+import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.Result.NOT_SET;
+import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.Result.SATISFACTORY;
+import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.Result.SATISFACTORY_FOLLOWING_OFFICIAL_INTERVENTION;
+
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.defra.tracesx.notificationschema.representation.ConsignmentCheck;
+
+public class DocumentCheckResultValidatorTest {
+
+  private DocumentCheckResultValidator validator;
+
+  @Before
+  public void setUp() {
+    validator = new DocumentCheckResultValidator();
+  }
+
+  @Test
+  public void isValid_returnsTrue_whenConsignmentCheckIsNull() {
+    assertTrue(validator.isValid(null, null));
+  }
+
+  @Test
+  public void isValid_returnsTrue_whenDocumentCheckIsNull() {
+    ConsignmentCheck check = new ConsignmentCheck();
+
+    assertTrue(validator.isValid(check, null));
+  }
+
+  @Test
+  public void isValid_returnsFalse_whenDocumentCheckResultIsNotSet() {
+    ConsignmentCheck check = new ConsignmentCheck();
+    check.setDocumentCheckResult(NOT_SET);
+
+    assertFalse(validator.isValid(check, null));
+  }
+
+  @Test
+  public void isValid_returnsFalse_whenDocumentCheckResultIsSatisfactoryFollowingOfficialIntervention() {
+    ConsignmentCheck check = new ConsignmentCheck();
+    check.setDocumentCheckResult(SATISFACTORY_FOLLOWING_OFFICIAL_INTERVENTION);
+
+    assertFalse(validator.isValid(check, null));
+  }
+
+  @Test
+  public void isValid_returnsTrue_whenDocumentCheckResultIsSatisfactory() {
+    ConsignmentCheck check = new ConsignmentCheck();
+    check.setDocumentCheckResult(SATISFACTORY);
+
+    assertTrue(validator.isValid(check, null));
+  }
+
+  @Test
+  public void isValid_returnsTrue_whenDocumentCheckResultIsNotSatisfactory() {
+    ConsignmentCheck check = new ConsignmentCheck();
+    check.setDocumentCheckResult(NOT_SATISFACTORY);
+
+    assertTrue(validator.isValid(check, null));
+  }
+}

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/HighRiskEUDocumentCheckResultValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/HighRiskEUDocumentCheckResultValidatorTest.java
@@ -5,34 +5,35 @@ import static org.junit.Assert.assertFalse;
 import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.Result.NOT_SATISFACTORY;
 import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.Result.NOT_SET;
 import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.Result.SATISFACTORY;
+import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.Result.SATISFACTORY_FOLLOWING_OFFICIAL_INTERVENTION;
 
 import org.junit.Before;
 import org.junit.Test;
 import uk.gov.defra.tracesx.notificationschema.representation.ConsignmentCheck;
 
-public class DocumentCheckEuStandardValidatorTest {
+public class HighRiskEUDocumentCheckResultValidatorTest {
 
-  private DocumentCheckResultValidator validator;
+  private HighRiskEUDocumentCheckResultValidator validator;
 
   @Before
   public void setUp() {
-    validator = new DocumentCheckResultValidator();
+    validator = new HighRiskEUDocumentCheckResultValidator();
   }
 
   @Test
-  public void testThatValidatorReturnsTrueIfNullPassed() {
+  public void isValid_returnsTrue_whenConsignmentCheckIsNull() {
     assertTrue(validator.isValid(null, null));
   }
 
   @Test
-  public void testThatValidatorReturnsTrueIfIsDocumentCheckResultReturnsNull() {
+  public void isValid_returnsTrue_whenDocumentCheckIsNull() {
     ConsignmentCheck check = new ConsignmentCheck();
 
     assertTrue(validator.isValid(check, null));
   }
 
   @Test
-  public void testThatValidatorReturnsFalseIfDocumentCheckResultIsNotSet() {
+  public void isValid_returnsFalse_whenDocumentCheckIsNotSet() {
     ConsignmentCheck check = new ConsignmentCheck();
     check.setDocumentCheckResult(NOT_SET);
 
@@ -40,7 +41,15 @@ public class DocumentCheckEuStandardValidatorTest {
   }
 
   @Test
-  public void testThatValidatorReturnsTrueIfDocumentCheckResultIsSatisfactory() {
+  public void isValid_returnsTrue_whenDocumentCheckResultIsSatisfactoryFollowingOfficialIntervention() {
+    ConsignmentCheck check = new ConsignmentCheck();
+    check.setDocumentCheckResult(SATISFACTORY_FOLLOWING_OFFICIAL_INTERVENTION);
+
+    assertTrue(validator.isValid(check, null));
+  }
+
+  @Test
+  public void isValid_returnsTrue_whenDocumentCheckResultIsSatisfactory() {
     ConsignmentCheck check = new ConsignmentCheck();
     check.setDocumentCheckResult(SATISFACTORY);
 
@@ -48,7 +57,7 @@ public class DocumentCheckEuStandardValidatorTest {
   }
 
   @Test
-  public void testThatValidatorReturnsTrueIffDocumentCheckResultIsNotSatisfactory() {
+  public void isValid_returnsTrue_whenDocumentCheckResultIsNotSatisfactory() {
     ConsignmentCheck check = new ConsignmentCheck();
     check.setDocumentCheckResult(NOT_SATISFACTORY);
 


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | bridget.hodgson (Kainos) |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [IMTA-10138 new options for results](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/227) |
> | **GitLab MR Number** | [227](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/227) |
> | **Date Originally Opened** | Tue, 24 Aug 2021 |
> | **Approved on GitLab by** | James Taylor, Reece Bennett (KAINOS), Robert Hall (KAINOS), lee mason (KAINOS) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: Ticket: https://eaflood.atlassian.net/browse/IMTA-10138

### :book: Changes:
* New option for a Result on IPAFFS. "Satisfactory following official intervention"
* New option should only be for high risk EU notifications.  Ched P and Ched D only.