### PR TITLE
IMTA-8674-Fix jenkins pipeline to promote newly bumped NPM artifactory

### DIFF
--- a/imports-frontend-entities/package-lock.json
+++ b/imports-frontend-entities/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ipaffs/imports-frontend-entities",
-  "version": "1.0.330",
+  "version": "1.0.331",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@ipaffs/imports-frontend-entities",
-      "version": "1.0.330",
+      "version": "1.0.331",
       "license": "ISC",
       "dependencies": {
         "ajv": "6.12.6",

--- a/imports-frontend-entities/package.json
+++ b/imports-frontend-entities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipaffs/imports-frontend-entities",
-  "version": "1.0.330",
+  "version": "1.0.331",
   "repository": {
     "type": "git"
   },


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Łukasz Pietrynczak (Kainos) |
> | **GitLab Project** | [imports/imports-notification-schema](https://giteux.azure.defra.cloud/imports/imports-notification-schema) |
> | **GitLab Merge Request** | [IMTA-8674-Fix jenkins pipeline to promot...](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/419) |
> | **GitLab MR Number** | [419](https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/419) |
> | **Date Originally Opened** | Fri, 23 Aug 2024 |
> | **Approved on GitLab by** | Ajith Thomas (Kainos), Harrison Duffield (Kainos), Josh Craig (Kainos), Martin Willitts (Kainos) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: [Jira Ticket](https://eaflood.atlassian.net/browse/IMTA-8674)

### :chart_with_upwards_trend: [SonarQube Report](https://vss-sonarqube.azure.defra.cloud/dashboard?branch=feature%2FIMTA-8674-fix-Jenkins-pipeline-to-promote-the-newly-bumped-NPM-artifact-to-Artifactory&id=Imports-Notification-Schema)

### :book: Changes:

- NPM version bump to trigger jenkins publis build with updated pipeline library concerning IMTA-8764.