### PR TITLE
IMTA-9803: Add validation for part two decision default options

### DIFF
--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/Decision.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/Decision.java
@@ -26,9 +26,16 @@ import uk.gov.defra.tracesx.notificationschema.validation.annotations.NotAccepta
 import uk.gov.defra.tracesx.notificationschema.validation.annotations.NotAcceptableEstablishment;
 import uk.gov.defra.tracesx.notificationschema.validation.annotations.NotAcceptableOtherReason;
 import uk.gov.defra.tracesx.notificationschema.validation.annotations.NotAcceptableReason;
+import uk.gov.defra.tracesx.notificationschema.validation.annotations.NotNullTemporaryExitBip;
+import uk.gov.defra.tracesx.notificationschema.validation.annotations.NotNullTranshipmentBip;
+import uk.gov.defra.tracesx.notificationschema.validation.annotations.NotNullTranshipmentThirdCountry;
+import uk.gov.defra.tracesx.notificationschema.validation.annotations.NotNullTransitDestinationThirdCountry;
+import uk.gov.defra.tracesx.notificationschema.validation.annotations.NotNullTransitExitBip;
+import uk.gov.defra.tracesx.notificationschema.validation.annotations.NotNullTransitThirdCountry;
 import uk.gov.defra.tracesx.notificationschema.validation.annotations.SpecificWarehouse;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCedFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCedOrCvedpFieldValidation;
+import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCvedaOrCvedpFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCvedpFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationHighRiskNonChedppFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationNotAcceptableReasonsValidation;
@@ -65,6 +72,36 @@ import javax.validation.constraints.NotNull;
     message =
         "{uk.gov.defra.tracesx.notificationschema.representation.parttwo.decision"
             + ".notacceptablecountry.not.null}")
+@NotNullTemporaryExitBip(
+    groups = NotificationCvedaOrCvedpFieldValidation.class,
+    message =
+        "{uk.gov.defra.tracesx.notificationschema.representation.parttwo.decision"
+            + ".temporaryexitbip.not.null}")
+@NotNullTranshipmentBip(
+    groups = NotificationCvedaOrCvedpFieldValidation.class,
+    message =
+        "{uk.gov.defra.tracesx.notificationschema.representation.parttwo.decision"
+            + ".transhipmentbip.not.null}")
+@NotNullTranshipmentThirdCountry(
+    groups = NotificationCvedaOrCvedpFieldValidation.class,
+    message =
+        "{uk.gov.defra.tracesx.notificationschema.representation.parttwo.decision"
+            + ".transhipmentthirdcountry.not.null}")
+@NotNullTransitDestinationThirdCountry(
+    groups = NotificationCvedaOrCvedpFieldValidation.class,
+    message =
+        "{uk.gov.defra.tracesx.notificationschema.representation.parttwo.decision"
+            + ".transitdestinationthirdcountry.not.null}")
+@NotNullTransitExitBip(
+    groups = NotificationCvedaOrCvedpFieldValidation.class,
+    message =
+        "{uk.gov.defra.tracesx.notificationschema.representation.parttwo.decision"
+            + ".transitexitbip.not.null}")
+@NotNullTransitThirdCountry(
+    groups = NotificationCvedaOrCvedpFieldValidation.class,
+    message =
+        "{uk.gov.defra.tracesx.notificationschema.representation.parttwo.decision"
+            + ".transitthirdcountry.not.null}")
 @SpecificWarehouse(
     groups = {
         NotificationCvedpFieldValidation.class

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/NotNullTemporaryExitBip.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/NotNullTemporaryExitBip.java
@@ -1,0 +1,22 @@
+package uk.gov.defra.tracesx.notificationschema.validation.annotations;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+@Target({TYPE})
+@Retention(RUNTIME)
+@Constraint(validatedBy = NotNullTemporaryExitBipValidator.class)
+@Documented
+public @interface NotNullTemporaryExitBip {
+  String message() default "Temporary exit BIP must be selected";
+
+  Class<?>[] groups() default {};
+
+  Class<? extends Payload>[] payload() default {};
+}

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/NotNullTemporaryExitBipValidator.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/NotNullTemporaryExitBipValidator.java
@@ -1,0 +1,36 @@
+package uk.gov.defra.tracesx.notificationschema.validation.annotations;
+
+import org.apache.commons.lang3.StringUtils;
+import uk.gov.defra.tracesx.notificationschema.representation.Decision;
+import uk.gov.defra.tracesx.notificationschema.representation.enumeration.DecisionEnum;
+import uk.gov.defra.tracesx.notificationschema.validation.utils.HibernateContextUtils;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class NotNullTemporaryExitBipValidator implements
+    ConstraintValidator<NotNullTemporaryExitBip, Decision> {
+
+  @Override
+  public void initialize(NotNullTemporaryExitBip constraintAnnotation) {
+    // No action
+  }
+
+  @Override
+  public boolean isValid(Decision decision, ConstraintValidatorContext context) {
+    boolean isValid = true;
+    if (decision != null && decision.getDecision() != null
+        && DecisionEnum.ACCEPTABLE_FOR_TEMPORARY_IMPORT.equals(decision.getDecision())) {
+      isValid = StringUtils.isNotBlank(decision.getTemporaryExitBip());
+    }
+
+    if (!isValid) {
+      HibernateContextUtils.setHibernateContext(context,
+          "{uk.gov.defra.tracesx.notificationschema.representation.parttwo.decision"
+              + ".temporaryexitbip.not.null}",
+          "temporaryexitbip");
+    }
+
+    return isValid;
+  }
+}

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/NotNullTranshipmentBip.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/NotNullTranshipmentBip.java
@@ -1,0 +1,22 @@
+package uk.gov.defra.tracesx.notificationschema.validation.annotations;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+@Target({TYPE})
+@Retention(RUNTIME)
+@Constraint(validatedBy = NotNullTranshipmentBipValidator.class)
+@Documented
+public @interface NotNullTranshipmentBip {
+  String message() default "Transhipment BIP must be selected";
+
+  Class<?>[] groups() default {};
+
+  Class<? extends Payload>[] payload() default {};
+}

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/NotNullTranshipmentBipValidator.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/NotNullTranshipmentBipValidator.java
@@ -1,0 +1,36 @@
+package uk.gov.defra.tracesx.notificationschema.validation.annotations;
+
+import org.apache.commons.lang3.StringUtils;
+import uk.gov.defra.tracesx.notificationschema.representation.Decision;
+import uk.gov.defra.tracesx.notificationschema.representation.enumeration.DecisionEnum;
+import uk.gov.defra.tracesx.notificationschema.validation.utils.HibernateContextUtils;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class NotNullTranshipmentBipValidator implements
+    ConstraintValidator<NotNullTranshipmentBip, Decision> {
+
+  @Override
+  public void initialize(NotNullTranshipmentBip constraintAnnotation) {
+    // No action
+  }
+
+  @Override
+  public boolean isValid(Decision decision, ConstraintValidatorContext context) {
+    boolean isValid = true;
+    if (decision != null && decision.getDecision() != null
+        && DecisionEnum.ACCEPTABLE_FOR_TRANSHIPMENT.equals(decision.getDecision())) {
+      isValid = StringUtils.isNotBlank(decision.getTranshipmentBip());
+    }
+
+    if (!isValid) {
+      HibernateContextUtils.setHibernateContext(context,
+          "{uk.gov.defra.tracesx.notificationschema.representation.parttwo.decision"
+              + ".transhipmentbip.not.null}",
+          "transhipmentbip");
+    }
+
+    return isValid;
+  }
+}

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/NotNullTranshipmentThirdCountry.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/NotNullTranshipmentThirdCountry.java
@@ -1,0 +1,22 @@
+package uk.gov.defra.tracesx.notificationschema.validation.annotations;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+@Target({TYPE})
+@Retention(RUNTIME)
+@Constraint(validatedBy = NotNullTranshipmentThirdCountryValidator.class)
+@Documented
+public @interface NotNullTranshipmentThirdCountry {
+  String message() default "Transhipment exit country must be selected";
+
+  Class<?>[] groups() default {};
+
+  Class<? extends Payload>[] payload() default {};
+}

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/NotNullTranshipmentThirdCountryValidator.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/NotNullTranshipmentThirdCountryValidator.java
@@ -1,0 +1,36 @@
+package uk.gov.defra.tracesx.notificationschema.validation.annotations;
+
+import org.apache.commons.lang3.StringUtils;
+import uk.gov.defra.tracesx.notificationschema.representation.Decision;
+import uk.gov.defra.tracesx.notificationschema.representation.enumeration.DecisionEnum;
+import uk.gov.defra.tracesx.notificationschema.validation.utils.HibernateContextUtils;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class NotNullTranshipmentThirdCountryValidator implements
+    ConstraintValidator<NotNullTranshipmentThirdCountry, Decision> {
+
+  @Override
+  public void initialize(NotNullTranshipmentThirdCountry constraintAnnotation) {
+    // No action
+  }
+
+  @Override
+  public boolean isValid(Decision decision, ConstraintValidatorContext context) {
+    boolean isValid = true;
+    if (decision != null && decision.getDecision() != null
+        && DecisionEnum.ACCEPTABLE_FOR_TRANSHIPMENT.equals(decision.getDecision())) {
+      isValid = StringUtils.isNotBlank(decision.getTranshipmentThirdCountry());
+    }
+
+    if (!isValid) {
+      HibernateContextUtils.setHibernateContext(context,
+          "{uk.gov.defra.tracesx.notificationschema.representation.parttwo.decision"
+              + ".transhipmentthirdcountry.not.null}",
+          "transhipmentthirdcountry");
+    }
+
+    return isValid;
+  }
+}

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/NotNullTransitDestinationThirdCountry.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/NotNullTransitDestinationThirdCountry.java
@@ -1,0 +1,22 @@
+package uk.gov.defra.tracesx.notificationschema.validation.annotations;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+@Target({TYPE})
+@Retention(RUNTIME)
+@Constraint(validatedBy = NotNullTransitDestinationThirdCountryValidator.class)
+@Documented
+public @interface NotNullTransitDestinationThirdCountry {
+  String message() default "Transit exit country must be selected";
+
+  Class<?>[] groups() default {};
+
+  Class<? extends Payload>[] payload() default {};
+}

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/NotNullTransitDestinationThirdCountryValidator.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/NotNullTransitDestinationThirdCountryValidator.java
@@ -1,0 +1,36 @@
+package uk.gov.defra.tracesx.notificationschema.validation.annotations;
+
+import org.apache.commons.lang3.StringUtils;
+import uk.gov.defra.tracesx.notificationschema.representation.Decision;
+import uk.gov.defra.tracesx.notificationschema.representation.enumeration.DecisionEnum;
+import uk.gov.defra.tracesx.notificationschema.validation.utils.HibernateContextUtils;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class NotNullTransitDestinationThirdCountryValidator implements
+    ConstraintValidator<NotNullTransitDestinationThirdCountry, Decision> {
+
+  @Override
+  public void initialize(NotNullTransitDestinationThirdCountry constraintAnnotation) {
+    // No action
+  }
+
+  @Override
+  public boolean isValid(Decision decision, ConstraintValidatorContext context) {
+    boolean isValid = true;
+    if (decision != null && decision.getDecision() != null
+        && DecisionEnum.ACCEPTABLE_FOR_TRANSIT.equals(decision.getDecision())) {
+      isValid = StringUtils.isNotBlank(decision.getTransitDestinationThirdCountry());
+    }
+
+    if (!isValid) {
+      HibernateContextUtils.setHibernateContext(context,
+          "{uk.gov.defra.tracesx.notificationschema.representation.parttwo.decision"
+              + ".transitdestinationthirdcountry.not.null}",
+          "transitdestinationthirdcountry");
+    }
+
+    return isValid;
+  }
+}

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/NotNullTransitExitBip.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/NotNullTransitExitBip.java
@@ -1,0 +1,22 @@
+package uk.gov.defra.tracesx.notificationschema.validation.annotations;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+@Target({TYPE})
+@Retention(RUNTIME)
+@Constraint(validatedBy = NotNullTransitExitBipValidator.class)
+@Documented
+public @interface NotNullTransitExitBip {
+  String message() default "Transit exit BIP must be selected";
+
+  Class<?>[] groups() default {};
+
+  Class<? extends Payload>[] payload() default {};
+}

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/NotNullTransitExitBipValidator.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/NotNullTransitExitBipValidator.java
@@ -1,0 +1,36 @@
+package uk.gov.defra.tracesx.notificationschema.validation.annotations;
+
+import org.apache.commons.lang3.StringUtils;
+import uk.gov.defra.tracesx.notificationschema.representation.Decision;
+import uk.gov.defra.tracesx.notificationschema.representation.enumeration.DecisionEnum;
+import uk.gov.defra.tracesx.notificationschema.validation.utils.HibernateContextUtils;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class NotNullTransitExitBipValidator implements
+    ConstraintValidator<NotNullTransitExitBip, Decision> {
+
+  @Override
+  public void initialize(NotNullTransitExitBip constraintAnnotation) {
+    // No action
+  }
+
+  @Override
+  public boolean isValid(Decision decision, ConstraintValidatorContext context) {
+    boolean isValid = true;
+    if (decision != null && decision.getDecision() != null
+        && DecisionEnum.ACCEPTABLE_FOR_TRANSIT.equals(decision.getDecision())) {
+      isValid = StringUtils.isNotBlank(decision.getTransitExitBip());
+    }
+
+    if (!isValid) {
+      HibernateContextUtils.setHibernateContext(context,
+          "{uk.gov.defra.tracesx.notificationschema.representation.parttwo.decision"
+              + ".transitexitbip.not.null}",
+          "transitexitbip");
+    }
+
+    return isValid;
+  }
+}

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/NotNullTransitThirdCountry.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/NotNullTransitThirdCountry.java
@@ -1,0 +1,22 @@
+package uk.gov.defra.tracesx.notificationschema.validation.annotations;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+@Target({TYPE})
+@Retention(RUNTIME)
+@Constraint(validatedBy = NotNullTransitThirdCountryValidator.class)
+@Documented
+public @interface NotNullTransitThirdCountry {
+  String message() default "Transit exit country must be selected";
+
+  Class<?>[] groups() default {};
+
+  Class<? extends Payload>[] payload() default {};
+}

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/NotNullTransitThirdCountryValidator.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/NotNullTransitThirdCountryValidator.java
@@ -1,0 +1,36 @@
+package uk.gov.defra.tracesx.notificationschema.validation.annotations;
+
+import org.apache.commons.lang3.StringUtils;
+import uk.gov.defra.tracesx.notificationschema.representation.Decision;
+import uk.gov.defra.tracesx.notificationschema.representation.enumeration.DecisionEnum;
+import uk.gov.defra.tracesx.notificationschema.validation.utils.HibernateContextUtils;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class NotNullTransitThirdCountryValidator implements
+    ConstraintValidator<NotNullTransitThirdCountry, Decision> {
+
+  @Override
+  public void initialize(NotNullTransitThirdCountry constraintAnnotation) {
+    // No action
+  }
+
+  @Override
+  public boolean isValid(Decision decision, ConstraintValidatorContext context) {
+    boolean isValid = true;
+    if (decision != null && decision.getDecision() != null
+        && DecisionEnum.ACCEPTABLE_FOR_TRANSIT.equals(decision.getDecision())) {
+      isValid = StringUtils.isNotBlank(decision.getTransitThirdCountry());
+    }
+
+    if (!isValid) {
+      HibernateContextUtils.setHibernateContext(context,
+          "{uk.gov.defra.tracesx.notificationschema.representation.parttwo.decision"
+              + ".transitthirdcountry.not.null}",
+          "transitthirdcountry");
+    }
+
+    return isValid;
+  }
+}

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/groups/NotificationCvedaOrCvedpFieldValidation.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/groups/NotificationCvedaOrCvedpFieldValidation.java
@@ -1,0 +1,5 @@
+package uk.gov.defra.tracesx.notificationschema.validation.groups;
+
+public interface NotificationCvedaOrCvedpFieldValidation extends
+        NotificationHighRiskFieldValidation {
+}

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/utils/HibernateContextUtils.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/utils/HibernateContextUtils.java
@@ -1,0 +1,22 @@
+package uk.gov.defra.tracesx.notificationschema.validation.utils;
+
+import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorContext;
+
+import javax.validation.ConstraintValidatorContext;
+
+public class HibernateContextUtils {
+
+  private HibernateContextUtils() {
+  }
+
+  public static void setHibernateContext(ConstraintValidatorContext context,
+                                         String message, String propertyPath) {
+    HibernateConstraintValidatorContext hibernateContext =
+        context.unwrap(HibernateConstraintValidatorContext.class);
+    hibernateContext.disableDefaultConstraintViolation();
+    hibernateContext
+        .buildConstraintViolationWithTemplate(message)
+        .addPropertyNode(propertyPath)
+        .addConstraintViolation();
+  }
+}

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/NotNullTemporaryExitBipValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/NotNullTemporaryExitBipValidatorTest.java
@@ -1,0 +1,105 @@
+package uk.gov.defra.tracesx.notificationschema.validation.annotations;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.DecisionEnum.ACCEPTABLE_FOR_TEMPORARY_IMPORT;
+import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.DecisionEnum.ACCEPTABLE_FOR_TRANSIT;
+
+import javax.validation.ConstraintValidatorContext;
+import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorContext;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.theories.DataPoints;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.defra.tracesx.notificationschema.representation.Decision;
+import uk.gov.defra.tracesx.notificationschema.representation.enumeration.DecisionEnum;
+
+@RunWith(MockitoJUnitRunner.class)
+public class NotNullTemporaryExitBipValidatorTest {
+
+  @DataPoints("Other decisions")
+  public static final DecisionEnum[] decisions =
+      new DecisionEnum[]{
+          ACCEPTABLE_FOR_TEMPORARY_IMPORT
+      };
+  @Mock
+  HibernateConstraintValidatorContext hibernateConstraintValidatorContextMock;
+  @Mock
+  ConstraintValidatorContext constraintValidatorContextMock;
+  @Mock
+  ConstraintValidatorContext.ConstraintViolationBuilder constraintViolationBuilderMock;
+  @Mock
+  ConstraintValidatorContext.ConstraintViolationBuilder.NodeBuilderCustomizableContext nodeBuilderContextMock;
+  private NotNullTemporaryExitBipValidator validator;
+  private Decision decision;
+
+  @Before
+  public void setUp() {
+    validator = new NotNullTemporaryExitBipValidator();
+    this.decision = Decision.builder().build();
+
+    when(constraintValidatorContextMock
+        .unwrap(HibernateConstraintValidatorContext.class))
+        .thenReturn(hibernateConstraintValidatorContextMock);
+
+    when(hibernateConstraintValidatorContextMock
+        .buildConstraintViolationWithTemplate(anyString()))
+        .thenReturn(constraintViolationBuilderMock);
+
+    when(constraintViolationBuilderMock.addPropertyNode(anyString()))
+        .thenReturn(nodeBuilderContextMock);
+  }
+
+  @Test
+  public void isValid_ReturnsTrue_WhenNoPartTwo() {
+    assertThat(validator.isValid(null, constraintValidatorContextMock)).isTrue();
+  }
+
+  @Test
+  public void isValid_ReturnsTrue_WhenNoDecision() {
+    assertThat(validator.isValid(decision, constraintValidatorContextMock)).isTrue();
+  }
+
+  @Test
+  public void isValid_ReturnsTrue_WhenDecisionIsNull() {
+    decision.setDecision(null);
+
+    assertThat(validator.isValid(decision, constraintValidatorContextMock)).isTrue();
+  }
+
+  @Test
+  public void isValid_ReturnsFalse_WhenTemporaryExitBipIsNull() {
+    decision.setDecision(ACCEPTABLE_FOR_TEMPORARY_IMPORT);
+    decision.setTemporaryExitBip(null);
+
+    assertThat(validator.isValid(decision, constraintValidatorContextMock)).isFalse();
+  }
+
+  @Test
+  public void isValid_ReturnsTrue_WhenTemporaryExitBipIsNullAndAcceptableForTransit() {
+    decision.setDecision(ACCEPTABLE_FOR_TRANSIT);
+    decision.setTemporaryExitBip(null);
+
+    assertThat(validator.isValid(decision, constraintValidatorContextMock)).isTrue();
+  }
+
+  @Test
+  public void isValid_ReturnsFalse_WhenTemporaryExitBipIsEmptyString() {
+    decision.setDecision(ACCEPTABLE_FOR_TEMPORARY_IMPORT);
+    decision.setTemporaryExitBip("");
+
+    assertThat(validator.isValid(decision, constraintValidatorContextMock)).isFalse();
+  }
+
+  @Test
+  public void isValid_ReturnsTrue_WhenDecisionIsAcceptableForTemporaryImport() {
+    decision.setDecision(ACCEPTABLE_FOR_TEMPORARY_IMPORT);
+    decision.setTemporaryExitBip("GBPHD1");
+
+    assertThat(validator.isValid(decision, constraintValidatorContextMock)).isTrue();
+  }
+
+}

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/NotNullTranshipmentBipValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/NotNullTranshipmentBipValidatorTest.java
@@ -1,0 +1,104 @@
+package uk.gov.defra.tracesx.notificationschema.validation.annotations;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.DecisionEnum.ACCEPTABLE_FOR_TRANSHIPMENT;
+import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.DecisionEnum.ACCEPTABLE_FOR_TRANSIT;
+
+import javax.validation.ConstraintValidatorContext;
+import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorContext;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.theories.DataPoints;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.defra.tracesx.notificationschema.representation.Decision;
+import uk.gov.defra.tracesx.notificationschema.representation.enumeration.DecisionEnum;
+
+@RunWith(MockitoJUnitRunner.class)
+public class NotNullTranshipmentBipValidatorTest {
+
+  @DataPoints("Other decisions")
+  public static final DecisionEnum[] decisions =
+      new DecisionEnum[]{
+          ACCEPTABLE_FOR_TRANSHIPMENT
+      };
+  @Mock
+  HibernateConstraintValidatorContext hibernateConstraintValidatorContextMock;
+  @Mock
+  ConstraintValidatorContext constraintValidatorContextMock;
+  @Mock
+  ConstraintValidatorContext.ConstraintViolationBuilder constraintViolationBuilderMock;
+  @Mock
+  ConstraintValidatorContext.ConstraintViolationBuilder.NodeBuilderCustomizableContext nodeBuilderContextMock;
+  private NotNullTranshipmentBipValidator validator;
+  private Decision decision;
+
+  @Before
+  public void setUp() {
+    validator = new NotNullTranshipmentBipValidator();
+    this.decision = Decision.builder().build();
+
+    when(constraintValidatorContextMock
+        .unwrap(HibernateConstraintValidatorContext.class))
+        .thenReturn(hibernateConstraintValidatorContextMock);
+
+    when(hibernateConstraintValidatorContextMock
+        .buildConstraintViolationWithTemplate(anyString()))
+        .thenReturn(constraintViolationBuilderMock);
+
+    when(constraintViolationBuilderMock.addPropertyNode(anyString()))
+        .thenReturn(nodeBuilderContextMock);
+  }
+
+  @Test
+  public void isValid_ReturnsTrue_WhenNoPartTwo() {
+    assertThat(validator.isValid(null, constraintValidatorContextMock)).isTrue();
+  }
+
+  @Test
+  public void isValid_ReturnsTrue_WhenNoDecision() {
+    assertThat(validator.isValid(decision, constraintValidatorContextMock)).isTrue();
+  }
+
+  @Test
+  public void isValid_ReturnsTrue_WhenDecisionIsNull() {
+    decision.setDecision(null);
+
+    assertThat(validator.isValid(decision, constraintValidatorContextMock)).isTrue();
+  }
+
+  @Test
+  public void isValid_ReturnsFalse_WhenTranshipmentBipIsNull() {
+    decision.setDecision(ACCEPTABLE_FOR_TRANSHIPMENT);
+    decision.setTranshipmentBip(null);
+
+    assertThat(validator.isValid(decision, constraintValidatorContextMock)).isFalse();
+  }
+
+  @Test
+  public void isValid_ReturnsTrue_WhenTranshipmentBipIsNullAndAcceptableForTransit() {
+    decision.setDecision(ACCEPTABLE_FOR_TRANSIT);
+    decision.setTranshipmentBip(null);
+
+    assertThat(validator.isValid(decision, constraintValidatorContextMock)).isTrue();
+  }
+
+  @Test
+  public void isValid_ReturnsFalse_WhenTranshipmentBipIsEmptyString() {
+    decision.setDecision(ACCEPTABLE_FOR_TRANSHIPMENT);
+    decision.setTranshipmentBip("");
+
+    assertThat(validator.isValid(decision, constraintValidatorContextMock)).isFalse();
+  }
+
+  @Test
+  public void isValid_ReturnsTrue_WhenDecisionIsAcceptableForTranshipment() {
+    decision.setDecision(ACCEPTABLE_FOR_TRANSHIPMENT);
+    decision.setTranshipmentBip("GBPHD1");
+
+    assertThat(validator.isValid(decision, constraintValidatorContextMock)).isTrue();
+  }
+}

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/NotNullTranshipmentThirdCountryValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/NotNullTranshipmentThirdCountryValidatorTest.java
@@ -1,0 +1,104 @@
+package uk.gov.defra.tracesx.notificationschema.validation.annotations;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.DecisionEnum.ACCEPTABLE_FOR_TRANSHIPMENT;
+import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.DecisionEnum.ACCEPTABLE_FOR_TRANSIT;
+
+import javax.validation.ConstraintValidatorContext;
+import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorContext;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.theories.DataPoints;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.defra.tracesx.notificationschema.representation.Decision;
+import uk.gov.defra.tracesx.notificationschema.representation.enumeration.DecisionEnum;
+
+@RunWith(MockitoJUnitRunner.class)
+public class NotNullTranshipmentThirdCountryValidatorTest {
+
+  @DataPoints("Other decisions")
+  public static final DecisionEnum[] decisions =
+      new DecisionEnum[]{
+          ACCEPTABLE_FOR_TRANSHIPMENT
+      };
+  @Mock
+  HibernateConstraintValidatorContext hibernateConstraintValidatorContextMock;
+  @Mock
+  ConstraintValidatorContext constraintValidatorContextMock;
+  @Mock
+  ConstraintValidatorContext.ConstraintViolationBuilder constraintViolationBuilderMock;
+  @Mock
+  ConstraintValidatorContext.ConstraintViolationBuilder.NodeBuilderCustomizableContext nodeBuilderContextMock;
+  private NotNullTranshipmentThirdCountryValidator validator;
+  private Decision decision;
+
+  @Before
+  public void setUp() {
+    validator = new NotNullTranshipmentThirdCountryValidator();
+    this.decision = Decision.builder().build();
+
+    when(constraintValidatorContextMock
+        .unwrap(HibernateConstraintValidatorContext.class))
+        .thenReturn(hibernateConstraintValidatorContextMock);
+
+    when(hibernateConstraintValidatorContextMock
+        .buildConstraintViolationWithTemplate(anyString()))
+        .thenReturn(constraintViolationBuilderMock);
+
+    when(constraintViolationBuilderMock.addPropertyNode(anyString()))
+        .thenReturn(nodeBuilderContextMock);
+  }
+
+  @Test
+  public void isValid_ReturnsTrue_WhenNoPartTwo() {
+    assertThat(validator.isValid(null, constraintValidatorContextMock)).isTrue();
+  }
+
+  @Test
+  public void isValid_ReturnsTrue_WhenNoDecision() {
+    assertThat(validator.isValid(decision, constraintValidatorContextMock)).isTrue();
+  }
+
+  @Test
+  public void isValid_ReturnsTrue_WhenDecisionIsNull() {
+    decision.setDecision(null);
+
+    assertThat(validator.isValid(decision, constraintValidatorContextMock)).isTrue();
+  }
+
+  @Test
+  public void isValid_ReturnsFalse_WhenTranshipmentBipIsNull() {
+    decision.setDecision(ACCEPTABLE_FOR_TRANSHIPMENT);
+    decision.setTranshipmentThirdCountry(null);
+
+    assertThat(validator.isValid(decision, constraintValidatorContextMock)).isFalse();
+  }
+
+  @Test
+  public void isValid_ReturnsTrue_WhenTranshipmentThirdCountryIsNullAndAcceptableForTransit() {
+    decision.setDecision(ACCEPTABLE_FOR_TRANSIT);
+    decision.setTranshipmentThirdCountry(null);
+
+    assertThat(validator.isValid(decision, constraintValidatorContextMock)).isTrue();
+  }
+
+  @Test
+  public void isValid_ReturnsFalse_WhenTranshipmentThirdCountryIsEmptyString() {
+    decision.setDecision(ACCEPTABLE_FOR_TRANSHIPMENT);
+    decision.setTranshipmentThirdCountry("");
+
+    assertThat(validator.isValid(decision, constraintValidatorContextMock)).isFalse();
+  }
+
+  @Test
+  public void isValid_ReturnsTrue_WhenDecisionIsAcceptableForTranshipment() {
+    decision.setDecision(ACCEPTABLE_FOR_TRANSHIPMENT);
+    decision.setTranshipmentThirdCountry("AF");
+
+    assertThat(validator.isValid(decision, constraintValidatorContextMock)).isTrue();
+  }
+}

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/NotNullTransitDestinationThirdCountryValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/NotNullTransitDestinationThirdCountryValidatorTest.java
@@ -1,0 +1,105 @@
+package uk.gov.defra.tracesx.notificationschema.validation.annotations;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.DecisionEnum.ACCEPTABLE_FOR_TRANSHIPMENT;
+import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.DecisionEnum.ACCEPTABLE_FOR_TRANSIT;
+
+import javax.validation.ConstraintValidatorContext;
+import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorContext;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.theories.DataPoints;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.defra.tracesx.notificationschema.representation.Decision;
+import uk.gov.defra.tracesx.notificationschema.representation.enumeration.DecisionEnum;
+
+@RunWith(MockitoJUnitRunner.class)
+public class NotNullTransitDestinationThirdCountryValidatorTest {
+
+  @DataPoints("Other decisions")
+  public static final DecisionEnum[] decisions =
+      new DecisionEnum[]{
+          ACCEPTABLE_FOR_TRANSIT
+      };
+  @Mock
+  HibernateConstraintValidatorContext hibernateConstraintValidatorContextMock;
+  @Mock
+  ConstraintValidatorContext constraintValidatorContextMock;
+  @Mock
+  ConstraintValidatorContext.ConstraintViolationBuilder constraintViolationBuilderMock;
+  @Mock
+  ConstraintValidatorContext.ConstraintViolationBuilder.NodeBuilderCustomizableContext nodeBuilderContextMock;
+  private NotNullTransitDestinationThirdCountryValidator validator;
+  private Decision decision;
+
+  @Before
+  public void setUp() {
+    validator = new NotNullTransitDestinationThirdCountryValidator();
+    this.decision = Decision.builder().build();
+
+    when(constraintValidatorContextMock
+        .unwrap(HibernateConstraintValidatorContext.class))
+        .thenReturn(hibernateConstraintValidatorContextMock);
+
+    when(hibernateConstraintValidatorContextMock
+        .buildConstraintViolationWithTemplate(anyString()))
+        .thenReturn(constraintViolationBuilderMock);
+
+    when(constraintViolationBuilderMock.addPropertyNode(anyString()))
+        .thenReturn(nodeBuilderContextMock);
+  }
+
+  @Test
+  public void isValid_ReturnsTrue_WhenNoPartTwo() {
+    assertThat(validator.isValid(null, constraintValidatorContextMock)).isTrue();
+  }
+
+  @Test
+  public void isValid_ReturnsTrue_WhenNoDecision() {
+    assertThat(validator.isValid(decision, constraintValidatorContextMock)).isTrue();
+  }
+
+  @Test
+  public void isValid_ReturnsTrue_WhenDecisionIsNull() {
+    decision.setDecision(null);
+
+    assertThat(validator.isValid(decision, constraintValidatorContextMock)).isTrue();
+  }
+
+  @Test
+  public void isValid_ReturnsFalse_WhenTransitDestinationThirdCountryIsNull() {
+    decision.setDecision(ACCEPTABLE_FOR_TRANSIT);
+    decision.setTransitDestinationThirdCountry(null);
+
+    assertThat(validator.isValid(decision, constraintValidatorContextMock)).isFalse();
+  }
+
+  @Test
+  public void isValid_ReturnsTrue_WhenTransitDestinationThirdCountryIsNullAndAcceptableForTranshipment() {
+    decision.setDecision(ACCEPTABLE_FOR_TRANSHIPMENT);
+    decision.setTransitDestinationThirdCountry(null);
+
+    assertThat(validator.isValid(decision, constraintValidatorContextMock)).isTrue();
+  }
+
+  @Test
+  public void isValid_ReturnsFalse_WhenTransitDestinationThirdCountryIsEmptyString() {
+    decision.setDecision(ACCEPTABLE_FOR_TRANSIT);
+    decision.setTransitDestinationThirdCountry("");
+
+    assertThat(validator.isValid(decision, constraintValidatorContextMock)).isFalse();
+  }
+
+  @Test
+  public void isValid_ReturnsTrue_WhenDecisionIsAcceptableForTransit() {
+    decision.setDecision(ACCEPTABLE_FOR_TRANSIT);
+    decision.setTransitDestinationThirdCountry("AF");
+
+    assertThat(validator.isValid(decision, constraintValidatorContextMock)).isTrue();
+  }
+}

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/NotNullTransitExitBipValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/NotNullTransitExitBipValidatorTest.java
@@ -1,0 +1,104 @@
+package uk.gov.defra.tracesx.notificationschema.validation.annotations;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.DecisionEnum.ACCEPTABLE_FOR_TRANSHIPMENT;
+import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.DecisionEnum.ACCEPTABLE_FOR_TRANSIT;
+
+import javax.validation.ConstraintValidatorContext;
+import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorContext;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.theories.DataPoints;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.defra.tracesx.notificationschema.representation.Decision;
+import uk.gov.defra.tracesx.notificationschema.representation.enumeration.DecisionEnum;
+
+@RunWith(MockitoJUnitRunner.class)
+public class NotNullTransitExitBipValidatorTest {
+
+  @DataPoints("Other decisions")
+  public static final DecisionEnum[] decisions =
+      new DecisionEnum[]{
+          ACCEPTABLE_FOR_TRANSIT
+      };
+  @Mock
+  HibernateConstraintValidatorContext hibernateConstraintValidatorContextMock;
+  @Mock
+  ConstraintValidatorContext constraintValidatorContextMock;
+  @Mock
+  ConstraintValidatorContext.ConstraintViolationBuilder constraintViolationBuilderMock;
+  @Mock
+  ConstraintValidatorContext.ConstraintViolationBuilder.NodeBuilderCustomizableContext nodeBuilderContextMock;
+  private NotNullTransitExitBipValidator validator;
+  private Decision decision;
+
+  @Before
+  public void setUp() {
+    validator = new NotNullTransitExitBipValidator();
+    this.decision = Decision.builder().build();
+
+    when(constraintValidatorContextMock
+        .unwrap(HibernateConstraintValidatorContext.class))
+        .thenReturn(hibernateConstraintValidatorContextMock);
+
+    when(hibernateConstraintValidatorContextMock
+        .buildConstraintViolationWithTemplate(anyString()))
+        .thenReturn(constraintViolationBuilderMock);
+
+    when(constraintViolationBuilderMock.addPropertyNode(anyString()))
+        .thenReturn(nodeBuilderContextMock);
+  }
+
+  @Test
+  public void isValid_ReturnsTrue_WhenNoPartTwo() {
+    assertThat(validator.isValid(null, constraintValidatorContextMock)).isTrue();
+  }
+
+  @Test
+  public void isValid_ReturnsTrue_WhenNoDecision() {
+    assertThat(validator.isValid(decision, constraintValidatorContextMock)).isTrue();
+  }
+
+  @Test
+  public void isValid_ReturnsTrue_WhenDecisionIsNull() {
+    decision.setDecision(null);
+
+    assertThat(validator.isValid(decision, constraintValidatorContextMock)).isTrue();
+  }
+
+  @Test
+  public void isValid_ReturnsFalse_WhenTransitExitBipIsNull() {
+    decision.setDecision(ACCEPTABLE_FOR_TRANSIT);
+    decision.setTransitExitBip(null);
+
+    assertThat(validator.isValid(decision, constraintValidatorContextMock)).isFalse();
+  }
+
+  @Test
+  public void isValid_ReturnsTrue_WhenTransitExitBipIsNullAndAcceptableForTranshipment() {
+    decision.setDecision(ACCEPTABLE_FOR_TRANSHIPMENT);
+    decision.setTransitExitBip(null);
+
+    assertThat(validator.isValid(decision, constraintValidatorContextMock)).isTrue();
+  }
+
+  @Test
+  public void isValid_ReturnsFalse_WhenTransitExitBipIsEmptyString() {
+    decision.setDecision(ACCEPTABLE_FOR_TRANSIT);
+    decision.setTransitExitBip("");
+
+    assertThat(validator.isValid(decision, constraintValidatorContextMock)).isFalse();
+  }
+
+  @Test
+  public void isValid_ReturnsTrue_WhenDecisionIsAcceptableForTransit() {
+    decision.setDecision(ACCEPTABLE_FOR_TRANSIT);
+    decision.setTransitExitBip("GBPHD1");
+
+    assertThat(validator.isValid(decision, constraintValidatorContextMock)).isTrue();
+  }
+}

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/NotNullTransitThirdCountryValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/NotNullTransitThirdCountryValidatorTest.java
@@ -1,0 +1,104 @@
+package uk.gov.defra.tracesx.notificationschema.validation.annotations;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.DecisionEnum.ACCEPTABLE_FOR_TRANSHIPMENT;
+import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.DecisionEnum.ACCEPTABLE_FOR_TRANSIT;
+
+import javax.validation.ConstraintValidatorContext;
+import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorContext;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.theories.DataPoints;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.defra.tracesx.notificationschema.representation.Decision;
+import uk.gov.defra.tracesx.notificationschema.representation.enumeration.DecisionEnum;
+
+@RunWith(MockitoJUnitRunner.class)
+public class NotNullTransitThirdCountryValidatorTest {
+
+  @DataPoints("Other decisions")
+  public static final DecisionEnum[] decisions =
+      new DecisionEnum[]{
+          ACCEPTABLE_FOR_TRANSIT
+      };
+  @Mock
+  HibernateConstraintValidatorContext hibernateConstraintValidatorContextMock;
+  @Mock
+  ConstraintValidatorContext constraintValidatorContextMock;
+  @Mock
+  ConstraintValidatorContext.ConstraintViolationBuilder constraintViolationBuilderMock;
+  @Mock
+  ConstraintValidatorContext.ConstraintViolationBuilder.NodeBuilderCustomizableContext nodeBuilderContextMock;
+  private NotNullTransitThirdCountryValidator validator;
+  private Decision decision;
+
+  @Before
+  public void setUp() {
+    validator = new NotNullTransitThirdCountryValidator();
+    this.decision = Decision.builder().build();
+
+    when(constraintValidatorContextMock
+        .unwrap(HibernateConstraintValidatorContext.class))
+        .thenReturn(hibernateConstraintValidatorContextMock);
+
+    when(hibernateConstraintValidatorContextMock
+        .buildConstraintViolationWithTemplate(anyString()))
+        .thenReturn(constraintViolationBuilderMock);
+
+    when(constraintViolationBuilderMock.addPropertyNode(anyString()))
+        .thenReturn(nodeBuilderContextMock);
+  }
+
+  @Test
+  public void isValid_ReturnsTrue_WhenNoPartTwo() {
+    assertThat(validator.isValid(null, constraintValidatorContextMock)).isTrue();
+  }
+
+  @Test
+  public void isValid_ReturnsTrue_WhenNoDecision() {
+    assertThat(validator.isValid(decision, constraintValidatorContextMock)).isTrue();
+  }
+
+  @Test
+  public void isValid_ReturnsTrue_WhenDecisionIsNull() {
+    decision.setDecision(null);
+
+    assertThat(validator.isValid(decision, constraintValidatorContextMock)).isTrue();
+  }
+
+  @Test
+  public void isValid_ReturnsFalse_WhenTransitThirdCountryIsNull() {
+    decision.setDecision(ACCEPTABLE_FOR_TRANSIT);
+    decision.setTransitThirdCountry(null);
+
+    assertThat(validator.isValid(decision, constraintValidatorContextMock)).isFalse();
+  }
+
+  @Test
+  public void isValid_ReturnsTrue_WhenTransitThirdCountryIsNullAndAcceptableForTranshipment() {
+    decision.setDecision(ACCEPTABLE_FOR_TRANSHIPMENT);
+    decision.setTransitThirdCountry(null);
+
+    assertThat(validator.isValid(decision, constraintValidatorContextMock)).isTrue();
+  }
+
+  @Test
+  public void isValid_ReturnsFalse_WhenTransitThirdCountryIsEmptyString() {
+    decision.setDecision(ACCEPTABLE_FOR_TRANSIT);
+    decision.setTransitThirdCountry("");
+
+    assertThat(validator.isValid(decision, constraintValidatorContextMock)).isFalse();
+  }
+
+  @Test
+  public void isValid_ReturnsTrue_WhenDecisionIsAcceptableForTransit() {
+    decision.setDecision(ACCEPTABLE_FOR_TRANSIT);
+    decision.setTransitThirdCountry("AF");
+
+    assertThat(validator.isValid(decision, constraintValidatorContextMock)).isTrue();
+  }
+}


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Ben Doherty (Kainos) |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [IMTA-9803: Add validation for part two d...](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/231) |
> | **GitLab MR Number** | [231](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/231) |
> | **Date Originally Opened** | Tue, 28 Sep 2021 |
> | **Approved on GitLab by** | Jahir, Sifat (KAINOS), Nicholas Martin, Reece Bennett (KAINOS), kamil mojek (KAINOS) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: Ticket: https://eaflood.atlassian.net/browse/IMTA-9803
### :book: Changes:
*  Add validation for part two decision default options