### PR TITLE
IMTA-13834 added phsi object in commodity risk results

### DIFF
--- a/imports-frontend-entities/package-lock.json
+++ b/imports-frontend-entities/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipaffs/imports-frontend-entities",
-  "version": "1.0.259",
+  "version": "1.0.261",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/imports-frontend-entities/package.json
+++ b/imports-frontend-entities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipaffs/imports-frontend-entities",
-  "version": "1.0.259",
+  "version": "1.0.261",
   "repository": {
     "type": "git"
   },

--- a/imports-frontend-entities/src/entities/commodity_risk_result.js
+++ b/imports-frontend-entities/src/entities/commodity_risk_result.js
@@ -7,6 +7,7 @@ module.exports = class CommodityRiskResult {
     this.hmiDecision = obj.hmiDecision
     this.phsiDecision = obj.phsiDecision
     this.phsiClassification = obj.phsiClassification
+    this.phsi = obj.phsi
     this.uniqueId = obj.uniqueId
     this.eppoCode = obj.eppoCode
     this.variety = obj.variety

--- a/imports-frontend-entities/src/entities/phsi.js
+++ b/imports-frontend-entities/src/entities/phsi.js
@@ -1,0 +1,12 @@
+const handler = require('./base/handler')
+
+module.exports = class Phsi {
+  constructor(obj = {}) {
+
+    this.documentCheck = obj.documentCheck
+    this.identityCheck = obj.identityCheck
+    this.physicalCheck = obj.physicalCheck
+
+    return Object.seal(new Proxy(this, handler))
+  }
+}

--- a/imports-frontend-entities/test/entities_test.js
+++ b/imports-frontend-entities/test/entities_test.js
@@ -53,6 +53,7 @@ const Transporter = require('../src/entities/transporter')
 const AccompanyingDocument = require('../src/entities/accompanying_document')
 const CatchCertificate = require('../src/entities/catch_certificate')
 const CommodityRiskResult = require('../src/entities/commodity_risk_result')
+const Phsi = require('../src/entities/phsi')
 const InspectionOverride = require('../src/entities/inspection_override')
 const ExternalReference = require('../src/entities/external_reference')
 const RiskAssessment = require('../src/entities/risk_assessment')
@@ -110,6 +111,7 @@ describe('Entities: ', () => {
     AccompanyingDocument,
     CatchCertificate,
     CommodityRiskResult,
+    Phsi,
     InspectionOverride,
     ExternalReference,
     RiskAssessment

--- a/notification-schema-core/resources/notification-schema.json
+++ b/notification-schema-core/resources/notification-schema.json
@@ -2662,6 +2662,24 @@
             "Controlled"
           ]
         },
+        "phsi": {
+          "type": "object",
+          "description": "PHSI Decision Breakdown",
+          "properties": {
+            "documentCheck": {
+              "type": "boolean",
+              "description": "Whether or not a documentary check is required for PHSI"
+            },
+            "identityCheck": {
+              "type": "boolean",
+              "description": "Whether or not an identity check is required for PHSI"
+            },
+            "physicalCheck": {
+              "type": "boolean",
+              "description": "Whether or not a physical check is required for PHSI"
+            }
+          }
+        },
         "uniqueId": {
           "type": "string",
           "minLength": 0,

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/CommodityRiskResult.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/CommodityRiskResult.java
@@ -25,6 +25,7 @@ public class CommodityRiskResult {
   private HmiDecision hmiDecision;
   private PhsiDecision phsiDecision;
   private PhsiClassification phsiClassification;
+  private Phsi phsi;
   private UUID uniqueId;
   private String eppoCode;
   private String variety;

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/Phsi.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/Phsi.java
@@ -1,0 +1,21 @@
+package uk.gov.defra.tracesx.notificationschema.representation;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Data
+@JsonInclude(Include.NON_EMPTY)
+@NoArgsConstructor(access = AccessLevel.PUBLIC)
+@AllArgsConstructor(access = AccessLevel.PUBLIC)
+public class Phsi {
+
+  private Boolean documentCheck;
+  private Boolean identityCheck;
+  private Boolean physicalCheck;
+}


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Phani Yallam |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [IMTA-13834 added phsi object in commodit...](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/308) |
> | **GitLab MR Number** | [308](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/308) |
> | **Date Originally Opened** | Tue, 28 Feb 2023 |
> | **Approved on GitLab by** | Jonathan Magee, Reece Bennett (KAINOS), Stephen Donaghey (KAINOS) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: [Jira Ticket](https://eaflood.atlassian.net/browse/IMTA-13834)

### :chart_with_upwards_trend: [SonarQube Report](https://vss-sonarqube.azure.defra.cloud/dashboard?branch=feature%2FIMTA-13834-adding-phsi-in-risk-assessment&id=Imports-Notification-Schema)

### :building_construction: [Jenkins Pipeline](https://jenkins-imports.azure.defra.cloud/job/imports-notification-schema/job/feature%2FIMTA-13834-adding-phsi-in-risk-assessment/)

### :book: Changes:

- added phsi object in commodity risk results