### PR TITLE
IMTA-15396: Changes EU CHEDA content on transport details and transport before bip page

### DIFF
--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/MeansOfTransportBeforeBip.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/MeansOfTransportBeforeBip.java
@@ -36,10 +36,7 @@ public class MeansOfTransportBeforeBip implements MeansOfTransport {
           "{uk.gov.defra.tracesx.notificationschema.representation.partone"
               + ".meansoftransportfromentrypoint.id.chedpp.not.empty}")
   @NotEmpty(
-      groups = {
-          NotificationCvedaEuFieldValidation.class,
-          NotificationChedppFieldValidation.class
-      },
+      groups = NotificationCvedaEuFieldValidation.class,
       message =
           "{uk.gov.defra.tracesx.notificationschema.representation.partone"
               + ".meansoftransportfromentrypoint.id.eucveda.not.empty}")
@@ -78,10 +75,12 @@ public class MeansOfTransportBeforeBip implements MeansOfTransport {
           "{uk.gov.defra.tracesx.notificationschema.representation.partone"
               + ".meansoftransportfromentrypoint.document.not.empty}")
   @NotEmpty(
-      groups = {
-          NotificationCvedaEuFieldValidation.class,
-          NotificationChedppFieldValidation.class
-      },
+      groups = NotificationChedppFieldValidation.class,
+      message =
+          "{uk.gov.defra.tracesx.notificationschema.representation.partone"
+              + ".meansoftransportfromentrypoint.document.chedpp.not.empty}")
+  @NotEmpty(
+      groups = NotificationCvedaEuFieldValidation.class,
       message =
            "{uk.gov.defra.tracesx.notificationschema.representation.partone"
               + ".meansoftransportfromentrypoint.document.eucveda.not.empty}")


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Josh Craig (Kainos) |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [IMTA-15396: Changes EU CHEDA content on ...](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/357) |
> | **GitLab MR Number** | [357](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/357) |
> | **Date Originally Opened** | Thu, 23 Nov 2023 |
> | **Approved on GitLab by** | Jonathan Magee, Mayuresh Kadu, Toyin Ajani (Kainos) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: [Jira Ticket](https://eaflood.atlassian.net/browse/IMTA-15396)

### :chart_with_upwards_trend: [SonarQube Report](https://vss-sonarqube.azure.defra.cloud/dashboard?branch=feature%2FIMTA-15396-EU-CHEDA-changes-to-transport-page-content&id=Imports-Notification-Schema)

### :book: Changes:

- changes to validation group for meansOfTransportbeforebip to separate euCHEDA and CHEDPP