### PR TITLE
IMTA-14074: Add phsiRuleType to commodity risk result

### DIFF
--- a/imports-frontend-entities/package-lock.json
+++ b/imports-frontend-entities/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipaffs/imports-frontend-entities",
-  "version": "1.0.267",
+  "version": "1.0.268",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/imports-frontend-entities/package.json
+++ b/imports-frontend-entities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipaffs/imports-frontend-entities",
-  "version": "1.0.267",
+  "version": "1.0.268",
   "repository": {
     "type": "git"
   },

--- a/imports-frontend-entities/src/entities/commodity_risk_result.js
+++ b/imports-frontend-entities/src/entities/commodity_risk_result.js
@@ -14,6 +14,7 @@ module.exports = class CommodityRiskResult {
     this.isWoody = obj.isWoody
     this.indoorOutdoor = obj.indoorOutdoor
     this.propagation = obj.propagation
+    this.phsiRuleType = obj.phsiRuleType
 
     return Object.seal(new Proxy(this, handler))
   }

--- a/notification-schema-core/resources/notification-schema.json
+++ b/notification-schema-core/resources/notification-schema.json
@@ -2726,6 +2726,15 @@
           "type": "string",
           "description": "Whether the propagation is considered a Plant, Bulb, Seed or None",
           "maxLength": 100
+        },
+        "phsiRuleType": {
+          "type": "string",
+          "description": "Rule type for PHSI checks",
+          "enum": [
+            "Commodity",
+            "Consignment",
+            "MixedConsignment"
+          ]
         }
       }
     }

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/CommodityRiskResult.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/CommodityRiskResult.java
@@ -11,6 +11,7 @@ import lombok.NoArgsConstructor;
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.HmiDecision;
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.PhsiClassification;
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.PhsiDecision;
+import uk.gov.defra.tracesx.notificationschema.representation.enumeration.PhsiRuleType;
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.RiskDecision;
 
 @Builder
@@ -31,4 +32,5 @@ public class CommodityRiskResult {
   private boolean isWoody;
   private String indoorOutdoor;
   private String propagation;
+  private PhsiRuleType phsiRuleType;
 }

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/PhsiRuleType.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/PhsiRuleType.java
@@ -1,0 +1,33 @@
+package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.util.Arrays;
+
+public enum PhsiRuleType {
+  COMMODITY("Commodity"),
+  CONSIGNMENT("Consignment"),
+  MIXED_CONSIGNMENT("MixedConsignment");
+
+  private final String value;
+
+  PhsiRuleType(String value) {
+    this.value = value;
+  }
+
+  public static PhsiRuleType fromValue(String text) {
+    return Arrays.stream(PhsiRuleType.values())
+        .filter(label -> label.value.equals(text))
+        .findFirst()
+        .orElse(null);
+  }
+
+  @JsonValue
+  public String getValue() {
+    return value;
+  }
+
+  @Override
+  public String toString() {
+    return value;
+  }
+}

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/PhsiRuleTypeTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/enumeration/PhsiRuleTypeTest.java
@@ -1,0 +1,43 @@
+package uk.gov.defra.tracesx.notificationschema.representation.enumeration;
+
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertNull;
+
+import org.junit.Test;
+
+public class PhsiRuleTypeTest {
+
+  private final static String COMMODITY = "Commodity";
+  private final static String CONSIGNMENT = "Consignment";
+  private final static String MIXED_CONSIGNMENT = "MixedConsignment";
+  private final static String INVALID_STRING = "invalid-string";
+
+  @Test
+  public void givenAValidEnumValue_whenToStringCalled_shouldReturnStringValue() {
+    String enumResult = PhsiRuleType.COMMODITY.toString();
+
+    assertEquals(enumResult, COMMODITY);
+  }
+
+  @Test
+  public void givenAValidEnumValue_whenGetValueCalled_shouldReturnValue() {
+    String enumResult = PhsiRuleType.CONSIGNMENT.getValue();
+
+    assertEquals(enumResult, CONSIGNMENT);
+  }
+
+  @Test
+  public void givenAValueValid_whenFromValueCalled_shouldReturnEnumValue() {
+    PhsiRuleType enumResult = PhsiRuleType.fromValue(MIXED_CONSIGNMENT);
+
+    assertEquals(enumResult, PhsiRuleType.MIXED_CONSIGNMENT);
+  }
+
+  @Test
+  public void givenAnInvalidValue_whenFromValueCalled_shouldReturnNull() {
+    PhsiDecision enumResult = PhsiDecision.fromValue(INVALID_STRING);
+
+    assertNull(enumResult);
+  }
+
+}


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Asad Khan (Kainos) |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [IMTA-14074: Add phsiRuleType to commodit...](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/315) |
> | **GitLab MR Number** | [315](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/315) |
> | **Date Originally Opened** | Mon, 27 Mar 2023 |
> | **Approved on GitLab by** | Adam McNeilly (Kainos), Phani Yallam, Stephen Donaghey (KAINOS), lee mason (KAINOS) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: [Jira Ticket](https://eaflood.atlassian.net/browse/IMTA-14074)

### :chart_with_upwards_trend: [SonarQube Report](https://vss-sonarqube.azure.defra.cloud/dashboard?branch=feature%2FIMTA-14074-consume-new-phsi-rule-type-from-the-risk-engine-api&id=Imports-Notification-Schema)

### :building_construction: [Jenkins Pipeline](https://jenkins-imports.azure.defra.cloud/job/imports-notification-schema/job/feature%2FIMTA-14074-consume-new-phsi-rule-type-from-the-risk-engine-api/)

### :book: Changes:
- Added phsiRuleType to commodity risk result