### PR TITLE
IMTA-14288: updating the is woody value type

### DIFF
--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/CommodityRiskResult.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/CommodityRiskResult.java
@@ -29,7 +29,7 @@ public class CommodityRiskResult {
   private UUID uniqueId;
   private String eppoCode;
   private String variety;
-  private boolean isWoody;
+  private Boolean isWoody;
   private String indoorOutdoor;
   private String propagation;
   private PhsiRuleType phsiRuleType;


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Toyin Ajani (Kainos) |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [IMTA-14288: updating the is woody value ...](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/318) |
> | **GitLab MR Number** | [318](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/318) |
> | **Date Originally Opened** | Tue, 2 May 2023 |
> | **Approved on GitLab by** | Lewis Birks (Kainos), Marc-Steeven Eyeni-Kantsey (Kainos), Mayuresh Kadu |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: [Jira Ticket](https://eaflood.atlassian.net/browse/IMTA-14288)

### :chart_with_upwards_trend: [SonarQube Report](https://vss-sonarqube.azure.defra.cloud/dashboard?branch=feature%2FIMTA-14288-updating-woody-value-type&id=Imports-Notification-Schema)

### :building_construction: [Jenkins Pipeline](https://jenkins-imports.azure.defra.cloud/job/imports-notification-schema/job/feature%2FIMTA-14288-updating-woody-value-type/)

### :book: Changes:

- Changing the value type for Java representation from primitive to non-primitive to allow for correct variable name when automatic Jackson object mapping is applied
- Fix has been tested with hotfix version and proved to do the mapping correctly