### PR TITLE
IMTA-11328: Both seal number and container number are now optional, however at…

### DIFF
--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/NotificationSealsContainers.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/NotificationSealsContainers.java
@@ -7,8 +7,9 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import uk.gov.defra.tracesx.notificationschema.validation.annotations.ChedppSealsAndContainers;
+import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationChedppFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCvedaEuFieldValidation;
-import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationHighRiskFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationHighRiskNonChedppFieldValidation;
 
 import javax.validation.constraints.NotBlank;
@@ -18,11 +19,13 @@ import javax.validation.constraints.NotBlank;
 @JsonInclude(Include.NON_EMPTY)
 @NoArgsConstructor(access = AccessLevel.PUBLIC)
 @AllArgsConstructor(access = AccessLevel.PUBLIC)
+@ChedppSealsAndContainers(
+    groups = NotificationChedppFieldValidation.class)
 public class NotificationSealsContainers {
 
   @NotBlank(
       groups = {
-          NotificationHighRiskFieldValidation.class,
+          NotificationHighRiskNonChedppFieldValidation.class,
           NotificationCvedaEuFieldValidation.class
       },
       message = "Seal number cannot be empty")

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedppSealsAndContainers.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedppSealsAndContainers.java
@@ -1,0 +1,24 @@
+package uk.gov.defra.tracesx.notificationschema.validation.annotations;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+@Target({TYPE, FIELD})
+@Retention(RUNTIME)
+@Constraint(validatedBy = ChedppSealsAndContainersValidator.class)
+@Documented
+public @interface ChedppSealsAndContainers {
+
+  String message() default "Enter either a seal or container number";
+
+  Class<?>[] groups() default {};
+
+  Class<? extends Payload>[] payload() default {};
+}

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedppSealsAndContainersValidator.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedppSealsAndContainersValidator.java
@@ -1,0 +1,21 @@
+package uk.gov.defra.tracesx.notificationschema.validation.annotations;
+
+import org.apache.commons.lang3.StringUtils;
+import uk.gov.defra.tracesx.notificationschema.representation.NotificationSealsContainers;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class ChedppSealsAndContainersValidator
+    implements ConstraintValidator<ChedppSealsAndContainers, NotificationSealsContainers> {
+
+  @Override
+  public boolean isValid(NotificationSealsContainers notificationSealsContainers,
+      ConstraintValidatorContext constraintValidatorContext) {
+    if (notificationSealsContainers != null) {
+      return !StringUtils.isEmpty(notificationSealsContainers.getContainerNumber())
+          || !StringUtils.isEmpty(notificationSealsContainers.getSealNumber());
+    }
+    return true;
+  }
+}

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedppSealsAndContainersValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedppSealsAndContainersValidatorTest.java
@@ -1,0 +1,46 @@
+package uk.gov.defra.tracesx.notificationschema.validation.annotations;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.defra.tracesx.notificationschema.representation.NotificationSealsContainers;
+
+public class ChedppSealsAndContainersValidatorTest {
+
+  private ChedppSealsAndContainersValidator validator;
+
+  @Before
+  public void setup() {
+    validator = new ChedppSealsAndContainersValidator();
+  }
+
+  @Test
+  public void isValid_ReturnsTrue_WhenNotificationSealHasContainerNumberAndSealNumber() {
+    NotificationSealsContainers containers = new NotificationSealsContainers("s1", "c1", false, "");
+    assertThat(validator.isValid(containers, null)).isTrue();
+  }
+
+  @Test
+  public void isValid_ReturnsTrue_WhenNotificationSealHasContainerNumber() {
+    NotificationSealsContainers containers = new NotificationSealsContainers(null, "c1", false, "");
+    assertThat(validator.isValid(containers, null)).isTrue();
+  }
+
+  @Test
+  public void isValid_ReturnsTrue_WhenNotificationSealHasSealNumber() {
+    NotificationSealsContainers containers = new NotificationSealsContainers("s1", null, false, "");
+    assertThat(validator.isValid(containers, null)).isTrue();
+  }
+
+  @Test
+  public void isValid_ReturnsTrue_WhenNotificationSealsContainersIsNull() {
+    assertThat(validator.isValid(null, null)).isTrue();
+  }
+
+  @Test
+  public void isValid_ReturnsFalse_WhenNotificationDoesNotHaveAContainerNumberOrSealNumber() {
+    NotificationSealsContainers containers = new NotificationSealsContainers(null, null, false, "");
+    assertThat(validator.isValid(containers, null)).isFalse();
+  }
+}


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | lee mason (KAINOS) |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [IMTA-11328: Both seal number and contain...](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/265) |
> | **GitLab MR Number** | [265](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/265) |
> | **Date Originally Opened** | Thu, 7 Apr 2022 |
> | **Approved on GitLab by** | Blakeley, Paul (Kainos), Jahir, Sifat (KAINOS), Lewis Birks (Kainos), Nicholas Martin, kamil mojek (KAINOS) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: ticket: https://eaflood.atlassian.net/browse/IMTA-11328

### :book: Changes:
* Both seal number and container number are now optional, however at least one has to be specified

### :chart_with_upwards_trend: SonarQube Report
[Click here](https://vss-sonarqube.azure.defra.cloud/dashboard?branch=feature%2FIMTA-11328-optional-seal-number&id=Imports-Notification-Schema) to view the SonarQube report.


![Screenshot_2022-04-07_at_15.47.40](/uploads/c55bc13231739ad68374ab6ea296c347/Screenshot_2022-04-07_at_15.47.40.png)

