### PR TITLE
IMTA-14149: CHED-P Cloning Migration - Temporary Migration

### DIFF
--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/AccompanyingDocument.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/AccompanyingDocument.java
@@ -1,10 +1,12 @@
 package uk.gov.defra.tracesx.notificationschema.representation;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.time.LocalDate;
+import java.util.Objects;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -12,6 +14,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.DocumentType;
+import uk.gov.defra.tracesx.notificationschema.representation.enumeration.ExternalSystem;
 import uk.gov.defra.tracesx.notificationschema.representation.serialisation.IsoDateDeserializer;
 import uk.gov.defra.tracesx.notificationschema.representation.serialisation.IsoDateSerializer;
 import uk.gov.defra.tracesx.notificationschema.validation.annotations.PhytosanitaryCertificateAttachmentRequired;
@@ -38,4 +41,10 @@ public class AccompanyingDocument {
   private UUID uploadUserId = null;
   private UUID uploadOrganisationId = null;
   private ExternalReference externalReference = null;
+
+  @JsonIgnore
+  public boolean isClonedDocument() {
+    return Objects.nonNull(externalReference) && externalReference.getSystem()
+        .equals(ExternalSystem.ECERT);
+  }
 }

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/Notification.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/Notification.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.swagger.annotations.ApiModelProperty;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
@@ -16,6 +17,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import uk.gov.defra.tracesx.notificationschema.representation.enumeration.ExternalSystem;
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.NotificationTypeEnum;
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.StatusEnum;
 import uk.gov.defra.tracesx.notificationschema.representation.serialisation.IsoOffsetDateTimeDeserializer;
@@ -152,6 +154,13 @@ public class Notification {
   @JsonIgnore
   public boolean isChedpp() {
     return NotificationTypeEnum.CHEDPP.equals(type);
+  }
+
+  @JsonIgnore
+  public boolean isClonedChedP() {
+    return NotificationTypeEnum.CVEDP.equals(type) && Objects.nonNull(externalReferences)
+        && externalReferences.stream().anyMatch(externalRef ->
+        externalRef.getSystem() == ExternalSystem.ECERT);
   }
 
   @JsonSerialize(using = IsoOffsetDateTimeSerializer.class)

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/AccompanyingDocumentsTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/AccompanyingDocumentsTest.java
@@ -1,0 +1,36 @@
+package uk.gov.defra.tracesx.notificationschema.representation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+import uk.gov.defra.tracesx.notificationschema.representation.enumeration.ExternalSystem;
+
+public class AccompanyingDocumentsTest {
+
+  @Test
+  public void isClonedDocument_ReturnsTrue_whenExternalReferenceIsECERT() {
+    AccompanyingDocument accompanyingDocument = AccompanyingDocument.builder()
+        .externalReference(ExternalReference.builder().
+            system(ExternalSystem.ECERT)
+            .build())
+        .build();
+    assertThat(accompanyingDocument.isClonedDocument()).isTrue();
+  }
+
+  @Test
+  public void isClonedDocument_ReturnsFalse_whenExternalReferenceIsNotECERT() {
+    AccompanyingDocument accompanyingDocument = AccompanyingDocument.builder()
+        .externalReference(ExternalReference.builder()
+            .system(ExternalSystem.EPHYTO)
+            .build())
+        .build();
+    assertThat(accompanyingDocument.isClonedDocument()).isFalse();
+  }
+
+  @Test
+  public void isClonedDocument_ReturnsFalse_whenNoExternalReference() {
+    AccompanyingDocument accompanyingDocument = AccompanyingDocument.builder()
+        .build();
+    assertThat(accompanyingDocument.isClonedDocument()).isFalse();
+  }
+}

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/NotificationTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/representation/NotificationTest.java
@@ -2,7 +2,9 @@ package uk.gov.defra.tracesx.notificationschema.representation;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.List;
 import org.junit.Test;
+import uk.gov.defra.tracesx.notificationschema.representation.enumeration.ExternalSystem;
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.NotificationTypeEnum;
 
 public class NotificationTest {
@@ -31,5 +33,32 @@ public class NotificationTest {
   public void isChedpp_ReturnsTrue_whenTypeIsChedpp() {
     notification.setType(NotificationTypeEnum.CHEDPP);
     assertThat(notification.isChedpp()).isTrue();
+  }
+
+  @Test
+  public void isClonedChedP_ReturnsTrue_whenTypeIsChedpAndCloned() {
+    notification.setType(NotificationTypeEnum.CVEDP);
+    notification.setExternalReferences(List.of(ExternalReference.builder().system(ExternalSystem.ECERT).build()));
+    assertThat(notification.isClonedChedP()).isTrue();
+  }
+
+  @Test
+  public void isClonedChedP_ReturnsFalse_whenTypeIsNotChedp() {
+    notification.setType(NotificationTypeEnum.CHEDPP);
+    notification.setExternalReferences(List.of(ExternalReference.builder().system(ExternalSystem.ECERT).build()));
+    assertThat(notification.isClonedChedP()).isFalse();
+  }
+
+  @Test
+  public void isClonedChedP_ReturnsFalse_whenTypeIsChedpAndExternalReferenceIsEPHYTO() {
+    notification.setType(NotificationTypeEnum.CVEDP);
+    notification.setExternalReferences(List.of(ExternalReference.builder().system(ExternalSystem.EPHYTO).build()));
+    assertThat(notification.isClonedChedP()).isFalse();
+  }
+
+  @Test
+  public void isClonedChedP_ReturnsFalse_whenTypeIsChedpNoExternalReference() {
+    notification.setType(NotificationTypeEnum.CVEDP);
+    assertThat(notification.isClonedChedP()).isFalse();
   }
 }


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | prabash balasuriya (kainos) |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [IMTA-14149: CHED-P Cloning Migration - T...](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/317) |
> | **GitLab MR Number** | [317](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/317) |
> | **Date Originally Opened** | Fri, 14 Apr 2023 |
> | **Approved on GitLab by** | Lewis Birks (Kainos), Odran Muldoon (Kainos), Shawn Chan (Kainos), Toyin Ajani (Kainos) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: [Jira Ticket](https://eaflood.atlassian.net/browse/IMTA-14149)

### :chart_with_upwards_trend: [SonarQube Report](https://vss-sonarqube.azure.defra.cloud/dashboard?branch=feature%2FIMTA-14149-temp-migration&id=Imports-Notification-Schema)

### :building_construction: [Jenkins Pipeline](https://jenkins-imports.azure.defra.cloud/job/imports-notification-schema/job/feature%2FIMTA-14149-temp-migration/)

### :book: Changes:
* Added some helper methods to get if a notification is a cloned notification and a document is a cloned document

### :white_check_mark: Selenium Test Run:

PENDING