### PR TITLE
IMTA-13899: Adding external reference for establishments of origin to js entities

### DIFF
--- a/imports-frontend-entities/package-lock.json
+++ b/imports-frontend-entities/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipaffs/imports-frontend-entities",
-  "version": "1.0.263",
+  "version": "1.0.265",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/imports-frontend-entities/package.json
+++ b/imports-frontend-entities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipaffs/imports-frontend-entities",
-  "version": "1.0.263",
+  "version": "1.0.265",
   "repository": {
     "type": "git"
   },

--- a/imports-frontend-entities/src/entities/external_reference.js
+++ b/imports-frontend-entities/src/entities/external_reference.js
@@ -7,6 +7,9 @@ module.exports = class ExternalReference {
 
     this.system = obj.system
     this.reference = obj.reference
+    this.exactMatch = obj.exactMatch
+    this.verifiedByImporter = obj.verifiedByImporter
+    this.verifiedByInspector = obj.verifiedByInspector
 
     return Object.seal(new Proxy(this, handler))
   }

--- a/imports-frontend-entities/src/entities/veterinary_information.js
+++ b/imports-frontend-entities/src/entities/veterinary_information.js
@@ -8,6 +8,7 @@ const { getList } = require('../utils/list')
 module.exports = class VeterinaryInformation {
   constructor(obj = {}) {
 
+    this.establishmentsOfOriginExternalReference = obj.establishmentsOfOriginExternalReference
     this.establishmentsOfOrigin = _.get(obj, 'establishmentsOfOrigin', []).map(
         x => new ApprovedEstablishment(x))
     this.veterinaryDocument = obj.veterinaryDocument


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | kamil mojek (KAINOS) |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [IMTA-13899: Adding external reference fo...](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/311) |
> | **GitLab MR Number** | [311](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/311) |
> | **Date Originally Opened** | Thu, 16 Mar 2023 |
> | **Approved on GitLab by** | Blakeley, Paul (Kainos), Marina Tihova, Nicholas Martin, Reece Bennett (KAINOS), prabash balasuriya (kainos) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :book: Changes:

- JS entity updates for changes from https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/307
- original ticket for schema changes: https://eaflood.atlassian.net/browse/IMTA-13861

### :link: ticket: https://eaflood.atlassian.net/browse/IMTA-13889

### :chart_with_upwards_trend: SonarQube Report

[Click here](https://vss-sonarqube.azure.defra.cloud/dashboard?branch=feature%2FIMTA-13889-chedp-cloning-approved-establishments-verified-by-importer&id=Imports-Notification-Schema) to view the SonarQube report.