### PR TITLE
[IMTA-18063] Amend Schema for Ched Type Version

### DIFF
--- a/imports-frontend-entities/package-lock.json
+++ b/imports-frontend-entities/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ipaffs/imports-frontend-entities",
-  "version": "1.0.326",
+  "version": "1.0.327",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@ipaffs/imports-frontend-entities",
-      "version": "1.0.326",
+      "version": "1.0.327",
       "license": "ISC",
       "dependencies": {
         "ajv": "6.12.6",

--- a/imports-frontend-entities/package.json
+++ b/imports-frontend-entities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipaffs/imports-frontend-entities",
-  "version": "1.0.326",
+  "version": "1.0.327",
   "repository": {
     "type": "git"
   },

--- a/imports-frontend-entities/src/constants/ched_type_versions.js
+++ b/imports-frontend-entities/src/constants/ched_type_versions.js
@@ -6,5 +6,8 @@ module.exports = Object.freeze({
   DEFAULT: 1,
   CHED_D: {
     SINGLE_JOURNEY: 2
+  },
+  CHED_A: {
+    SINGLE_JOURNEY: 2
   }
 })


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | joe hoy (KAINOS) |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [[IMTA-18063] Amend Schema for Ched Type ...](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/416) |
> | **GitLab MR Number** | [416](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/416) |
> | **Date Originally Opened** | Mon, 12 Aug 2024 |
> | **Approved on GitLab by** | Eric Kennedy (Kainos), Harrison Duffield (Kainos), Lewis Birks (Kainos) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: [Jira Ticket](https://eaflood.atlassian.net/browse/IMTA-18063)

### :chart_with_upwards_trend: [SonarQube Report](https://vss-sonarqube.azure.defra.cloud/dashboard?branch=feature%2FIMTA-18063-Update-Ched-Type-Version-For-Single-Ched-A&id=Imports-Notification-Schema)

### :building_construction: [Jenkins Pipeline](https://jenkins-imports.azure.defra.cloud/job/imports-notification-schema/job/feature%2FIMTA-18063-Update-Ched-Type-Version-For-Single-Ched-A/)

### :book: Changes:

- Added CHED Type A to Schema for Single Journey