### PR TITLE
IMTA-12139 Removed responsibleForTransport field

### DIFF
--- a/notification-schema-core/resources/notification-schema.json
+++ b/notification-schema-core/resources/notification-schema.json
@@ -645,7 +645,7 @@
         },
         "responsibleForTransport": {
           "type": "string",
-          "description": "Person who is responsible for transport"
+          "description": "(Deprecated in IMTA-12139) Person who is responsible for transport"
         },
         "veterinaryInformation": {
           "type": "object",

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/PartOne.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/PartOne.java
@@ -342,14 +342,6 @@ public class PartOne {
               + ".estimatedjourneytimeinminutes.not.null}")
   private Integer estimatedJourneyTimeInMinutes;
 
-  @NotEmpty(
-      groups = {
-        NotificationCvedaFieldValidation.class,
-        TransporterDetailsRequiredEuCvedaValidation.class
-      },
-      message =
-          "{uk.gov.defra.tracesx.notificationschema.representation.partone"
-              + ".responsiblefortransport.not.empty}")
   private String responsibleForTransport;
 
   @Valid


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | akbar shaik (Kainos) |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [IMTA-12139 Removed responsibleForTranspo...](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/278) |
> | **GitLab MR Number** | [278](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/278) |
> | **Date Originally Opened** | Mon, 13 Jun 2022 |
> | **Approved on GitLab by** | Jana Latzberg (Kainos), Kelly Moore, Reece Bennett (KAINOS) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: Ticket: https://eaflood.atlassian.net/browse/IMTA-12139
### :book: Changes:
* Removed responsibleForTransport field

### :white_check_mark: Green Sonar report Build
* [https://vss-sonarqube.azure.defra.cloud/dashboard?id=Imports-Notification-Schema&branch=feature%2FIMTA-12139-removed-responsible-for-transport&resolved=false](![Screenshot_2022-06-13_at_14.49.28](/uploads/3fea0134994ffc2d4400bf99a1980f86/Screenshot_2022-06-13_at_14.49.28.png))