### PR TITLE
IMTA-9130 Auto Clearance Mark as Auto Cleared

### DIFF
--- a/imports-frontend-entities/package-lock.json
+++ b/imports-frontend-entities/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipaffs/imports-frontend-entities",
-  "version": "1.0.153",
+  "version": "1.0.154",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/imports-frontend-entities/package.json
+++ b/imports-frontend-entities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipaffs/imports-frontend-entities",
-  "version": "1.0.153",
+  "version": "1.0.154",
   "repository": {
     "type": "git"
   },

--- a/imports-frontend-entities/src/entities/part_two.js
+++ b/imports-frontend-entities/src/entities/part_two.js
@@ -44,6 +44,8 @@ module.exports = class PartTwo {
         ? new EconomicOperator(obj.controlledDestination) : undefined
     this.accompanyingDocuments = getList(_.get(obj, 'accompanyingDocuments', []), AccompanyingDocument)
     this.commodityChecks = getList(_.get(obj, 'commodityChecks', []), CommodityChecks)
+    this.phsiAutoCleared = obj.phsiAutoCleared
+    this.hmiAutoCleared = obj.hmiAutoCleared
 
     return Object.seal(new Proxy(this, handler))
   }

--- a/notification-schema-core/resources/notification-schema.json
+++ b/notification-schema-core/resources/notification-schema.json
@@ -1211,6 +1211,14 @@
               }
             }
           }
+        },
+        "phsiAutoCleared": {
+          "type": "boolean",
+          "description": "Have the PHSI regulated commodities been auto cleared?"
+        },
+        "hmiAutoCleared": {
+          "type": "boolean",
+          "description": "Have the HMI regulated commodities been auto cleared?"
         }
       }
     },

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/PartTwo.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/PartTwo.java
@@ -98,4 +98,8 @@ public class PartTwo {
   private List<AccompanyingDocument> accompanyingDocuments;
 
   private List<CommodityChecks> commodityChecks;
+
+  private Boolean phsiAutoCleared;
+
+  private Boolean hmiAutoCleared;
 }


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Stephen Donaghey (KAINOS) |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [IMTA-9130 Auto Clearance Mark as Auto Cl...](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/185) |
> | **GitLab MR Number** | [185](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/185) |
> | **Date Originally Opened** | Mon, 22 Feb 2021 |
> | **Approved on GitLab by** | Blakeley, Paul (Kainos), dominik henjes (KAINOS), iwan roberts (KAINOS) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Setting boolean flags for both PHSI and HMI checks to mark them as already auto cleared, to take them out of calculation.