### PR TITLE
IMTA-11904: Adding new boolean flag to hold whether a bulk upload is in progress

### DIFF
--- a/imports-frontend-entities/src/entities/notification.js
+++ b/imports-frontend-entities/src/entities/notification.js
@@ -45,6 +45,7 @@ module.exports = class Notification {
     this.agencyOrganisationId = obj.agencyOrganisationId
     this.riskDecisionLockingTime = obj.riskDecisionLockingTime;
     this.isRiskDecisionLocked = obj.isRiskDecisionLocked;
+    this.isBulkUploadInProgress = obj.isBulkUploadInProgress;
 
     validate(this)
 

--- a/notification-schema-core/resources/notification-schema.json
+++ b/notification-schema-core/resources/notification-schema.json
@@ -824,6 +824,10 @@
     "isRiskDecisionLocked": {
       "type": "boolean",
       "description": "is the risk decision locked?"
+    },
+    "isBulkUploadInProgress": {
+      "type": "boolean",
+      "description": "Boolean flag that indicates whether a bulk upload is in progress"
     }
   },
   "definitions": {

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/Notification.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/Notification.java
@@ -160,4 +160,5 @@ public class Notification {
   private LocalDateTime riskDecisionLockingTime;
 
   private Boolean isRiskDecisionLocked;
+  private Boolean isBulkUploadInProgress;
 }


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Sean Treanor (KAINOS) |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [IMTA-11904: Adding new boolean flag to h...](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/281) |
> | **GitLab MR Number** | [281](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/281) |
> | **Date Originally Opened** | Wed, 6 Jul 2022 |
> | **Approved on GitLab by** | Apurva Jhunjhunwala (Kainos), Kelly Moore, kingsley.Osime (Kainos) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: Ticket: https://eaflood.atlassian.net/browse/IMTA-11904
### :book: Changes:
* Adding isBulkUploadInProgress boolean flag

### :chart_with_upwards_trend: SonarQube Report
[Click here](https://vss-sonarqube.azure.defra.cloud/dashboard?branch=feature/IMTA-11904-business-rule-validation&id=Imports-Notification-Schema) to view the SonarQube report.