### PR TITLE
IMTA-18006 add isAutoclearanceExempted field to Notification

### DIFF
--- a/imports-frontend-entities/package-lock.json
+++ b/imports-frontend-entities/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ipaffs/imports-frontend-entities",
-  "version": "1.0.324",
+  "version": "1.0.325",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@ipaffs/imports-frontend-entities",
-      "version": "1.0.324",
+      "version": "1.0.325",
       "license": "ISC",
       "dependencies": {
         "ajv": "6.12.6",

--- a/imports-frontend-entities/package.json
+++ b/imports-frontend-entities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipaffs/imports-frontend-entities",
-  "version": "1.0.324",
+  "version": "1.0.325",
   "repository": {
     "type": "git"
   },

--- a/imports-frontend-entities/src/entities/notification.js
+++ b/imports-frontend-entities/src/entities/notification.js
@@ -48,6 +48,7 @@ module.exports = class Notification {
     this.isCdsFullMatched = obj.isCdsFullMatched;
     this.chedTypeVersion = obj.chedTypeVersion;
     this.isGMRMatched = obj.isGMRMatched;
+    this.isAutoClearanceExempted = obj.isAutoclearanceExempted
 
     validate(this)
 

--- a/notification-schema-core/resources/notification-schema.json
+++ b/notification-schema-core/resources/notification-schema.json
@@ -992,6 +992,10 @@
     "isGMRMatched": {
       "type": "boolean",
       "description": "Indicates whether a CHED has been matched with a GVMS GMR via DMP"
+    },
+    "isAutoClearanceExempted": {
+      "type": "boolean",
+      "description": "Indicates whether CHED is exempted from autoclearance"
     }
   },
   "definitions": {

--- a/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/Notification.java
+++ b/notification-schema-java/src/main/java/uk/gov/defra/tracesx/notificationschema/representation/Notification.java
@@ -189,4 +189,5 @@ public class Notification {
   private Boolean isCdsFullMatched;
   private short chedTypeVersion;
   private Boolean isGMRMatched;
+  private Boolean isAutoClearanceExempted;
 }


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Maciej Trzasalski (Kainos) |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [IMTA-18006 add isAutoclearanceExempted f...](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/409) |
> | **GitLab MR Number** | [409](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/409) |
> | **Date Originally Opened** | Tue, 2 Jul 2024 |
> | **Approved on GitLab by** | Jana Latzberg (Kainos), Marina Tihova, Shawn Chan (Kainos), niamh mclarnon (Kainos) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: [Jira Ticket](https://eaflood.atlassian.net/browse/IMTA-18006)

### :chart_with_upwards_trend: [SonarQube Report](https://vss-sonarqube.azure.defra.cloud/dashboard?branch=feature%2FIMTA-18006-add-is-autoclearance-exempted-to-notification&id=Imports-Notification-Schema)

### :building_construction: [Jenkins Pipeline](https://jenkins-imports.azure.defra.cloud/job/imports-notification-schema/job/feature%2FIMTA-18006-add-is-autoclearance-exempted-to-notification/)

### :book: Changes:

- add new field `notification.isAutoClearanceExempted`