### PR TITLE
IMTA-15361: adding number of catch certs

### DIFF
--- a/imports-frontend-entities/package-lock.json
+++ b/imports-frontend-entities/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ipaffs/imports-frontend-entities",
-  "version": "1.0.310",
+  "version": "1.0.311",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@ipaffs/imports-frontend-entities",
-      "version": "1.0.310",
+      "version": "1.0.311",
       "license": "ISC",
       "dependencies": {
         "ajv": "6.12.6",

--- a/imports-frontend-entities/package.json
+++ b/imports-frontend-entities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipaffs/imports-frontend-entities",
-  "version": "1.0.310",
+  "version": "1.0.311",
   "repository": {
     "type": "git"
   },

--- a/imports-frontend-entities/src/entities/catch_certificate_attachment.js
+++ b/imports-frontend-entities/src/entities/catch_certificate_attachment.js
@@ -7,6 +7,7 @@ module.exports = class CatchCertificateAttachment {
 
         this.attachmentId = obj.attachmentId
         this.catchCertificateDetails = getList(obj.catchCertificateDetails ?? [], CatchCertificateDetails)
+        this.numberOfCatchCertificates = obj.numberOfCatchCertificates
 
         return Object.seal(new Proxy(this, handler))
     }

--- a/notification-schema-core/resources/notification-schema.json
+++ b/notification-schema-core/resources/notification-schema.json
@@ -2579,6 +2579,12 @@
           "type": "string",
           "description": "The UUID of the uploaded catch certificate file in blob storage"
         },
+        "numberOfCatchCertificates": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 20,
+          "description": "The total number of catch certificates on the attachment"
+        },
         "CatchCertificateDetails": {
           "type": "array",
           "description": "List of catch certificate details",

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/CatchCertificateAttachment.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/CatchCertificateAttachment.java
@@ -14,4 +14,5 @@ public class CatchCertificateAttachment {
 
   private String attachmentId;
   private List<CatchCertificateDetails> catchCertificateDetails;
+  private Integer numberOfCatchCertificates;
 }


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Toyin Ajani (Kainos) |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [IMTA-15361: adding number of catch certs](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/361) |
> | **GitLab MR Number** | [361](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/361) |
> | **Date Originally Opened** | Wed, 29 Nov 2023 |
> | **Approved on GitLab by** | Mayuresh Kadu, Odran Muldoon (Kainos), Peter Rooke (Kainos) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: [Jira Ticket](https://eaflood.atlassian.net/browse/IMTA-15361)

### :chart_with_upwards_trend: [SonarQube Report](https://vss-sonarqube.azure.defra.cloud/dashboard?branch=feature%2FIMTA-15361-adding-number-of-catch-certs&id=Imports-Notification-Schema)

### :building_construction: [Jenkins Pipeline](https://jenkins-imports.azure.defra.cloud/job/imports-notification-schema/job/feature%2FIMTA-15361-adding-number-of-catch-certs/)

### :book: Changes:

- Adding in numberOfCatchCertificates to schema