### PR TITLE
IMTA-14388: Adding new isSelectedForChecks field to notification schema

### DIFF
--- a/imports-frontend-entities/package-lock.json
+++ b/imports-frontend-entities/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ipaffs/imports-frontend-entities",
-  "version": "1.0.270",
+  "version": "1.0.271",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@ipaffs/imports-frontend-entities",
-      "version": "1.0.263",
+      "version": "1.0.271",
       "license": "ISC",
       "dependencies": {
         "ajv": "6.12.6",

--- a/imports-frontend-entities/package.json
+++ b/imports-frontend-entities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipaffs/imports-frontend-entities",
-  "version": "1.0.270",
+  "version": "1.0.271",
   "repository": {
     "type": "git"
   },

--- a/imports-frontend-entities/src/entities/inspection_check.js
+++ b/imports-frontend-entities/src/entities/inspection_check.js
@@ -8,6 +8,7 @@ module.exports = class InspectionCheck {
     this.status = obj.status
     this.reason = obj.reason
     this.otherReason = obj.otherReason
+    this.isSelectedForChecks = obj.isSelectedForChecks
 
     return Object.seal(new Proxy(this, handler))
   }

--- a/notification-schema-core/resources/notification-schema.json
+++ b/notification-schema-core/resources/notification-schema.json
@@ -2618,6 +2618,10 @@
           "type": "string",
           "description": "Other reason text when selected reason is 'Other'",
           "maxLength": 32
+        },
+        "isSelectedForChecks" : {
+          "type": "boolean",
+          "description": "Has commodity been selected for checks?"
         }
       }
     },

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/InspectionCheck.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/InspectionCheck.java
@@ -21,4 +21,5 @@ public class InspectionCheck {
   private CheckStatus status;
   private String reason;
   private String otherReason;
+  private Boolean isSelectedForChecks;
 }


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Toyin Ajani (Kainos) |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [IMTA-14388: Adding new isSelectedForChec...](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/319) |
> | **GitLab MR Number** | [319](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/319) |
> | **Date Originally Opened** | Thu, 18 May 2023 |
> | **Approved on GitLab by** | Lewis Birks (Kainos), Marc-Steeven Eyeni-Kantsey (Kainos), Mayuresh Kadu, Odran Muldoon (Kainos) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: [Jira Ticket](https://eaflood.atlassian.net/browse/IMTA-14388)

### :chart_with_upwards_trend: [SonarQube Report](https://vss-sonarqube.azure.defra.cloud/dashboard?branch=feature%2FIMTA-14388-updating-notification-schema&id=Imports-Notification-Schema)

### :book: Changes:

- Updated notification schema with new field
- Updated inspection check Java representation and node entity with new field as required