### PR TITLE
IMTA-11922 EU standard validation is only applied for existing notification

### DIFF
--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/ConsignmentCheck.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/ConsignmentCheck.java
@@ -11,6 +11,7 @@ import uk.gov.defra.tracesx.notificationschema.representation.enumeration.Identi
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.IdentityCheckNotDoneReason;
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.PhysicalCheckNotDoneReason;
 import uk.gov.defra.tracesx.notificationschema.representation.enumeration.Result;
+import uk.gov.defra.tracesx.notificationschema.validation.annotations.ChedaDocumentCheckResult;
 import uk.gov.defra.tracesx.notificationschema.validation.annotations.DocumentCheckResult;
 import uk.gov.defra.tracesx.notificationschema.validation.annotations.EuStandardValidator;
 import uk.gov.defra.tracesx.notificationschema.validation.annotations.HighRiskEUDocumentCheckResult;
@@ -82,6 +83,11 @@ import javax.validation.constraints.NotNull;
     message =
         "{uk.gov.defra.tracesx.notificationschema.representation.parttwo.consignmentcheck"
             + ".eustandard.not.null}")
+@ChedaDocumentCheckResult(
+    groups = NotificationCvedaNonEuFieldValidation.class,
+    message =
+        "{uk.gov.defra.tracesx.notificationschema.representation.parttwo.consignmentcheck"
+            + ".documentarycheck.invalid.nonhighriskeu}")
 public class ConsignmentCheck {
 
   @NotNull(

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/Notification.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/Notification.java
@@ -27,7 +27,6 @@ import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationHig
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationPart3FieldValidation;
 import uk.gov.defra.tracesx.notificationschema.validation.groups.NotificationVeterinaryValidation;
 
-
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedaDocumentCheckResult.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedaDocumentCheckResult.java
@@ -1,0 +1,24 @@
+package uk.gov.defra.tracesx.notificationschema.validation.annotations;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+@Target({TYPE, ANNOTATION_TYPE})
+@Retention(RUNTIME)
+@Constraint(validatedBy = ChedaDocumentCheckResultValidator.class)
+@Documented
+public @interface ChedaDocumentCheckResult {
+
+  String message() default "Invalid option";
+
+  Class<?>[] groups() default {};
+
+  Class<? extends Payload>[] payload() default {};
+}

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedaDocumentCheckResultValidator.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedaDocumentCheckResultValidator.java
@@ -1,0 +1,32 @@
+package uk.gov.defra.tracesx.notificationschema.validation.annotations;
+
+import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.Result.NOT_SATISFACTORY;
+import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.Result.NOT_SET;
+import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.Result.SATISFACTORY;
+import static uk.gov.defra.tracesx.notificationschema.validation.utils.ConsignmentCheckUtil.isExistingCHEDANotification;
+
+import uk.gov.defra.tracesx.notificationschema.representation.ConsignmentCheck;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class ChedaDocumentCheckResultValidator implements
+    ConstraintValidator<ChedaDocumentCheckResult, ConsignmentCheck> {
+
+  @Override
+  public boolean isValid(ConsignmentCheck consignmentCheck, ConstraintValidatorContext context) {
+    if (consignmentCheck != null && !isExistingCHEDANotification(consignmentCheck)) {
+      return (consignmentCheck.getEuStandard() == NOT_SET
+          && consignmentCheck.getNationalRequirements() == NOT_SET
+          && (consignmentCheck.getDocumentCheckResult() == SATISFACTORY
+          || consignmentCheck.getDocumentCheckResult() == NOT_SATISFACTORY));
+    }
+
+    return true;
+  }
+
+  @Override
+  public void initialize(ChedaDocumentCheckResult constraintAnnotation) {
+    // no action
+  }
+}

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/EuStandardValidatorImpl.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/EuStandardValidatorImpl.java
@@ -1,7 +1,9 @@
 package uk.gov.defra.tracesx.notificationschema.validation.annotations;
 
+import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.Result.NOT_SET;
+
 import uk.gov.defra.tracesx.notificationschema.representation.ConsignmentCheck;
-import uk.gov.defra.tracesx.notificationschema.representation.enumeration.Result;
+import uk.gov.defra.tracesx.notificationschema.validation.utils.ConsignmentCheckUtil;
 
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
@@ -11,7 +13,11 @@ public class EuStandardValidatorImpl
 
   @Override
   public boolean isValid(ConsignmentCheck consignmentCheck, ConstraintValidatorContext context) {
-    return consignmentCheck.getEuStandard() != Result.NOT_SET;
+    if (consignmentCheck != null
+        && ConsignmentCheckUtil.isExistingCHEDANotification(consignmentCheck)) {
+      return consignmentCheck.getEuStandard() != NOT_SET;
+    }
+    return true;
   }
 
   @Override

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/utils/ConsignmentCheckUtil.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/validation/utils/ConsignmentCheckUtil.java
@@ -1,0 +1,17 @@
+package uk.gov.defra.tracesx.notificationschema.validation.utils;
+
+import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.Result.NOT_SET;
+
+import uk.gov.defra.tracesx.notificationschema.representation.ConsignmentCheck;
+
+public class ConsignmentCheckUtil {
+
+  private ConsignmentCheckUtil() {
+  }
+
+  public static boolean isExistingCHEDANotification(ConsignmentCheck consignmentCheck) {
+    return (consignmentCheck.getDocumentCheckResult() == NOT_SET
+        && (consignmentCheck.getEuStandard() != NOT_SET
+        || consignmentCheck.getNationalRequirements() != NOT_SET));
+  }
+}

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedaDocumentCheckResultValidatorTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/ChedaDocumentCheckResultValidatorTest.java
@@ -1,0 +1,171 @@
+package uk.gov.defra.tracesx.notificationschema.validation.annotations;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.Result.DEROGATION;
+import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.Result.NOT_DONE;
+import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.Result.NOT_SATISFACTORY;
+import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.Result.NOT_SET;
+import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.Result.SATISFACTORY;
+import static uk.gov.defra.tracesx.notificationschema.representation.enumeration.Result.SATISFACTORY_FOLLOWING_OFFICIAL_INTERVENTION;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.defra.tracesx.notificationschema.representation.ConsignmentCheck;
+
+public class ChedaDocumentCheckResultValidatorTest {
+
+  private ChedaDocumentCheckResultValidator validator;
+  private ConsignmentCheck check;
+
+  @Before
+  public void setUp() {
+    validator = new ChedaDocumentCheckResultValidator();
+    check = new ConsignmentCheck();
+    validator.initialize(null);
+  }
+
+  @Test
+  public void isValid_returnsFalse_whenDocumentCheckSatisfactoryEuStandardAndNationalRequirementNull() {
+    assertFalse(validator.isValid(check, null));
+  }
+
+  @Test
+  public void isValid_returnsTrue_whenConsignmentCheckIsNull() {
+    Assert.assertTrue(validator.isValid(null, null));
+  }
+
+  @Test
+  public void isValid_returnsTrue_whenDocumentCheckSatisfactoryEuStandardNotSetAndNationalRequirementNotSet() {
+    check.setDocumentCheckResult(SATISFACTORY);
+    check.setEuStandard(NOT_SET);
+    check.setNationalRequirements(NOT_SET);
+
+    assertTrue(validator.isValid(check, null));
+  }
+
+  @Test
+  public void isValid_returnsTrue_whenDocumentCheckNotSatisfactoryEuStandardNotSetAndNationalRequirementNotSet() {
+    check.setDocumentCheckResult(NOT_SATISFACTORY);
+    check.setEuStandard(NOT_SET);
+    check.setNationalRequirements(NOT_SET);
+
+    assertTrue(validator.isValid(check, null));
+  }
+
+  @Test
+  public void isValid_returnsFalse_whenDocumentCheckEuStandardAndNationalRequirementNotSatisfactory() {
+    check.setDocumentCheckResult(NOT_SATISFACTORY);
+    check.setEuStandard(NOT_SATISFACTORY);
+    check.setNationalRequirements(NOT_SATISFACTORY);
+
+    assertFalse(validator.isValid(check, null));
+  }
+
+  @Test
+  public void isValid_returnsFalse_whenDocumentCheckEuStandardAndNationalRequirementSatisfactory() {
+    check.setDocumentCheckResult(SATISFACTORY);
+    check.setEuStandard(SATISFACTORY);
+    check.setNationalRequirements(SATISFACTORY);
+
+    assertFalse(validator.isValid(check, null));
+  }
+
+  @Test
+  public void isValid_returnsFalse_whenDocumentCheckOfficialInterventionEuStandardNotDoneAndNationalRequirementDerogation() {
+    check.setDocumentCheckResult(SATISFACTORY_FOLLOWING_OFFICIAL_INTERVENTION);
+    check.setEuStandard(NOT_DONE);
+    check.setNationalRequirements(DEROGATION);
+
+    assertFalse(validator.isValid(check, null));
+  }
+
+  @Test
+  public void isValid_returnsTrue_whenDocumentCheckNotSetEuStandardSatisfactoryAndNationalRequirementSatisfactory() {
+    check.setDocumentCheckResult(NOT_SET);
+    check.setEuStandard(SATISFACTORY);
+    check.setNationalRequirements(SATISFACTORY);
+
+    assertTrue(validator.isValid(check, null));
+  }
+
+  @Test
+  public void isValid_returnsTrue_whenDocumentCheckNotSetEuStandardNotSatisfactoryAndNationalRequirementNotSatisfactory() {
+    check.setDocumentCheckResult(NOT_SET);
+    check.setEuStandard(NOT_SATISFACTORY);
+    check.setNationalRequirements(NOT_SATISFACTORY);
+
+    assertTrue(validator.isValid(check, null));
+  }
+
+  @Test
+  public void isValid_returnsTrue_whenDocumentCheckNotSetEuStandardNotSatisfactoryAndNationalRequirementSatisfactory() {
+    check.setDocumentCheckResult(NOT_SET);
+    check.setEuStandard(NOT_SATISFACTORY);
+    check.setNationalRequirements(SATISFACTORY);
+
+    assertTrue(validator.isValid(check, null));
+  }
+
+  @Test
+  public void isValid_returnsTrue_whenDocumentCheckNotSetEuStandardSatisfactoryAndNationalRequirementNotSatisfactory() {
+    check.setDocumentCheckResult(NOT_SET);
+    check.setEuStandard(SATISFACTORY);
+    check.setNationalRequirements(NOT_SATISFACTORY);
+
+    assertTrue(validator.isValid(check, null));
+  }
+
+  @Test
+  public void isValid_returnsFalse_whenDocumentCheckEuStandardAndNationalRequirementNotSet() {
+    check.setDocumentCheckResult(NOT_SET);
+    check.setEuStandard(NOT_SET);
+    check.setNationalRequirements(NOT_SET);
+
+    assertFalse(validator.isValid(check, null));
+  }
+
+  @Test
+  public void isValid_returnsTrue_whenDocumentCheckEuStandardNotSetNationalRequirementSet() {
+    check.setDocumentCheckResult(NOT_SET);
+    check.setEuStandard(NOT_SET);
+    check.setNationalRequirements(SATISFACTORY);
+
+    assertTrue(validator.isValid(check, null));
+  }
+
+  @Test
+  public void isValid_returnsTrue_whenDocumentCheckNotSetEuStandardNotSatisfactoryNationalRequirementSatisFactory() {
+    check.setDocumentCheckResult(NOT_SET);
+    check.setEuStandard(NOT_SATISFACTORY);
+    check.setNationalRequirements(SATISFACTORY);
+
+    assertTrue(validator.isValid(check, null));
+  }
+
+  @Test
+  public void isValid_returnsTrue_whenDocumentCheckNullEuStandardAndNationalRequirementNotSet() {
+    check.setEuStandard(NOT_SET);
+    check.setNationalRequirements(NOT_SET);
+
+    assertFalse(validator.isValid(check, null));
+  }
+
+  @Test
+  public void isValid_returnsTrue_whenDocumentCheckEuStandardNullAndNationalRequirementNotSet() {
+    check.setDocumentCheckResult(NOT_SET);
+    check.setNationalRequirements(NOT_SET);
+
+    assertTrue(validator.isValid(check, null));
+  }
+
+  @Test
+  public void isValid_returnsTrue_whenDocumentCheckSatisfactoryEuStandardAndNationalRequirementNullt() {
+    check.setDocumentCheckResult(SATISFACTORY);
+    check.setEuStandard(NOT_SET);
+
+    assertFalse(validator.isValid(check, null));
+  }
+
+}

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/EuStandardValidatorImplTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/annotations/EuStandardValidatorImplTest.java
@@ -3,6 +3,7 @@ package uk.gov.defra.tracesx.notificationschema.validation.annotations;
 import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertFalse;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import uk.gov.defra.tracesx.notificationschema.representation.ConsignmentCheck;
@@ -20,16 +21,72 @@ public class EuStandardValidatorImplTest {
   @Test
   public void givenEuStandardIsSatisfactory_whenICallIsValid_thenResultIsTrue() {
     ConsignmentCheck consignmentCheck = new ConsignmentCheck();
+    consignmentCheck.setDocumentCheckResult(Result.NOT_SET);
     consignmentCheck.setEuStandard(Result.SATISFACTORY);
 
     assertTrue(validator.isValid(consignmentCheck, null));
   }
 
   @Test
+  public void givenEuStandardIsNotSetAndNationalRequirementsSatisfactory_whenICallIsValid_thenResultIsTrue() {
+    ConsignmentCheck consignmentCheck = new ConsignmentCheck();
+    consignmentCheck.setDocumentCheckResult(Result.NOT_SET);
+    consignmentCheck.setEuStandard(Result.NOT_SET);
+    consignmentCheck.setNationalRequirements(Result.SATISFACTORY);
+
+    assertFalse(validator.isValid(consignmentCheck, null));
+  }
+
+  @Test
   public void givenEuStandardIsNotSet_whenICallIsValid_thenResultIsFalse() {
     ConsignmentCheck consignmentCheck = new ConsignmentCheck();
     consignmentCheck.setEuStandard(Result.NOT_SET);
+    consignmentCheck.setDocumentCheckResult(Result.NOT_SET);
+    consignmentCheck.setNationalRequirements(Result.SATISFACTORY);
 
     assertFalse(validator.isValid(consignmentCheck, null));
+  }
+
+  @Test
+  public void newNotification_withNotSetChecks_thenResultIsTrue() {
+    ConsignmentCheck consignmentCheck = new ConsignmentCheck();
+    consignmentCheck.setEuStandard(Result.NOT_SET);
+    consignmentCheck.setDocumentCheckResult(Result.NOT_SET);
+    consignmentCheck.setNationalRequirements(Result.NOT_SET);
+
+    assertTrue(validator.isValid(consignmentCheck, null));
+  }
+
+  @Test
+  public void newNotification_thenResultIsTrue() {
+    ConsignmentCheck consignmentCheck = new ConsignmentCheck();
+    consignmentCheck.setDocumentCheckResult(Result.NOT_SET);
+
+    assertTrue(validator.isValid(consignmentCheck, null));
+  }
+
+  @Test
+  public void validate_documentCheckNotSetEuStandardAndNationalRequirementChecksSet_thenResultIsTrue() {
+    ConsignmentCheck consignmentCheck = new ConsignmentCheck();
+    consignmentCheck.setEuStandard(Result.NOT_SET);
+    consignmentCheck.setDocumentCheckResult(Result.NOT_SET);
+    consignmentCheck.setNationalRequirements(Result.NOT_SET);
+
+    assertTrue(validator.isValid(consignmentCheck, null));
+  }
+
+  @Test
+  public void validate_documentCheckIstSetEuStandardAndNationalRequirementChecksNotSet_thenResultIsTrue() {
+    ConsignmentCheck consignmentCheck = new ConsignmentCheck();
+    consignmentCheck.setEuStandard(Result.NOT_SET);
+    consignmentCheck.setDocumentCheckResult(Result.SATISFACTORY);
+    consignmentCheck.setNationalRequirements(Result.NOT_SET);
+
+    assertTrue(validator.isValid(consignmentCheck, null));
+  }
+
+  @Test
+  public void isValid_returnsTrue_whenConsignmentCheckIsNull() {
+    Assert.assertTrue(validator.isValid(null, null));
   }
 }

--- a/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/utils/ConsignmentCheckUtilTest.java
+++ b/notification-schema-java/src/test/java/uk/gov/defra/tracesx/notificationschema/validation/utils/ConsignmentCheckUtilTest.java
@@ -1,0 +1,98 @@
+package uk.gov.defra.tracesx.notificationschema.validation.utils;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static uk.gov.defra.tracesx.notificationschema.validation.utils.ConsignmentCheckUtil.isExistingCHEDANotification;
+
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.defra.tracesx.notificationschema.representation.ConsignmentCheck;
+import uk.gov.defra.tracesx.notificationschema.representation.enumeration.Result;
+
+public class ConsignmentCheckUtilTest {
+
+  ConsignmentCheck consignmentCheck;
+
+  @Before
+  public void setUp() throws Exception {
+    consignmentCheck = new ConsignmentCheck();
+  }
+
+  @Test
+  public void isValid_returnsFalse_whenDocumentCheckSatisfactoryEuStandardAndNationalRequirementNull() {
+    assertFalse(isExistingCHEDANotification(consignmentCheck));
+  }
+
+  @Test
+  public void isChedAAlreadyCreatedAndChecksSetToEuSatisfactoryAndNationalSatisfactory_thenResultIsTrue() {
+    consignmentCheck.setDocumentCheckResult(Result.NOT_SET);
+    consignmentCheck.setEuStandard(Result.SATISFACTORY);
+    consignmentCheck.setNationalRequirements(Result.SATISFACTORY);
+
+    assertTrue(isExistingCHEDANotification(consignmentCheck));
+  }
+
+  @Test
+  public void isChedAAlreadyCreatedAndChecksSetToEuNotSatisfactoryAndNationalSatisfactory_thenResultIsTrue() {
+    consignmentCheck.setDocumentCheckResult(Result.NOT_SET);
+    consignmentCheck.setEuStandard(Result.NOT_SATISFACTORY);
+    consignmentCheck.setNationalRequirements(Result.SATISFACTORY);
+
+    assertTrue(isExistingCHEDANotification(consignmentCheck));
+  }
+
+  @Test
+  public void isChedAAlreadyCreatedAndChecksSetToEuSatisfactoryAndNationalNotSatisfactory_thenResultIsTrue() {
+    consignmentCheck.setDocumentCheckResult(Result.NOT_SET);
+    consignmentCheck.setEuStandard(Result.SATISFACTORY);
+    consignmentCheck.setNationalRequirements(Result.NOT_SATISFACTORY);
+
+    assertTrue(isExistingCHEDANotification(consignmentCheck));
+  }
+
+  @Test
+  public void isChedAAlreadyCreatedAndChecksSetToEuNotSatisfactoryAndNationalNotSatisfactory_thenResultIsTrue() {
+    consignmentCheck.setDocumentCheckResult(Result.NOT_SET);
+    consignmentCheck.setEuStandard(Result.NOT_SATISFACTORY);
+    consignmentCheck.setNationalRequirements(Result.NOT_SATISFACTORY);
+
+    assertTrue(isExistingCHEDANotification(consignmentCheck));
+  }
+
+  @Test
+  public void isChedANewWithSetToEuSatisfactoryAndNationalSatisfactory_thenResultIsFalse() {
+    consignmentCheck.setDocumentCheckResult(Result.SATISFACTORY);
+    consignmentCheck.setEuStandard(Result.SATISFACTORY);
+    consignmentCheck.setNationalRequirements(Result.SATISFACTORY);
+
+    assertFalse(isExistingCHEDANotification(consignmentCheck));
+  }
+
+  @Test
+  public void isChedANewWithSetToEuNotSatisfactoryAndNationalSatisfactory_thenResultIsFalse() {
+    consignmentCheck.setDocumentCheckResult(Result.SATISFACTORY);
+    consignmentCheck.setEuStandard(Result.NOT_SATISFACTORY);
+    consignmentCheck.setNationalRequirements(Result.SATISFACTORY);
+
+    assertFalse(isExistingCHEDANotification(consignmentCheck));
+  }
+
+  @Test
+  public void isChedANewWithSetToEuSatisfactoryAndNationalNotSatisfactory_thenResultIsFalse() {
+    consignmentCheck.setDocumentCheckResult(Result.SATISFACTORY);
+    consignmentCheck.setEuStandard(Result.SATISFACTORY);
+    consignmentCheck.setNationalRequirements(Result.NOT_SATISFACTORY);
+
+    assertFalse(isExistingCHEDANotification(consignmentCheck));
+  }
+
+  @Test
+  public void isChedANewWithSetToEuNotSatisfactoryAndNationalNotSatisfactory_thenResultIsFalse() {
+    consignmentCheck.setDocumentCheckResult(Result.SATISFACTORY);
+    consignmentCheck.setEuStandard(Result.NOT_SATISFACTORY);
+    consignmentCheck.setNationalRequirements(Result.NOT_SATISFACTORY);
+
+    assertFalse(isExistingCHEDANotification(consignmentCheck));
+  }
+
+}


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | akbar shaik (Kainos) |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [IMTA-11922 EU standard validation is onl...](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/276) |
> | **GitLab MR Number** | [276](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/276) |
> | **Date Originally Opened** | Thu, 19 May 2022 |
> | **Approved on GitLab by** | Jana Latzberg (Kainos), Kelly Moore, Reece Bennett (KAINOS) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: Ticket: https://eaflood.atlassian.net/browse/IMTA-11922
### :book: Changes:
* Updated document check, EU Standard and National requirements checks validation

### :white_check_mark: Green Sonar report
![Screenshot_2022-05-23_at_09.42.46](/uploads/ec42405792255610398931df91821220/Screenshot_2022-05-23_at_09.42.46.png)