### PR TITLE
IMTA-14241 Make the PoE mandatory on review page for EU CHEDA

### DIFF
--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/PartOne.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/PartOne.java
@@ -46,6 +46,7 @@ import uk.gov.defra.tracesx.notificationschema.validation.annotations.ImpPortOfE
 import uk.gov.defra.tracesx.notificationschema.validation.annotations.NotNullPurposeExitBip;
 import uk.gov.defra.tracesx.notificationschema.validation.annotations.NotNullPurposeExitDate;
 import uk.gov.defra.tracesx.notificationschema.validation.annotations.PhytosanitaryCertificateRequired;
+import uk.gov.defra.tracesx.notificationschema.validation.annotations.PortOfEntryAndPointOfEntryNotEmpty;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCedFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationChedppFieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationCvedaEuFieldValidation;
@@ -105,6 +106,10 @@ import uk.gov.defra.tracesx.notificationschema.validation.groups.TransporterDeta
 @ChedppPodRequired(
     groups = NotificationChedppFieldValidation.class,
     message = "{uk.gov.defra.tracesx.notificationschema.representation.partone.pod.required}")
+@PortOfEntryAndPointOfEntryNotEmpty(
+    groups = {NotificationCvedaEuFieldValidation.class},
+    message = "{uk.gov.defra.tracesx.notificationschema.representation.partone.portofentry"
+        + ".pointofentry.eucveda.not.null}")
 public class PartOne {
 
   private TypeOfImp typeOfImp;
@@ -240,10 +245,6 @@ public class PartOne {
       message = "{uk.gov.defra.tracesx.notificationschema.representation.partone.purpose.not.null}")
   private Purpose purpose;
 
-  @NotBlank(
-      groups = NotificationCvedaEuFieldValidation.class,
-      message = "{uk.gov.defra.tracesx.notificationschema.representation.partone.pointofentry"
-          + ".eucveda.not.null}")
   @NotBlank(
       groups = NotificationHighRiskFieldValidation.class,
       message = "{uk.gov.defra.tracesx.notificationschema.representation.partone.pointofentry"

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/PortOfEntryAndPointOfEntryNotEmpty.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/PortOfEntryAndPointOfEntryNotEmpty.java
@@ -1,0 +1,23 @@
+package uk.gov.defra.tracesx.notificationschema.validation.annotations;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+@Target(TYPE)
+@Retention(RUNTIME)
+@Constraint(validatedBy = PortOfEntryAndPointOfEntryNotEmptyValidator.class)
+@Documented
+public @interface PortOfEntryAndPointOfEntryNotEmpty {
+
+  String message() default "Add a port of entry";
+
+  Class<?>[] groups() default {};
+
+  Class<? extends Payload>[] payload() default {};
+}

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/PortOfEntryAndPointOfEntryNotEmptyValidator.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/PortOfEntryAndPointOfEntryNotEmptyValidator.java
@@ -1,0 +1,19 @@
+package uk.gov.defra.tracesx.notificationschema.validation.annotations;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import uk.gov.defra.tracesx.notificationschema.representation.PartOne;
+
+public class PortOfEntryAndPointOfEntryNotEmptyValidator implements
+    ConstraintValidator<PortOfEntryAndPointOfEntryNotEmpty, PartOne> {
+
+  @Override
+  public boolean isValid(PartOne partOne, ConstraintValidatorContext constraintValidatorContext) {
+    if (partOne == null) {
+      return false;
+    }
+
+    return partOne.getPortOfEntry() != null && !partOne.getPortOfEntry().isBlank()
+        && partOne.getPointOfEntry() != null && !partOne.getPointOfEntry().isBlank();
+  }
+}

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/PortOfEntryAndPointOfEntryNotEmptyValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/PortOfEntryAndPointOfEntryNotEmptyValidatorTest.java
@@ -1,0 +1,90 @@
+package uk.gov.defra.tracesx.notificationschema.validation.annotations;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import java.util.ArrayList;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.defra.tracesx.notificationschema.representation.PartOne;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PortOfEntryAndPointOfEntryNotEmptyValidatorTest {
+
+  private PortOfEntryAndPointOfEntryNotEmptyValidator validator;
+
+  private PartOne partOne;
+
+  @Before
+  public void setUp() {
+    validator = new PortOfEntryAndPointOfEntryNotEmptyValidator();
+    partOne = new PartOne();
+  }
+
+  @Test
+  public void validatorShouldReturnFalseIfPartOneIsNull() {
+    // Given
+    partOne = null;
+
+    // When
+    boolean result = validator.isValid(partOne, null);
+
+    // Then
+    assertFalse(result);
+  }
+
+  @Test
+  public void validatorShouldHandleTestCasesCorrectly() {
+    ArrayList<ValidatorTestCase> expectedResultTestCases = buildExpectedResults();
+    for (ValidatorTestCase nextExpectedResult: expectedResultTestCases) {
+      runAndCheckValidation(nextExpectedResult);
+    }
+  }
+
+  private void runAndCheckValidation(ValidatorTestCase validatorTestCase){
+    partOne.setPointOfEntry(validatorTestCase.pointOfEntry);
+    partOne.setPortOfEntry(validatorTestCase.portOfEntry);
+    boolean result = validator.isValid(partOne, null);
+
+    assertEquals(validatorTestCase.expectedResult, result);
+  }
+
+  private ArrayList<ValidatorTestCase> buildExpectedResults(){
+    ArrayList<ValidatorTestCase> list = new ArrayList<>();
+    // Both set
+    list.add(new ValidatorTestCase("PORT","POINT",true));
+
+    //Neither set
+    list.add(new ValidatorTestCase(null,null,false));
+    list.add(new ValidatorTestCase(null,"",false));
+    list.add(new ValidatorTestCase("",null,false));
+    list.add(new ValidatorTestCase("","",false));
+
+    // port of entry set but point of entry not set
+    list.add(new ValidatorTestCase("PORT",null,false));
+    list.add(new ValidatorTestCase("PORT","",false));
+    list.add(new ValidatorTestCase("PORT",null,false));
+    list.add(new ValidatorTestCase("PORT","",false));
+
+    // port of entry not set but point of entry set
+    list.add(new ValidatorTestCase(null,"POINT",false));
+    list.add(new ValidatorTestCase(null,"POINT",false));
+    list.add(new ValidatorTestCase("","POINT",false));
+    list.add(new ValidatorTestCase("","POINT",false));
+    return list;
+  }
+
+  private static class ValidatorTestCase {
+    public String portOfEntry;
+    public String pointOfEntry;
+    public boolean expectedResult;
+
+    public ValidatorTestCase(String portOfEntry, String pointOfEntry, boolean expectedResult){
+      this.pointOfEntry = pointOfEntry;
+      this.portOfEntry = portOfEntry;
+      this.expectedResult = expectedResult;
+    }
+  }
+}


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Jonathan Magee |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [IMTA-14241 Make the PoE mandatory on rev...](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/320) |
> | **GitLab MR Number** | [320](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/320) |
> | **Date Originally Opened** | Wed, 7 Jun 2023 |
> | **Approved on GitLab by** | Eugene Fahy (Kainos), Phani Yallam, prabash balasuriya (kainos) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: [Jira Ticket](https://eaflood.atlassian.net/browse/IMTA-14241)

### :chart_with_upwards_trend: [SonarQube Report](https://vss-sonarqube.azure.defra.cloud/dashboard?branch=feature%2FIMTA-14241-Make-the-PoE-mandatory-on-review-page-for-EU-CHEDA&id=Imports-Notification-Schema)

### :building_construction: [Jenkins Pipeline](https://jenkins-imports.azure.defra.cloud/job/imports-notification-schema/job/feature%2FIMTA-14241-Make-the-PoE-mandatory-on-review-page-for-EU-CHEDA/)

### :book: Changes:

- Altered the validation to make Point Of Entry and Port Of Entry mandatory for EU CHEDA