### PR TITLE
IMTA-14555 notification schema update - has checks complete

### DIFF
--- a/imports-frontend-entities/package-lock.json
+++ b/imports-frontend-entities/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ipaffs/imports-frontend-entities",
-  "version": "1.0.271",
+  "version": "1.0.272",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@ipaffs/imports-frontend-entities",
-      "version": "1.0.271",
+      "version": "1.0.272",
       "license": "ISC",
       "dependencies": {
         "ajv": "6.12.6",

--- a/imports-frontend-entities/package.json
+++ b/imports-frontend-entities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipaffs/imports-frontend-entities",
-  "version": "1.0.271",
+  "version": "1.0.272",
   "repository": {
     "type": "git"
   },

--- a/imports-frontend-entities/src/entities/inspection_check.js
+++ b/imports-frontend-entities/src/entities/inspection_check.js
@@ -9,6 +9,7 @@ module.exports = class InspectionCheck {
     this.reason = obj.reason
     this.otherReason = obj.otherReason
     this.isSelectedForChecks = obj.isSelectedForChecks
+    this.hasChecksComplete = obj.hasChecksComplete
 
     return Object.seal(new Proxy(this, handler))
   }

--- a/notification-schema-core/resources/notification-schema.json
+++ b/notification-schema-core/resources/notification-schema.json
@@ -2622,6 +2622,10 @@
         "isSelectedForChecks" : {
           "type": "boolean",
           "description": "Has commodity been selected for checks?"
+        },
+        "hasChecksComplete" : {
+          "type": "boolean",
+          "description": "Has commodity completed this type of check"
         }
       }
     },

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/InspectionCheck.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/InspectionCheck.java
@@ -22,4 +22,5 @@ public class InspectionCheck {
   private String reason;
   private String otherReason;
   private Boolean isSelectedForChecks;
+  private Boolean hasChecksComplete;
 }


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Toyin Ajani (Kainos) |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [IMTA-14555 notification schema update - ...](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/323) |
> | **GitLab MR Number** | [323](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/323) |
> | **Date Originally Opened** | Tue, 20 Jun 2023 |
> | **Approved on GitLab by** | Marc-Steeven Eyeni-Kantsey (Kainos), Mayuresh Kadu, kamil mojek (KAINOS) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: [Jira Ticket](https://eaflood.atlassian.net/browse/IMTA-14555)

### :chart_with_upwards_trend: [SonarQube Report](https://vss-sonarqube.azure.defra.cloud/dashboard?branch=feature%2FIMTA-14555-notification-schema-update-checksComplete&id=Imports-Notification-Schema)

### :book: Changes:

- Updating schema with hasChecksComplete in partTwo commodityChecks object
- Change tested locally

FE entities added to artifactory:
![Screenshot_2023-06-20_at_10.22.08](/uploads/f1886cdcb122d25d33252a1676b2c0be/Screenshot_2023-06-20_at_10.22.08.png)