### PR TITLE
IMTA-9127: Making port of entry field mandatory for IMP

### DIFF
--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/PartOne.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/PartOne.java
@@ -26,6 +26,7 @@ import uk.gov.defra.tracesx.notificationschema.validation.ValidationMessageCode;
 import uk.gov.defra.tracesx.notificationschema.validation.annotations.ChedppMinValueKeyDataPair;
 import uk.gov.defra.tracesx.notificationschema.validation.annotations.ChedppNotNullKeyDataPair;
 import uk.gov.defra.tracesx.notificationschema.validation.annotations.DogPlaceOfOriginImp;
+import uk.gov.defra.tracesx.notificationschema.validation.annotations.ImpPortOfEntry;
 import uk.gov.defra.tracesx.notificationschema.validation.annotations.NotNullPurposeExitBip;
 import uk.gov.defra.tracesx.notificationschema.validation.annotations.NotNullPurposeExitDate;
 import uk.gov.defra.tracesx.notificationschema.validation.annotations.NotNullWoodPackagingCommodity;
@@ -69,6 +70,10 @@ import javax.validation.constraints.NotNull;
     groups = NotificationCvedaFieldValidation.class,
     message = "{uk.gov.defra.tracesx.notificationschema.representation.partone.purpose"
         + ".exitbip.not.null}")
+@ImpPortOfEntry(
+    groups = {NotificationLowRiskFieldValidation.class},
+    message = "{uk.gov.defra.tracesx.notificationschema.representation.partone.portofentry"
+        + ".not.null}")
 public class PartOne {
 
   private TypeOfImp typeOfImp;

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ImpPortOfEntry.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ImpPortOfEntry.java
@@ -1,0 +1,23 @@
+package uk.gov.defra.tracesx.notificationschema.validation.annotations;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+@Target(TYPE)
+@Retention(RUNTIME)
+@Constraint(validatedBy = ImpPortOfEntryValidator.class)
+@Documented
+public @interface ImpPortOfEntry {
+
+  String message() default "Port of entry must be entered";
+
+  Class<?>[] groups() default {};
+
+  Class<? extends Payload>[] payload() default {};
+}

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ImpPortOfEntryValidator.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ImpPortOfEntryValidator.java
@@ -1,0 +1,19 @@
+package uk.gov.defra.tracesx.notificationschema.validation.annotations;
+
+import uk.gov.defra.tracesx.notificationschema.representation.PartOne;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class ImpPortOfEntryValidator implements
+    ConstraintValidator<ImpPortOfEntry, PartOne> {
+
+  @Override
+  public boolean isValid(PartOne partOne, ConstraintValidatorContext constraintValidatorContext) {
+    if (partOne == null) {
+      return false;
+    }
+
+    return partOne.getPortOfEntry() != null && !partOne.getPortOfEntry().isBlank();
+  }
+}

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ImpPortOfEntryValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ImpPortOfEntryValidatorTest.java
@@ -1,0 +1,72 @@
+package uk.gov.defra.tracesx.notificationschema.validation.annotations;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.defra.tracesx.notificationschema.representation.PartOne;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ImpPortOfEntryValidatorTest {
+
+  private ImpPortOfEntryValidator validator;
+
+  private PartOne partOne;
+
+  @Before
+  public void setUp() {
+    validator = new ImpPortOfEntryValidator();
+    partOne = new PartOne();
+  }
+
+  @Test
+  public void validatorShouldReturnFalseIfPartOneIsNull() {
+    // Given
+    partOne = null;
+
+    // When
+    boolean result = validator.isValid(partOne, null);
+
+    // Then
+    assertFalse(result);
+  }
+
+  @Test
+  public void validatorShouldReturnFalseIfThePortOfEntryFieldIsNull() {
+    // Given
+    partOne.setPortOfEntry(null);
+
+    // When
+    boolean result = validator.isValid(partOne, null);
+
+    // Then
+    assertFalse(result);
+  }
+
+  @Test
+  public void validatorShouldReturnFalseIfThePortOfEntryFieldIsBlank() {
+    // Given
+    partOne.setPortOfEntry("");
+
+    // When
+    boolean result = validator.isValid(partOne, null);
+
+    // Then
+    assertFalse(result);
+  }
+
+  @Test
+  public void validatorShouldReturnTrueIfThePortOfEntryFieldHasAValue() {
+    // Given
+    partOne.setPortOfEntry("Some port of entry");
+
+    // When
+    boolean result = validator.isValid(partOne, null);
+
+    // Then
+    assertTrue(result);
+  }
+}


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Sean Treanor (KAINOS) |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [IMTA-9127: Making port of entry field ma...](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/186) |
> | **GitLab MR Number** | [186](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/186) |
> | **Date Originally Opened** | Mon, 22 Feb 2021 |
> | **Approved on GitLab by** | Callum Atwal (kainos), Carl Evans (KAINOS), dominik henjes (KAINOS), iwan roberts (KAINOS) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

_No description_